### PR TITLE
feat: Implement batch tokenization for improved throughput

### DIFF
--- a/python/minisgl/tokenizer/tokenize.py
+++ b/python/minisgl/tokenizer/tokenize.py
@@ -14,10 +14,14 @@ class TokenizeManager:
         self.tokenizer = tokenizer
 
     def tokenize(self, msgs: List[TokenizeMsg]) -> List[torch.Tensor]:
-        results: List[torch.Tensor] = []
-        # TODO: batch tokenization
+        if len(msgs) == 0:
+            return []
+
+        # Step 1: Prepare all prompts (handle both chat templates and plain text)
+        prompts: List[str] = []
         for msg in msgs:
             if isinstance(msg.text, list):
+                # Chat format - apply chat template
                 prompt = self.tokenizer.apply_chat_template(
                     msg.text,
                     tokenize=False,
@@ -25,9 +29,22 @@ class TokenizeManager:
                 )
                 assert isinstance(prompt, str)
             else:
+                # Plain text
                 prompt = msg.text
-            input_ids: torch.Tensor = (  # type: ignore
-                self.tokenizer.encode(prompt, return_tensors="pt")
-            )
-            results.append(input_ids.view(-1).to(torch.int32))
+            prompts.append(prompt)
+
+        # Step 2: Batch tokenization (no padding for efficiency)
+        # Returns BatchEncoding with input_ids as List[List[int]]
+        batch_result = self.tokenizer(
+            prompts,
+            padding=False,
+            add_special_tokens=True,
+        )
+
+        # Step 3: Convert each result to individual tensor
+        results: List[torch.Tensor] = [
+            torch.tensor(input_ids, dtype=torch.int32)
+            for input_ids in batch_result["input_ids"]
+        ]
+
         return results


### PR DESCRIPTION
Replace sequential tokenization with batch processing using HuggingFace's native batch API. This change significantly improves tokenization performance, especially for larger batch sizes.

Key changes:
- Use tokenizer(prompts, padding=False) for batch processing
- Pre-process all messages (chat templates and plain text) before tokenization
- Convert batch results to individual int32 tensors


```
======================================================================
Batch Tokenization Performance Benchmark
======================================================================

Loading tokenizer...
Tokenizer loaded.

Running benchmarks (100 iterations per batch size)...

Batch Size   Sequential (s)   Batch (s)        Speedup     
----------------------------------------------------------------------
1            0.0130           0.0074           1.75        x
2            0.0333           0.0264           1.26        x
4            0.0640           0.0369           1.73        x
8            0.1022           0.0545           1.88        x
16           0.2353           0.0833           2.82        x
32           0.5041           0.1506           3.35        x
64           0.9826           0.2041           4.82        x
----------------------------------------------------------------------

Summary:
  - Best speedup: 4.82x (batch size 64)
  - Average speedup: 2.51x

Throughput (messages/second):
Batch Size   Sequential       Batch            Improvement 
----------------------------------------------------------------------
1            7696.7           13447.7          74.7        %
2            6001.2           7562.5           26.0        %
4            6253.3           10833.7          73.2        %
8            7824.3           14690.7          87.8        %
16           6801.2           19207.1          182.4       %
32           6348.1           21242.1          234.6       %
64           6513.5           31364.2          381.5       %
----------------------------------------------------------------------
```