### PR TITLE
feat: add Qwen2.5 model support

### DIFF
--- a/python/minisgl/models/qwen2.py
+++ b/python/minisgl/models/qwen2.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Tuple
+
+import torch
+from minisgl.core import get_global_ctx
+from minisgl.layers import BaseOP, OPList, ParallelLMHead, RMSNormFused, VocabParallelEmbedding
+from minisgl.utils import nvtx_annotate
+
+from .base import BaseLLMModel
+from .utils import GatedMLP as Qwen2MLP
+from .utils import RopeAttn as Qwen2Attn
+
+if TYPE_CHECKING:
+    from .config import ModelConfig
+
+
+class Qwen2DecoderLayer(BaseOP):
+    def __init__(self, config: ModelConfig, layer_id: int):
+        self.self_attn = Qwen2Attn(config, layer_id, has_qk_norm=False, has_attn_bias=True)
+        self.mlp = Qwen2MLP(config)
+        self.input_layernorm = RMSNormFused(
+            size=config.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+        self.post_attention_layernorm = RMSNormFused(
+            size=config.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+
+        self._layer_id = layer_id
+
+    @nvtx_annotate("Layer_{}", layer_id_field="_layer_id")
+    def forward(
+        self, x: torch.Tensor, residual: torch.Tensor | None = None
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        x, residual = self.input_layernorm.forward(x, residual)
+        x = self.self_attn.forward(x)
+        x, residual = self.post_attention_layernorm.forward(x, residual)
+        x = self.mlp.forward(x)
+        return x, residual
+
+
+class Qwen2Model(BaseOP):
+    def __init__(self, config: ModelConfig):
+        self.embed_tokens = VocabParallelEmbedding(
+            num_embeddings=config.vocab_size,
+            embedding_dim=config.hidden_size,
+        )
+        self.layers = OPList(
+            [Qwen2DecoderLayer(config, layer_id) for layer_id in range(config.num_layers)]
+        )
+        self.norm = RMSNormFused(
+            size=config.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        x = self.embed_tokens.forward(input_ids)
+        residual: torch.Tensor | None = None
+        for layer in self.layers.op_list:
+            x, residual = layer.forward(x, residual)
+        return self.norm.forward(x, residual)[0]
+
+
+class Qwen2ForCausalLM(BaseLLMModel):
+    def __init__(self, config: ModelConfig):
+        self.model = Qwen2Model(config)
+        self.lm_head = ParallelLMHead(
+            num_embeddings=config.vocab_size,
+            embedding_dim=config.hidden_size,
+            tie_word_embeddings=config.tie_word_embeddings,
+            tied_embedding=self.model.embed_tokens if config.tie_word_embeddings else None,
+        )
+        super().__init__()
+
+    def forward(self) -> torch.Tensor:
+        output = self.model.forward(get_global_ctx().batch.input_ids)
+        logits = self.lm_head.forward(output)
+        return logits
+
+
+__all__ = ["Qwen2ForCausalLM"]

--- a/python/minisgl/models/register.py
+++ b/python/minisgl/models/register.py
@@ -4,6 +4,7 @@ from .config import ModelConfig
 
 _MODEL_REGISTRY = {
     "LlamaForCausalLM": (".llama", "LlamaForCausalLM"),
+    "Qwen2ForCausalLM": (".qwen2", "Qwen2ForCausalLM"),
     "Qwen3ForCausalLM": (".qwen3", "Qwen3ForCausalLM"),
     "Qwen3MoeForCausalLM": (".qwen3_moe", "Qwen3MoeForCausalLM"),
 }


### PR DESCRIPTION

## Description

This PR adds support for the Qwen2.5 series models to the framework.

The implementation strictly follows the transformers reference implementations:
https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen2/modeling_qwen2.py
https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen3/modeling_qwen3.py

The differences between the two model versions were carefully compared during development.

## Results
Offline benchmark results on an RTX 3080 are shown below:
Qwen2.5-0.5B：
```
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[2026-02-04|18:40:25|core|rank=0] INFO     Free memory before loading model: 9.40 GiB
[2026-02-04|18:40:26|core|rank=0] INFO     Allocating 633590 pages for KV cache, K + V = 7.25 GiB
[2026-02-04|18:40:26|core|rank=0] INFO     Auto-selected attention backend: fi
[2026-02-04|18:40:26|core|rank=0] INFO     Free memory after initialization: 0.81 GiB
[2026-02-04|18:40:26|core|rank=0] INFO     Start capturing CUDA graphs with sizes: [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256]
[2026-02-04|18:40:26|core|rank=0] INFO     Free GPU memory before capturing CUDA graphs: 0.67 GiB
Capturing graphs: bs = 1   | avail_mem = 0.45 GiB: 100%|█| 35/35 [00:01<00:00, 34.42batch/
[2026-02-04|18:40:27|core|rank=0] INFO     Free GPU memory after capturing CUDA graphs: 0.45 GiB
Total: 10058tok, Time: 2.66s, Throughput: 3778.97tok/s
```

Qwen3-0.6B：
```
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[2026-02-04|18:41:06|core|rank=0] INFO     Free memory before loading model: 9.40 GiB
[2026-02-04|18:41:11|core|rank=0] INFO     Allocating 65617 pages for KV cache, K + V = 7.01 GiB
[2026-02-04|18:41:11|core|rank=0] INFO     Auto-selected attention backend: fi
[2026-02-04|18:41:11|core|rank=0] INFO     Free memory after initialization: 0.81 GiB
[2026-02-04|18:41:11|core|rank=0] INFO     Start capturing CUDA graphs with sizes: [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256]
[2026-02-04|18:41:11|core|rank=0] INFO     Free GPU memory before capturing CUDA graphs: 0.67 GiB
Capturing graphs: bs = 1   | avail_mem = 0.37 GiB: 100%|█| 35/35 [00:01<00:00, 31.66batch/
[2026-02-04|18:41:12|core|rank=0] INFO     Free GPU memory after capturing CUDA graphs: 0.37 GiB
Total: 10058tok, Time: 4.04s, Throughput: 2488.92tok/s
```

## Motivation
The Qwen2.5-0.5B model is widely used in TTS systems such as [SparkTTS](https://github.com/SparkAudio/Spark-TTS) and [Orpheus-TTS](https://github.com/canopyai/Orpheus-TTS) ，this framework can be integrated into high-quality TTS frameworks similar to [FlashTTS](https://github.com/HuiResearch/FlashTTS).

