### PR TITLE
[docs] Clarify multi-scheduler acknowledgment behavior

### DIFF
--- a/python/minisgl/server/launch.py
+++ b/python/minisgl/server/launch.py
@@ -102,7 +102,11 @@ def launch_server(run_shell: bool = False) -> None:
                 name=f"minisgl-tokenizer-{i}",
             ).start()
 
-        # 1 scheduler + n * tokenizers + 1 detokenizer
+        # Wait for acknowledgments from all worker processes:
+        # - world_size schedulers (but only primary rank sends ack)
+        # - num_tokenizers tokenizers
+        # - 1 detokenizer
+        # Total acks expected: 1 + num_tokenizers + 1 = num_tokenizers + 2
         for _ in range(num_tokenizers + 2):
             logger.info(ack_queue.get())
 


### PR DESCRIPTION
The previous comment suggested only 1 scheduler process existed, which was misleading. In reality, world_size scheduler processes are spawned (one per TP rank/GPU), but only the primary rank sends an acknowledgment to the parent process.

This commit updates the comment to explicitly mention:
- world_size schedulers are created
- Only the primary rank sends an ack
- Total expected acks = 1 + num_tokenizers + 1