### PR TITLE
transformers v5.0.0 use different AutoConfig item about rope_theta

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "msgpack",
     "sgl_kernel>=0.3.17.post1",
     "torch",
-    "transformers",
+    "transformers<=4.57.3",
     "flashinfer-python>=0.5.3",
     "pyzmq",
     "uvicorn",


### PR DESCRIPTION
transformers v5.0.0 use different AutoConfig item about rope_theta attr, so for now only 4.57.3 or lower version is supported