### PR TITLE
Fix: torch.AcceleratorError: CUDA error: an illegal memory access was encountered

### DIFF
--- a/python/minisgl/scheduler/scheduler.py
+++ b/python/minisgl/scheduler/scheduler.py
@@ -140,7 +140,7 @@ class Scheduler(SchedulerIOMixin):
             return
 
         batch, (_, next_tokens_cpu, copy_done) = last_data[0].batch, last_data[1]
-        copy_done.synchronize()
+        torch.cuda.synchronize(self.device)
         reply: List[DetokenizeMsg] = []
         new_finished_reqs: Set[Req] = set()
         with self.cache_manager.lazy_free_region():


### PR DESCRIPTION
# Summary

Replaced copy_done.synchronize() with torch.cuda.synchronize(self.device) for better synchronization handling. Fix the error `torch.AcceleratorError: CUDA error: an illegal memory access was encountered` raised when the server is being benchmarked.

I'm not quite sure whether the patch would cause performance degration, since it might effectively disable the CPU/GPU overlapped scheduling feature. But I think it is a good starting point.

# The Problem

When I benchmarked the server, it consistently raises error in server logs.

## Hardware

```
$ nvidia-smi
Sun Mar  1 15:02:56 2026       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 590.48.01              Driver Version: 590.48.01      CUDA Version: 13.1     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA GeForce RTX 3060        On  |   00000000:01:00.0  On |                  N/A |
|  0%   56C    P8             20W /  170W |   11036MiB /  12288MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
```

## Server log

```
$ python -m minisgl --model Qwen/Qwen3-1.7B --memory-ratio 0.8 --max-running-req 128 --port 1919
[2026-03-01|10:49:34] INFO     Parsed arguments:
ServerArgs(model_path='Qwen/Qwen3-1.7B', tp_info=DistributedInfo(rank=0, size=1), dtype=torch.bfloat16, max_running_req=128, attention_back
end='auto', moe_backend='auto', cuda_graph_bs=None, cuda_graph_max_bs=None, page_size=1, memory_ratio=0.8, distributed_timeout=60.0, use_du
mmy_weight=False, use_pynccl=True, max_seq_len_override=None, num_page_override=None, max_extend_tokens=8192, cache_type='radix', offline_m
ode=False, _unique_suffix='.pid=12795', server_host='127.0.0.1', server_port=1919, num_tokenizer=0, silent_output=False)
[2026-03-01|10:49:35|core|rank=0] INFO     Auto-selected attention backend: fi
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[2026-03-01|10:49:36|core|rank=0] INFO     Free memory before loading model: 10.74 GiB
Loading weights:  50%|███████████████████████████████████████████▌                                           | 1/2 [00:00<00:00,  2.79it/s]
[2026-03-01|10:49:37|initializer] INFO     Tokenize server 0 is ready
Loading weights: 100%|███████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  4.82it/s]
[2026-03-01|10:49:38|core|rank=0] INFO     Allocating 45228 tokens for KV cache, K + V = 4.83 GiB
[2026-03-01|10:49:38|core|rank=0] INFO     Free memory after initialization: 2.00 GiB
[2026-03-01|10:49:38|core|rank=0] INFO     Start capturing CUDA graphs with sizes: [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96,
 104, 112, 120, 128, 136, 144, 152, 160]
[2026-03-01|10:49:38|core|rank=0] INFO     Free GPU memory before capturing CUDA graphs: 1.97 GiB
Capturing graphs: bs = 1   | avail_mem = 1.71 GiB: 100%|████████████████████████████████████████████████| 23/23 [00:00<00:00, 28.81batch/s]
[2026-03-01|10:49:38|core|rank=0] INFO     Free GPU memory after capturing CUDA graphs: 1.70 GiB
[2026-03-01|10:49:40|core|rank=0] INFO     Scheduler is idle, waiting for new reqs...
[2026-03-01|10:49:40|initializer] INFO     Scheduler is ready
[2026-03-01|10:49:40|FrontendAPI] INFO     API server is ready to serve on 127.0.0.1:1919
INFO:     Started server process [12795]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:1919 (Press CTRL+C to quit)
INFO:     127.0.0.1:59220 - "GET /v1/models HTTP/1.1" 200 OK
INFO:     127.0.0.1:49772 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2026-03-01|10:50:44|core|rank=0] INFO     Scheduler is idle, waiting for new reqs...
INFO:     127.0.0.1:49778 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49792 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49800 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49816 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49828 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49836 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49852 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49856 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49858 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49872 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49882 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49888 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49896 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49902 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49916 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49918 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49932 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49936 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49950 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49966 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49970 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49980 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:49986 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50000 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50002 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50010 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50024 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50032 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50038 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50046 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50050 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50058 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50070 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50076 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50092 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50102 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50110 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50120 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50126 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50138 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50146 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50150 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50156 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50170 - "POST /v1/chat/completions HTTP/1.1" 200 OK
Process minisgl-TP0-scheduler:
Traceback (most recent call last):
  File "/usr/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/lib/python3.12/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "mini-sglang/main/python/minisgl/server/launch.py", line 31, in _run_scheduler
    scheduler.run_forever()
  File "mini-sglang/main/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "mini-sglang/main/python/minisgl/scheduler/scheduler.py", line 131, in run_forever
    data = self.overlap_loop(data)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "mini-sglang/main/python/minisgl/scheduler/scheduler.py", line 105, in overlap_loop
    self._process_last_data(last_data)
  File "mini-sglang/main/python/minisgl/scheduler/scheduler.py", line 143, in _process_last_data
    copy_done.synchronize()
  File "mini-sglang/main/.venv/lib/python3.12/site-packages/torch/cuda/streams.py", line 231, in synchronize
    super().synchronize()
torch.AcceleratorError: CUDA error: an illegal memory access was encountered
Search for `cudaErrorIllegalAddress' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.

