### PR TITLE
[Refactor] Rewrite prefill scheduling & clean up scheduler

### DIFF
--- a/python/minisgl/engine/engine.py
+++ b/python/minisgl/engine/engine.py
@@ -219,10 +219,10 @@ class Engine:
         copy_done_event.record(self.stream)
         return ForwardOutput(next_tokens_gpu, next_tokens_cpu, copy_done_event)
 
-    def prepare_batch(self, batch: Batch):
+    def prepare_batch(self, batch: Batch) -> None:
         self.attn_backend.prepare_metadata(batch, allow_graph=True)
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         self.graph_runner.destroy_cuda_graphs()
         torch.distributed.destroy_process_group()
         destroy_distributed()

--- a/python/minisgl/scheduler/prefill.py
+++ b/python/minisgl/scheduler/prefill.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Final, List, Tuple
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, List, Tuple
 
 import torch
-from minisgl.core import Req, SamplingParams
+from minisgl.core import Batch, Req
 from minisgl.utils import init_logger
 
 from .utils import PendingReq
@@ -20,83 +21,102 @@ logger = init_logger(__name__)
 
 
 class ChunkedReq(Req):
-    def __init__(
-        self,
-        *,
-        chunk_size: int,
-        host_ids: torch.Tensor,
-        device_ids: torch.Tensor,
-        table_idx: int,
-        cached_len: int,
-        output_len: int,
-        uid: int,
-        cache_handle: BaseCacheHandle,
-        sampling_params: SamplingParams,
-    ):
-        assert host_ids.is_cpu
-        self._real_output_len: Final = output_len
-        self._host_ids: Final = host_ids  # full id
-        self._device_ids: Final = device_ids  # pre-allocated device ids
-        new_input_len = cached_len + chunk_size
-        new_output_len = len(host_ids) + output_len - new_input_len
-        assert new_input_len < len(host_ids) and chunk_size > 0
-        assert len(device_ids) >= len(host_ids)
-        super().__init__(
-            input_ids=self._host_ids[:new_input_len],
-            table_idx=table_idx,
-            cached_len=cached_len,
-            output_len=new_output_len,
-            uid=uid,
-            cache_handle=cache_handle,
-            sampling_params=sampling_params,
-        )
-
-    def complete_one(self) -> None:
-        self.cached_len = self.device_len
-
-    @property
-    def remain_chunk_size(self) -> int:
-        return self.full_input_len - self.cached_len
-
-    @property
-    def full_input_len(self) -> int:
-        return len(self._host_ids)
-
-    def next_chunk(self, chunk_size: int) -> Req:
-        new_input_len = self.cached_len + chunk_size
-        assert self.cached_len == self.device_len and chunk_size > 0
-        assert new_input_len <= self.full_input_len
-        _slice = slice(self.cached_len, new_input_len)
-        self._device_ids[_slice].copy_(self._host_ids[_slice].pin_memory(), non_blocking=True)
-        self.host_ids = self._host_ids[:new_input_len]
-        self.device_len = new_input_len
-        if new_input_len < self.full_input_len:
-            return self
-        return Req(
-            input_ids=self._host_ids,
-            table_idx=self.table_idx,
-            cached_len=self.cached_len,
-            output_len=self._real_output_len,
-            uid=self.uid,
-            cache_handle=self.cache_handle,
-            sampling_params=self.sampling_params,
-        )
+    def append_host(self, next_token: torch.Tensor) -> None:
+        raise NotImplementedError("ChunkedReq should be sampled")
 
     def can_decode(self) -> bool:
         return False
 
 
