### PR TITLE
fix: correct assertion in lock_handle to allow ref_count == 0

### DIFF
--- a/python/minisgl/kvcache/radix_manager.py
+++ b/python/minisgl/kvcache/radix_manager.py
@@ -101,7 +101,7 @@ class RadixCacheManager(BaseCacheManager):
             while not node.is_root():
                 node = node.parent
                 node.ref_count -= 1
-                assert node.ref_count > 0
+                assert node.ref_count >= 0
                 if node.ref_count == 0:
                     self.evictable_size += node.length
                     self.protected_size -= node.length


### PR DESCRIPTION
The original assertion 'assert node.ref_count > 0' was incorrect because:
1. It would crash when ref_count reaches 0 after decrement
2. The following 'if node.ref_count == 0' branch was dead code

Changed to 'assert node.ref_count >= 0' so nodes can be properly marked as evictable when their ref_count drops to zero.