### PR TITLE
docs: align README/features CLI examples with args.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,20 +52,20 @@ Launch an OpenAI-compatible API server with a single command.
 
 ```bash
 # Deploy Qwen/Qwen3-0.6B on a single GPU
-python -m minisgl --model "Qwen/Qwen3-0.6B"
+python -m minisgl --model-path "Qwen/Qwen3-0.6B"
 
 # Deploy meta-llama/Llama-3.1-70B-Instruct on 4 GPUs with Tensor Parallelism, on port 30000
-python -m minisgl --model "meta-llama/Llama-3.1-70B-Instruct" --tp 4 --port 30000
+python -m minisgl --model-path "meta-llama/Llama-3.1-70B-Instruct" --tp-size 4 --port 30000
 ```
 
 Once the server is running, you can send requests using standard tools like `curl` or any OpenAI-compatible client.
 
 ### 4. Interactive Shell
 
-Chat with your model directly in the terminal by adding the `--shell` flag.
+Chat with your model directly in the terminal by adding the `--shell-mode` flag.
 
 ```bash
-python -m minisgl --model "Qwen/Qwen3-0.6B" --shell
+python -m minisgl --model-path "Qwen/Qwen3-0.6B" --shell-mode
 ```
 
 ![shell-example](https://lmsys.org/images/blog/minisgl/shell.png)
@@ -102,7 +102,7 @@ Launch command:
 
 ```bash
 # Mini-SGLang
-python -m minisgl --model "Qwen/Qwen3-32B" --tp 4 --cache naive
+python -m minisgl --model-path "Qwen/Qwen3-32B" --tp-size 4 --cache-type naive
 
 # SGLang
 python3 -m sglang.launch_server --model "Qwen/Qwen3-32B" --tp 4 \

--- a/docs/features.md
+++ b/docs/features.md
@@ -11,12 +11,12 @@ For demonstration and testing purposes, an interactive shell mode is available. 
 Example:
 
 ```bash
-python -m minisgl --model "Qwen/Qwen3-0.6B" --shell
+python -m minisgl --model-path "Qwen/Qwen3-0.6B" --shell-mode
 ```
 
 ## Distributed Serving
 
-To scale performance across multiple GPUs, Mini-SGLang supports Tensor Parallelism (TP). You can enable distributed serving by specifying the number of GPUs with the `--tp n` argument, where `n` is the degree of parallelism.
+To scale performance across multiple GPUs, Mini-SGLang supports Tensor Parallelism (TP). You can enable distributed serving by specifying the number of GPUs with the `--tp-size n` argument, where `n` is the degree of parallelism.
 
 ## Supported Models
 
@@ -33,7 +33,7 @@ Chunked Prefill, a technique introduced by [Sarathi-Serve](https://arxiv.org/abs
 
 Mini-SGLang integrates high-performance attention kernels, including [`FlashAttention`](https://github.com/Dao-AILab/flash-attention) and [`FlashInfer`](https://github.com/flashinfer-ai/flashinfer). It supports using different backends for the prefill and decode phases to maximize efficiency. For example, on NVIDIA Hopper GPUs, `FlashAttention3` is used for prefill and `FlashInfer` for decoding by default.
 
-You can specify the backend using the `--attn` argument. If two values are provided (e.g., `--attn fa3,fi`), the first specifies the prefill backend and the second the decode backend.
+You can specify the backend using the `--attn` argument (one of `fa3` or `fi`). Note: the codebase supports a hybrid string like `fa3,fi` for different prefill/decode backends, but the current CLI parser only accepts a single value.
 
 ## CUDA Graph
 
@@ -41,7 +41,7 @@ To minimize CPU launch overhead during decoding, Mini-SGLang supports capturing 
 
 ## Radix Cache
 
-Adopting the original design from [SGLang](https://github.com/sgl-project/sglang.git), Mini-SGLang implements a Radix Cache to manage the Key-Value (KV) cache. This allows the reuse of KV cache for shared prefixes across requests, reducing redundant computation. This feature is enabled by default but can be switched to a naive cache management strategy using `--cache naive`.
+Adopting the original design from [SGLang](https://github.com/sgl-project/sglang.git), Mini-SGLang implements a Radix Cache to manage the Key-Value (KV) cache. This allows the reuse of KV cache for shared prefixes across requests, reducing redundant computation. This feature is enabled by default but can be switched to a naive cache management strategy using `--cache-type naive`.
 
 ![radix](https://lmsys.org/images/blog/sglang/radix_attn.jpg)
 *Illustration of Radix Attention from [LMSYS Blog](https://lmsys.org/blog/2024-01-17-sglang/).*


### PR DESCRIPTION
This PR fixes inconsistencies between documentation examples and the actual CLI argument names defined in `python/minisgl/server/args.py`.

Changes:
- `README.md`: Updated `--model` ~ `--model-path`, `--tp` ~ `--tp-size`, `--shell` ~ `--shell-mode`, `--cache` ~ `--cache-type`
- `docs/features.md`: Same parameter name updates, plus a note about `--attn` CLI limitation

No code changes, documentation only. All examples should now work when copy-pasted.