-class PrefillManager:
-    def __init__(
+@dataclass
+class PrefillAdder:
+    token_budget: int
+    reserved_size: int
+    cache_manager: CacheManager
+    table_manager: TableManager
+
+    def _try_allocate_one(self, req: PendingReq) -> Tuple[BaseCacheHandle, int] | None:
+        handle, match_indices = self.cache_manager.match_req(req)
+        cached_len = handle.cached_len
+        # TODO: better estimate policy
+        extend_len = req.input_len - cached_len
+        estimated_len = extend_len + req.output_len
+
+        if estimated_len + self.reserved_size > self.cache_manager.available_size:
+            return None
+
+        self.cache_manager.lock(handle)
+        if estimated_len + self.reserved_size > self.cache_manager.available_size:
+            self.cache_manager.unlock(handle)
+            return None
+
+        table_idx = self.table_manager.allocate()
+        if cached_len > 0:  # NOTE: set the cached part
+            device_ids = self.table_manager.token_pool[table_idx][:cached_len]
+            page_entry = self.table_manager.page_table[table_idx][:cached_len]
+            device_ids.copy_(req.input_ids[:cached_len].pin_memory(), non_blocking=True)
+            page_entry.copy_(match_indices)
+
+        return handle, table_idx
+
+    def _add_one_req(
         self,
-        cache_manager: CacheManager,
-        table_manager: TableManager,
-        decode_manager: DecodeManager,
-    ) -> None:
-        self.pending_list: List[PendingReq] = []
-        self.cache_manager = cache_manager
-        self.table_manager = table_manager
-        self.decode_manager = decode_manager
+        pending_req: PendingReq,
+        cache_handle: BaseCacheHandle,
+        table_idx: int,
+        cached_len: int,
+    ) -> Req:
+        remain_len = pending_req.input_len - cached_len
+        chunk_size = min(self.token_budget, remain_len)
+        is_chunked = chunk_size < remain_len
+        CLS = ChunkedReq if is_chunked else Req
+        self.token_budget -= chunk_size
+        self.reserved_size += remain_len + pending_req.output_len
+        # NOTE: update the tokens ids only; new pages will be allocated in the scheduler
+        _slice = slice(cached_len, cached_len + chunk_size)
+        device_ids = self.table_manager.token_pool[table_idx][_slice]
+        device_ids.copy_(pending_req.input_ids[_slice].pin_memory(), non_blocking=True)
+        return CLS(
+            input_ids=pending_req.input_ids[: cached_len + chunk_size],
+            table_idx=table_idx,
+            cached_len=cached_len,
+            output_len=pending_req.output_len,
+            uid=pending_req.uid,
+            cache_handle=cache_handle,
+            sampling_params=pending_req.sampling_params,
+        )
+
+    def try_add_one(self, pending_req: PendingReq) -> Req | None:
+        if self.token_budget <= 0:
+            return None
+
+        if chunked_req := pending_req.chunked_req:
+            assert chunked_req.device_len == chunked_req.cached_len + 1
+            return self._add_one_req(
+                pending_req=pending_req,
+                cache_handle=chunked_req.cache_handle,
+                table_idx=chunked_req.table_idx,
+                cached_len=chunked_req.cached_len,
+            )
+
+        if resource := self._try_allocate_one(pending_req):
+            handle, table_idx = resource
+            return self._add_one_req(
+                pending_req=pending_req,
+                cache_handle=handle,
+                table_idx=table_idx,
+                cached_len=handle.cached_len,
+            )
+
+        return None
+
+
+@dataclass
+class PrefillManager:
+    cache_manager: CacheManager
+    table_manager: TableManager
+    decode_manager: DecodeManager
+    pending_list: List[PendingReq] = field(default_factory=list)
 
     def add_raw_req(self, req: UserMsg) -> None:
         self.pending_list.append(
@@ -108,126 +128,32 @@ class PrefillManager:
             )
         )
 
-    def try_allocate_one(
-        self, req: PendingReq, inflight_tokens: int
-    ) -> Tuple[BaseCacheHandle, int] | None:
-        handle, match_indices = self.cache_manager.match_req(req)
-        cached_len = handle.cached_len
-        # TODO: better estimate policy
-        extend_len = req.input_len - cached_len
-        estimated_len = extend_len + req.output_len
-
-        if estimated_len + inflight_tokens > self.cache_manager.available_size:
-            return None
-
-        self.cache_manager.lock(handle)
-        if estimated_len + inflight_tokens > self.cache_manager.available_size:
-            self.cache_manager.unlock(handle)
-            return None
-
-        other_indices = self.cache_manager.allocate(extend_len)
-        table_idx = self.table_manager.allocate()
-        page_entry = self.table_manager.page_table[table_idx]
-
-        # even for chunked req, we allocate the full extend_len here
-        # if cached, copy the matched indices first
-        if cached_len > 0:
-            page_entry[:cached_len] = match_indices
-        # since extend_len > 0, other indices must be non-empty
-        page_entry[cached_len : cached_len + extend_len] = other_indices
-        return handle, table_idx
-
-    def schedule_next_batch(self, prefill_budget: int) -> Tuple[torch.Tensor, List[Req]] | None:
-        from minisgl.kernel import make_2d_indices
-
+    def schedule_next_batch(self, prefill_budget: int) -> Batch | None:
         if len(self.pending_list) == 0:
             return None
 
         # estimated offset due to in-flight decode
