### PR TITLE
[Fix] JIT kernel compatibility with cuda 12.1/12.4

### DIFF
--- a/python/minisgl/kernel/csrc/include/minisgl/tensor.h
+++ b/python/minisgl/kernel/csrc/include/minisgl/tensor.h
@@ -32,6 +32,12 @@ struct SizeRef;
 struct DTypeRef;
 struct DeviceRef;
 
+inline constexpr auto kAnyDeviceID = -1;
+inline constexpr auto kAnySize = static_cast<int64_t>(-1);
+inline constexpr auto kNullSize = static_cast<int64_t>(0);
+inline constexpr auto kNullDType = static_cast<DLDataTypeCode>(18u);
+inline constexpr auto kNullDevice = static_cast<DLDeviceType>(-1);
+
 template <typename T> struct dtype_trait {};
 
 template <std::integral T> struct dtype_trait<T> {
@@ -49,23 +55,18 @@ template <std::floating_point T> struct dtype_trait<T> {
                  .lanes = 1};
 };
 
-inline constexpr auto kAnyDeviceID = -1;
-inline constexpr auto kAnySize = static_cast<int64_t>(-1);
-inline constexpr auto kNullSize = static_cast<int64_t>(0);
-inline constexpr auto kNullDType = static_cast<DLDataTypeCode>(18u);
-inline constexpr auto kNullDevice = static_cast<DLDeviceType>(-1);
+template <DLDeviceType Code> struct device_trait {
+  inline static constexpr auto value =
+      DLDevice{.device_type = Code, .device_id = kAnyDeviceID};
+};
 
 template <typename... Ts>
 inline constexpr auto kDTypeList =
     std::array<DLDataType, sizeof...(Ts)>{dtype_trait<Ts>::value...};
 
-template <auto Code>
-inline constexpr auto _kOneDevice = DLDevice{
-    .device_type = static_cast<DLDeviceType>(Code), .device_id = kAnyDeviceID};
-
-template <auto... Codes>
+template <DLDeviceType... Codes>
 inline constexpr auto kDeviceList =
