### PR TITLE
[Docs] Move nanovllm acknowledgements to benchmark scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You can also use `/reset` to clear the chat history.
 
 ### Offline inference
 
-See [bench_nanovllm.py](./benchmark/offline/bench_nanovllm.py) for more details. Set `MINISGL_DISABLE_OVERLAP_SCHEDULING=1` for ablation study on overlap scheduling.
+See [bench.py](./benchmark/offline/bench.py) for more details. Set `MINISGL_DISABLE_OVERLAP_SCHEDULING=1` for ablation study on overlap scheduling.
 
 Test Configuration:
 

--- a/benchmark/offline/bench.py
+++ b/benchmark/offline/bench.py
@@ -1,3 +1,5 @@
+# Adapted from: https://github.com/GeeeekExplorer/nano-vllm/blob/main/bench.py
+
 import time
 from random import randint, seed
 


### PR DESCRIPTION
Avoid directly use `bench_nanovllm.py` (which can be understood as "comparing minisgl with nanovllm") and add acknowledgements in the head of benchmark scripts.