### PR TITLE
[minor] gracefully handle Ctrl-D (EOFError) in shell mode

### DIFF
--- a/python/minisgl/server/api_server.py
+++ b/python/minisgl/server/api_server.py
@@ -369,6 +369,9 @@ async def shell():
                 print(msg, end="", flush=True)
             print("", flush=True)
             history.append((cmd, cur_msg))
+    except EOFError:
+        # user pressed Ctrl-D
+        pass
     finally:
         print("Exiting shell...")
         await asyncio.sleep(0.1)


### PR DESCRIPTION
Add EOFError exception handler in shell() function to properly handle when users press Ctrl-D to exit the interactive shell, ensuring cleanup code in the finally block still executes.