terminate called after throwing an instance of 'c10::AcceleratorError'
  what():  CUDA error: an illegal memory access was encountered
Search for `cudaErrorIllegalAddress' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.

Exception raised from c10_cuda_check_implementation at /pytorch/c10/cuda/CUDAException.cpp:44 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x80 (0
x7622a2b7cb80 in mini-sglang/main/.venv/lib/python3.12/site-packages/torch/lib/libc10.so)
frame #1: <unknown function> + 0x11fb7 (0x7622a2f44fb7 in mini-sglang/main/.venv/lib/python3.12/site-packages/torch/lib/libc10_cuda.so)
frame #2: <unknown function> + 0xc77b28 (0x762243e77b28 in mini-sglang/main/.venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so)
frame #3: <unknown function> + 0xc72b53 (0x762243e72b53 in mini-sglang/main/.venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so)
frame #4: <unknown function> + 0xc7a685 (0x762243e7a685 in mini-sglang/main/.venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so)
frame #5: <unknown function> + 0x4827af (0x7622944827af in mini-sglang/main/.venv/lib/python3.12/site-packages/torch/lib/libtorch_python.so)
frame #6: c10::TensorImpl::~TensorImpl() + 0x9 (0x7622a2b59d69 in mini-sglang/main/.venv/lib/python3.12/site-packages/torch/lib/libc10.so)
frame #7: <unknown function> + 0x7cb658 (0x7622947cb658 in mini-sglang/main/.venv/lib/python3.12/site-packages/torch/lib/libtorch_python.so)
frame #8: <unknown function> + 0x7cb9c5 (0x7622947cb9c5 in mini-sglang/main/.venv/lib/python3.12/site-packages/torch/lib/libtorch_python.so)
frame #9: mini-sglang/main/.venv/bin/python() [0x59159a]
frame #10: mini-sglang/main/.venv/bin/python() [0x59f2a3]
frame #11: mini-sglang/main/.venv/bin/python() [0x591572]
frame #12: mini-sglang/main/.venv/bin/python() [0x558d21]
frame #13: mini-sglang/main/.venv/bin/python() [0x6107d5]
frame #14: mini-sglang/main/.venv/bin/python() [0x6107e5]
frame #15: mini-sglang/main/.venv/bin/python() [0x6107e5]
frame #16: mini-sglang/main/.venv/bin/python() [0x6107e5]
frame #17: mini-sglang/main/.venv/bin/python() [0x6107e5]
frame #18: mini-sglang/main/.venv/bin/python() [0x6107e5]
frame #19: mini-sglang/main/.venv/bin/python() [0x5532db]
frame #20: mini-sglang/main/.venv/bin/python() [0x59f2a3]
frame #21: _PyEval_EvalFrameDefault + 0x566f (0x5dbecf in mini-sglang/main/.venv/bin/python)
frame #22: PyEval_EvalCode + 0x15b (0x5d582b in mini-sglang/main/.venv/bin/python)
frame #23: PyRun_StringFlags + 0xd3 (0x6087b3 in mini-sglang/main/.venv/bin/python)
frame #24: PyRun_SimpleStringFlags + 0x3e (0x6b392e in mini-sglang/main/.venv/bin/python)
frame #25: Py_RunMain + 0x481 (0x6bc5f1 in mini-sglang/main/.venv/bin/python)
frame #26: Py_BytesMain + 0x2d (0x6bc00d in mini-sglang/main/.venv/bin/python)
frame #27: <unknown function> + 0x2a1ca (0x7622a3c2a1ca in /lib/x86_64-linux-gnu/libc.so.6)
frame #28: __libc_start_main + 0x8b (0x7622a3c2a28b in /lib/x86_64-linux-gnu/libc.so.6)
frame #29: _start + 0x25 (0x657445 in mini-sglang/main/.venv/bin/python)

INFO:     127.0.0.1:50180 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50188 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50196 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50212 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50220 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50234 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50248 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50264 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50276 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50284 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50300 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50302 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50316 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50324 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50328 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50344 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50356 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50372 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50376 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50380 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50382 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50388 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50390 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50392 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50394 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50404 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50406 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50416 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50420 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50436 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50450 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50466 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50478 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50488 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50492 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50494 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50500 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50514 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50522 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50536 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50542 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50548 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50560 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50564 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50578 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50590 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50598 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50610 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50622 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50630 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50636 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50644 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50646 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50650 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50654 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:50664 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```