-        offset = self.decode_manager.inflight_tokens
-
-        # use FIFO
-        result: List[Req] = []
-        chunked_list: List[PendingReq] = []
-        for req in self.pending_list:
-            # We need at least 1 prefill budget, 1 table entry, and 1 cache space
-            if (
-                min(
-                    prefill_budget,
-                    self.cache_manager.available_size - offset,
-                    self.table_manager.available_size,
-                )
-                <= 0
-            ):
-                break
-
-            # if this is a chunked req, continue the chunking or finish it
-            if (chunked_req := req.chunked_req) is not None:
-                req.chunked_req = None
-                chunk_size = min(chunked_req.remain_chunk_size, prefill_budget)
-                assert chunk_size > 0
-                prefill_budget -= chunk_size
-                new_req = chunked_req.next_chunk(chunk_size)
-                if isinstance(new_req, ChunkedReq):
-                    req.chunked_req = new_req
-                    chunked_list.append(req)
-                result.append(new_req)
-                continue
-
-            if not (resource := self.try_allocate_one(req, offset)):
-                break
-
-            handle, table_idx = resource
-            cached_len = handle.cached_len
-            extend_len = req.input_len - cached_len
-            chunk_size = min(extend_len, prefill_budget)
-            is_chunked = chunk_size < extend_len
-            prefill_budget -= chunk_size
-
-            # prepare token pool
-            token_pool = self.table_manager.token_pool[table_idx]
-            first_input_len = cached_len + chunk_size
-            token_pool[:first_input_len].copy_(
-                req.input_ids[:first_input_len].pin_memory(), non_blocking=True
-            )
-            if is_chunked:
-                new_req = ChunkedReq(
-                    chunk_size=chunk_size,
-                    host_ids=req.input_ids,
-                    device_ids=token_pool,
-                    table_idx=table_idx,
-                    cached_len=cached_len,
-                    output_len=req.output_len,
-                    uid=req.uid,
-                    cache_handle=handle,
-                    sampling_params=req.sampling_params,
-                )
-                req.chunked_req = new_req
-                chunked_list.append(req)
-            else:
-                new_req = Req(
-                    input_ids=req.input_ids,
-                    output_len=req.output_len,
-                    table_idx=table_idx,
-                    cached_len=cached_len,
-                    uid=req.uid,
-                    cache_handle=handle,
-                    sampling_params=req.sampling_params,
-                )
-            result.append(new_req)
-
-        if len(result) == 0:
-            return None
-
-        assert prefill_budget >= 0
-        self.pending_list = chunked_list + self.pending_list[len(result) :]
-
-        new_2d_indices = make_2d_indices(
-            table_2d=self.table_manager.page_table,
-            ranges=[(req.table_idx, req.cached_len, req.device_len) for req in result],
-            load_table=False,
+        adder = PrefillAdder(
+            token_budget=prefill_budget,
+            reserved_size=self.decode_manager.inflight_tokens,
+            cache_manager=self.cache_manager,
+            table_manager=self.table_manager,
         )
-        return new_2d_indices, result
+        reqs: List[Req] = []
+        chunked_list: List[PendingReq] = []
+        for pending_req in self.pending_list:
+            if req := adder.try_add_one(pending_req):
+                pending_req.chunked_req = None
+                if isinstance(req, ChunkedReq):
+                    pending_req.chunked_req = req
+                    chunked_list.append(pending_req)
+                reqs.append(req)
+            else:
+                break  # We cannot add more requests
+        if len(reqs) == 0:
+            return None
+        self.pending_list = chunked_list + self.pending_list[len(reqs) :]
+        return Batch(reqs=reqs, phase="prefill")
 
     @property
     def runnable(self) -> bool:


### PR DESCRIPTION
cc @MisakaVan 

Also urgently need some test on the correctness of batching (like MMLU).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reworks prefill/decode scheduling to use `Batch` objects, introduces `PrefillAdder`, simplifies `DecodeManager`, updates cache handling, and shifts 2D index/page allocation into the scheduler.
> 
> - **Scheduler**:
>   - **Prefill**: Replace tuple-based scheduling with `Batch` return; add `PrefillAdder` to manage token budgets, cache/table allocation, and chunking via `ChunkedReq`.
>   - **Decode**: Simplify `DecodeManager` (no cache/table deps); returns `Batch` directly; enforce no `ChunkedReq` in decode.
>   - **Index Allocation**: Move 2D index creation/allocation to `_schedule_next_batch`; compute `needed_size` and call `make_2d_indices(..., store_value=cache_manager.allocate(...))`.
>   - **Resource Flow**: Update finished-req cleanup to cache prefixes via `CacheManager.free_and_cache_finished_req`.
> - **Core**:
>   - Replace `Phase` with simpler `Batch` holding `phase`; adjust `Req` init (compute `device_len` from `input_ids`, always set `cache_handle`).
> - **Cache**:
>   - Add private `_free`; change `free_and_cache_finished_req` to insert prefix and free newly-cached indices.
> - **Engine**:
>   - Type-hint cleanups; `prepare_batch`/`shutdown` now explicit `-> None`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cfd25717e5bd3a1d5c0898e2a08d63fbee2f1cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->