### PR TITLE
bugfix: fix hf config load dtype

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "msgpack",
     "sgl_kernel>=0.3.17.post1",
     "torch",
-    "transformers<=4.57.3",
+    "transformers>=4.56.0,<=4.57.3",
     "flashinfer-python>=0.5.3",
     "pyzmq",
     "uvicorn",


### PR DESCRIPTION
This PR fixes an issue where loading the HF config failed for models that use torch_dtype instead of dtype (e.g., Qwen3).

It adds a fallback check: if dtype is not present, it attempts to read torch_dtype.

Fixes #36 