### PR TITLE
bug fix:Fix: Missed lock/unlock of current node in RadixCacheManager when using lock_handle.

### DIFF
--- a/python/minisgl/kvcache/radix_manager.py
+++ b/python/minisgl/kvcache/radix_manager.py
@@ -99,19 +99,19 @@ class RadixCacheManager(BaseCacheManager):
         node = handle.node
         if unlock:
             while not node.is_root():
-                node = node.parent
                 node.ref_count -= 1
                 assert node.ref_count >= 0
                 if node.ref_count == 0:
                     self.evictable_size += node.length
                     self.protected_size -= node.length
+                node = node.parent
         else:
             while not node.is_root():
-                node = node.parent
                 if node.ref_count == 0:
                     self.evictable_size -= node.length
                     self.protected_size += node.length
                 node.ref_count += 1
+                node = node.parent
 
     def match_prefix(self, input_ids: torch.Tensor) -> Tuple[RadixCacheHandle, torch.Tensor]:
         node, prefix_len = self._walk(input_ids)


### PR DESCRIPTION
## Root Cause

In the while loop, the line node = node.parent was misplaced (positioned as the first line of the loop body).

This caused the code to immediately skip handle.node itself, only updating the reference count (ref_count) for its parent and higher-level ancestors.

## Impact
Current Node Unprotected: When a RadixCacheHandle is obtained via match_prefix, it points to a specific node in the tree (e.g., Node_B). Logically, this indicates that Node_B's data is currently in use.
Eviction Risk: Since lock_handle skips Node_B, its ref_count remains unchanged. If a system memory pressure triggers an eviction, the system will incorrectly assume Node_B has a reference count of 0 (unused) and evict (delete) it.
Crashes: When the inference engine subsequently attempts to access data from Node_B, it will encounter a released node or missing data, leading to a crash.

## Code Execution Walkthrough (Buggy Version)

Assume handle.node is Node_B, and the path is: Root -> Node_A -> Node_B.

```

# Buggy Flow
node = Node_B
while not node.is_root(): # Node_B is not root, enters loop
    node = node.parent    # <--- Immediately changes to Node_A!
    node.ref_count += 1   # Increments Node_A's ref_count
    # ...
    # Loop continues to process Root...
```

Result: Node_A is locked, but the actual target Node_B is completely ignored.

Solution

The current node's state (updating ref_count and size) must be processed before moving up to the parent node.

The corrected code is as follows:

```

    def lock_handle(self, handle: BaseCacheHandle, unlock: bool = False) -> None:
        assert isinstance(handle, RadixCacheHandle)
        node = handle.node
        if unlock:
            while not node.is_root():
                # --- Fix: Process the current node first ---
                node.ref_count -= 1
                assert node.ref_count >= 0
                if node.ref_count == 0:
                    self.evictable_size += node.length
                    self.protected_size -= node.length
                # --- Fix: Move to parent after processing ---
                node = node.parent 
        else:
            while not node.is_root():
                # --- Fix: Process the current node first ---
                if node.ref_count == 0:
                    self.evictable_size -= node.length
                    self.protected_size += node.length
                node.ref_count += 1
                # --- Fix: Move to parent after processing ---
                node = node.parent
```