-    std::array<DLDevice, sizeof...(Codes)>{_kOneDevice<Codes>...};
+    std::array<DLDevice, sizeof...(Codes)>{device_trait<Codes>::value...};
 
 template <typename T> struct PrintAbleSpan {
   explicit PrintAbleSpan(std::span<const T> data) : data(data) {}

--- a/python/minisgl/kernel/csrc/include/minisgl/utils.h
+++ b/python/minisgl/kernel/csrc/include/minisgl/utils.h
@@ -1,10 +1,37 @@
 #pragma once
 
+// ref:
+// https://forums.developer.nvidia.com/t/c-20s-source-location-compilation-error-when-using-nvcc-12-1/258026/3
+#ifdef __CUDACC__
+#pragma push_macro("__cpp_consteval")
+#pragma push_macro("_NODISCARD")
+#pragma push_macro("__builtin_LINE")
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wbuiltin-macro-redefined"
+#define __cpp_consteval 201811L
+#pragma clang diagnostic pop
+
+#ifdef _NODISCARD
+#undef _NODISCARD
+#define _NODISCARD
+#endif
+
+#define consteval constexpr
+
+#include <source_location>
+
+#undef consteval
+#pragma pop_macro("__cpp_consteval")
+#pragma pop_macro("_NODISCARD")
+#else
+#include <source_location>
+#endif
+
 #include <dlpack/dlpack.h>
 
 #include <concepts>
 #include <ostream>
-#include <source_location>
 #include <sstream>
 #include <utility>
 

--- a/python/minisgl/kernel/csrc/include/minisgl/warp.cuh
+++ b/python/minisgl/kernel/csrc/include/minisgl/warp.cuh
@@ -4,8 +4,6 @@
 #include <sys/cdefs.h>
 
 #include <cstddef>
-#include <cstdint>
-#include <type_traits>
 
 namespace device::warp {
 
@@ -37,40 +35,6 @@ inline constexpr auto resolve_unit_size(std::size_t x) -> std::size_t {
 template <std::size_t kBytes, std::size_t kUnit>
 using mem_package_t = decltype(get_mem_package<kUnit>());
 
-template <typename T, std::size_t N> struct uint_vec {
-  T data[N];
-};
-
-__always_inline __device__ auto load_nc(const uint1 *__restrict__ src)
-    -> uint1 {
-  uint32_t tmp;
-  asm volatile("ld.global.cs.b32 %0,[%1];" : "=r"(tmp) : "l"(src));
-  return uint1{tmp};
-}
-
-__always_inline __device__ auto load_nc(const uint2 *__restrict__ src)
-    -> uint2 {
-  uint32_t tmp0, tmp1;
-  asm volatile("ld.global.cs.v2.b32 {%0,%1},[%2];"
-               : "=r"(tmp0), "=r"(tmp1)
-               : "l"(src));
-  return uint2{tmp0, tmp1};
-}
-
-__always_inline __device__ void store_nc(uint1 *__restrict__ dst,
-                                         const uint1 &value) {
-  uint32_t tmp = value.x;
-  asm volatile("st.global.cs.b32 [%0],%1;" ::"l"(dst), "r"(tmp));
-}
-
-__always_inline __device__ void store_nc(uint2 *__restrict__ dst,
-                                         const uint2 &value) {
-  uint32_t tmp0 = value.x;
-  uint32_t tmp1 = value.y;
-  asm volatile("st.global.cs.v2.b32 [%0],{%1,%2};" ::"l"(dst), "r"(tmp0),
-               "r"(tmp1));
-}
-
 } // namespace details
 
 template <std::size_t kBytes,
@@ -91,52 +55,6 @@ __always_inline __device__ void copy(void *__restrict__ dst,
   for (std::size_t i = 0; i < kLoopCount; ++i) {
     const auto j = i * kWarpThreads + lane_id;
     dst_packed[j] = src_packed[j];
-  }
-}
-
-template <std::size_t kBytes,
-          std::size_t kUnit = details::resolve_unit_size(kBytes)>
-__always_inline __device__ auto load_vec(const void *__restrict__ src) {
-  using Package = details::mem_package_t<kBytes, kUnit>;
-  constexpr auto kBytesPerLoop = sizeof(Package) * kWarpThreads;
-  constexpr auto kLoopCount = kBytes / kBytesPerLoop;
-  using vec_t = details::uint_vec<Package, kLoopCount>;
-  static_assert(kBytes % kBytesPerLoop == 0,
-                "kBytes must be multiple of 128 bytes");
-
-  const auto src_packed = static_cast<const Package *>(src);
-  const auto lane_id = threadIdx.x % kWarpThreads;
-  vec_t vec;
-
-#pragma unroll kLoopCount
-  for (std::size_t i = 0; i < kLoopCount; ++i) {
-    const auto j = i * kWarpThreads + lane_id;
-    // vec.data[i] = src_packed[j];
-    vec.data[i] = details::load_nc(src_packed + j);
-  }
-  return vec;
-}
-
-template <std::size_t kBytes,
-          std::size_t kUnit = details::resolve_unit_size(kBytes), typename T>
-__always_inline __device__ void store_vec(void *__restrict__ dst,
-                                          const T &vec) {
-  using Package = details::mem_package_t<kBytes, kUnit>;
-  constexpr auto kBytesPerLoop = sizeof(Package) * kWarpThreads;
-  constexpr auto kLoopCount = kBytes / kBytesPerLoop;
-  using vec_t = details::uint_vec<Package, kLoopCount>;
-  static_assert(kBytes % kBytesPerLoop == 0,
-                "kBytes must be multiple of 128 bytes");
-  static_assert(std::is_same_v<T, vec_t>, "store_vec: src type mismatch");
-
-  const auto dst_packed = static_cast<Package *>(dst);
-  const auto lane_id = threadIdx.x % kWarpThreads;
-
-#pragma unroll kLoopCount
-  for (std::size_t i = 0; i < kLoopCount; ++i) {
-    const auto j = i * kWarpThreads + lane_id;
-    // dst_packed[j] = vec.data[i];
-    details::store_nc(dst_packed + j, vec.data[i]);
   }
 }
 

--- a/python/minisgl/kernel/csrc/jit/index.cu
+++ b/python/minisgl/kernel/csrc/jit/index.cu
@@ -88,7 +88,6 @@ __global__ __launch_bounds__(kNumThreads, kMaxOccupancy) void //
                                        (warp_id % kNumSplits) * kSizePerWarp);
       warp::copy<kSizePerWarp>(dst, src);
     } else {
-      // memset the warp to zero, using uint4 package
       warp::reset<kSizePerWarp>(dst);
     }
   }


### PR DESCRIPTION
Tested on H200 cuda 12.1 and 12.4 on official docker image from nvidia.

```
nvidia/cuda:12.9.0-devel-ubuntu24.04
nvidia/cuda:12.4.0-devel-ubuntu22.04
nvidia/cuda:12.1.0-devel-ubuntu22.04
```

This should fix #20 and fix #34. cc @wyclike @wwwsctvcom