## Benchmark command

The `bench_serving.py` was taken from https://github.com/sgl-project/sglang/blob/main/python/sglang/bench_serving.py without any modification

```
python bench_serving.py --backend sglang-oai-chat --dataset-name random --random-input 128 --random-output 128 --num-prompts 500 --request-rate 128 --random-range-ratio 1.0 --base-url http://127.0.0.1:1919
```

# Rationale of the fix

**The following content was mostly generated by AI. I reviewed it before adding it here**

**Root Cause: Resource Race in Overlap Scheduling**
In the overlap_loop of Scheduler, the next batch ($N$) is scheduled and launched on the GPU before the results of the previous batch ($N-1$) are processed:  
1. Scheduling Batch $N$: _schedule_next_batch is called. Because the results of batch $N-1$ haven't been processed yet, any requests that finished in batch $N-1$ (e.g., due to an EOS token) are still marked as "running." Consequently, they are scheduled again for batch $N$—this is "speculative execution."
2. Launching Batch $N$: Batch $N$ starts executing on the engine.stream (GPU).
3. Processing Batch $N-1$: _process_last_data is called for batch $N-1$. It identifies requests that finished and calls _free_req_resources, which returns their KV cache pages and table slots to the free pool.
4. The IMA(Illegal Memory Access): Because batch $N$ is already running on the GPU and is using those same resources (speculatively), freeing them on the CPU allows the next iteration ($N+1$) to reallocate and overwrite them. This leads to the batch $N$ kernels reading corrupted or out-of-bounds indices from the page_table, resulting in an illegal memory access.


**Why the Fix Works**
The original code used copy_done.synchronize(), which only blocked the CPU until batch $N-1$ was finished. This allowed _process_last_data to proceed while batch $N$ was still running.

By replacing it with torch.cuda.synchronize(self.device), the scheduler now waits for all ongoing GPU operations on the device to complete. This includes the speculatively launched batch $N$. As a result:
   - Batch $N$ is guaranteed to finish its execution before _process_last_data begins freeing any resources.
   - The race condition is eliminated because no resource is returned to the free pool while a GPU kernel is still potentially accessing it.

While this fix restores stability by effectively serializing parts of the execution, it ensures that speculative tokens don't conflict with resource management, preventing the CUDA illegal memory access reported in the logs.