### PR TITLE
refactor(tests): convert to pytest-style with integration markers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ pytest configuration for mini-sglang tests.
 """
 
 import pytest
-import torch
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+"""
+pytest configuration for mini-sglang tests.
+"""
+
+import pytest
+import torch
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-integration",
+        action="store_true",
+        default=False,
+        help="Run integration tests (requires multi-GPU and HF models)",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "integration: mark test as integration test (requires special hardware like multi-GPU)",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Automatically skip integration tests unless --run-integration is specified."""
+    if config.getoption("--run-integration"):
+        # Run all tests including integration tests
+        return
+
+    skip_integration = pytest.mark.skip(reason="need --run-integration option to run")
+    for item in items:
+        if "integration" in item.keywords:
+            item.add_marker(skip_integration)

--- a/tests/core/test_cache_allocate.py
+++ b/tests/core/test_cache_allocate.py
@@ -4,10 +4,9 @@ Test that CacheManager._allocate correctly handles eviction with page_size > 1.
 
 from __future__ import annotations
 
+import minisgl.core as core
 import pytest
 import torch
-
-import minisgl.core as core
 from minisgl.scheduler.cache import CacheManager
 
 

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
+import multiprocessing as mp
 import os
+
 import pytest
 import torch
-import multiprocessing as mp
-from transformers import AutoTokenizer
-
+from minisgl.core import SamplingParams
 from minisgl.distributed import DistributedInfo
 from minisgl.message import BaseBackendMsg, BaseTokenizerMsg, DetokenizeMsg, ExitMsg, UserMsg
 from minisgl.scheduler import Scheduler, SchedulerConfig
 from minisgl.utils import ZmqPullQueue, ZmqPushQueue, init_logger
-from minisgl.core import SamplingParams
+from transformers import AutoTokenizer
 
 logger = init_logger(__name__)
 

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import pytest
 import torch
 import multiprocessing as mp
 from transformers import AutoTokenizer
@@ -7,10 +9,33 @@ from transformers import AutoTokenizer
 from minisgl.distributed import DistributedInfo
 from minisgl.message import BaseBackendMsg, BaseTokenizerMsg, DetokenizeMsg, ExitMsg, UserMsg
 from minisgl.scheduler import Scheduler, SchedulerConfig
-from minisgl.utils import ZmqPullQueue, ZmqPushQueue, call_if_main, init_logger
+from minisgl.utils import ZmqPullQueue, ZmqPushQueue, init_logger
 from minisgl.core import SamplingParams
 
 logger = init_logger(__name__)
+
+# Default model path - can be overridden with environment variable
+MODEL_PATH = os.environ.get("MINISGL_TEST_MODEL", "meta-llama/Llama-3.1-8B-Instruct")
+
+
+def check_model_available():
+    """Check if the model is available locally or can be downloaded."""
+    try:
+        # Try to load tokenizer to check if model is accessible
+        AutoTokenizer.from_pretrained(MODEL_PATH, trust_remote_code=True)
+        return True
+    except Exception as e:
+        logger.warning(f"Model {MODEL_PATH} not available: {e}")
+        return False
+
+
+@pytest.fixture(scope="module")
+def require_model():
+    """Skip test if model is not available."""
+    if not check_model_available():
+        pytest.skip(
+            f"Model {MODEL_PATH} not available (set MINISGL_TEST_MODEL to use a local model)"
+        )
 
 
 @torch.inference_mode()
@@ -23,10 +48,10 @@ def scheduler(config: SchedulerConfig, queue: mp.Queue) -> None:
         logger.info_rank0("Scheduler exiting...")
 
 
-@call_if_main(__name__)
-def main():
+@pytest.mark.integration
+def test_scheduler_integration(require_model):
     config = SchedulerConfig(
-        model_path="meta-llama/Llama-3.1-8B-Instruct",
+        model_path=MODEL_PATH,
         tp_info=DistributedInfo(0, 1),
         dtype=torch.bfloat16,
         max_running_req=4,
@@ -51,7 +76,7 @@ def main():
         decoder=BaseTokenizerMsg.decoder,
     )
 
-    tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-3.1-8B-Instruct")
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH, trust_remote_code=True)
     prompt = "What's the answer to life, the universe, and everything?"
     ids = tokenizer.encode(prompt, return_tensors="pt").view(-1).to(torch.int32)
     send_backend.put(
@@ -71,3 +96,7 @@ def main():
 
     logger.info(tokenizer.decode(ids.tolist()))
     send_backend.put(ExitMsg())
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/kernel/test_comm.py
+++ b/tests/kernel/test_comm.py
@@ -1,14 +1,12 @@
 import os
 import time
 
+import minisgl.kernel as kernel
 import pytest
 import torch
 from minisgl.distributed import set_tp_info
-import minisgl.kernel as kernel
-from tqdm import tqdm
-
 from minisgl.utils import init_logger
-
+from tqdm import tqdm
 
 logger = init_logger(__name__)
 

--- a/tests/kernel/test_comm.py
+++ b/tests/kernel/test_comm.py
@@ -1,5 +1,7 @@
 import os
 import time
+
+import pytest
 import torch
 from minisgl.distributed import set_tp_info
 import minisgl.kernel as kernel
@@ -9,6 +11,13 @@ from minisgl.utils import init_logger
 
 
 logger = init_logger(__name__)
+
+
+@pytest.mark.integration
+def test_communication():
+    """Test NCCL communication primitives with tensor parallelism."""
+    tp_size = 4
+    run_test(tp_size)
 
 
 @torch.no_grad()
@@ -150,10 +159,10 @@ def run(tp_size: int, tp_rank: int):
     torch.distributed.destroy_process_group()
 
 
-if __name__ == "__main__":
+def run_test(tp_size: int):
+    """Run the communication test with multiprocessing."""
     import multiprocessing as mp
 
-    tp_size = 4
     mp.set_start_method("spawn", force=True)
     os.environ["MASTER_ADDR"] = "127.0.0.1"
     os.environ["MASTER_PORT"] = "12355"
@@ -170,3 +179,7 @@ if __name__ == "__main__":
         for p in p_list:
             p.terminate()
         raise
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/kernel/test_index.py
+++ b/tests/kernel/test_index.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
+
 from typing import Tuple
+
 import pytest
 import torch
 import torch.nn.functional as F
-
 from minisgl.benchmark.perf import compare_memory_kernel_perf
 from minisgl.kernel import indexing
 from minisgl.utils import init_logger

--- a/tests/kernel/test_index.py
+++ b/tests/kernel/test_index.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 from typing import Tuple
+import pytest
 import torch
 import torch.nn.functional as F
 
 from minisgl.benchmark.perf import compare_memory_kernel_perf
 from minisgl.kernel import indexing
-from minisgl.utils import call_if_main, init_logger
+from minisgl.utils import init_logger
 
 logger = init_logger(__name__)
 
@@ -29,7 +30,6 @@ def ref_indexing(
         return F.embedding(indices, weights)
 
 
-@call_if_main(__name__)
 def test_indexing():
     EMBED_SIZE = 4096
     NUM_TOKENS = 131072
@@ -61,7 +61,6 @@ def test_indexing():
         )
 
 
-@call_if_main(__name__)
 def test_indexing_with_mask():
     EMBED_SIZE = 4096
     NUM_TOKENS = 131072
@@ -99,3 +98,7 @@ def test_indexing_with_mask():
             description=f"BS={bs:6d} | ",
             extra_kwargs={"init_stream": False},
         )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/kernel/test_store.py
+++ b/tests/kernel/test_store.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
+import pytest
 from minisgl.benchmark.perf import compare_memory_kernel_perf
 import torch
 from minisgl.kernel import store_cache
-from minisgl.utils import call_if_main
 
 
-@call_if_main(__name__)
 def test_store_cache():
     HEAD_SIZE = 128
     NUM_TOKENS = 1048576  # 1M
@@ -51,3 +50,7 @@ def test_store_cache():
             description=f"BS={bs:6d} | ",
             extra_kwargs={"init_stream": False},
         )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/kernel/test_store.py
+++ b/tests/kernel/test_store.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import pytest
-from minisgl.benchmark.perf import compare_memory_kernel_perf
 import torch
+from minisgl.benchmark.perf import compare_memory_kernel_perf
 from minisgl.kernel import store_cache
 
 

--- a/tests/kernel/test_tensor.py
+++ b/tests/kernel/test_tensor.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
-from minisgl.kernel import test_tensor
-from minisgl.utils import call_if_main
+import pytest
+import minisgl.kernel as kernel
 import torch
 
 
-@call_if_main()
-def main():
+def test_tensor_op():
+    """Test the tensor operation kernel."""
     x = torch.empty((12, 2048), dtype=torch.int32, device="cpu")[:, :1024]
     y = torch.empty((12, 1024), dtype=torch.int64, device="cuda:1")
-    test_tensor(x, y)
+    kernel.test_tensor(x, y)
+    # The kernel should complete without error
+    # Add a simple assertion to verify execution
+    assert y.shape == (12, 1024)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/kernel/test_tensor.py
+++ b/tests/kernel/test_tensor.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import pytest
 import minisgl.kernel as kernel
+import pytest
 import torch
 
 

--- a/tests/misc/test_serialize.py
+++ b/tests/misc/test_serialize.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List
 
+import pytest
 from minisgl.core import SamplingParams
 import torch
 from minisgl.message import BatchBackendMsg, UserMsg
 from minisgl.message.utils import serialize_type, deserialize_type
-from minisgl.utils import call_if_main, init_logger
+from minisgl.utils import init_logger
 
 logger = init_logger(__name__)
 
@@ -19,7 +20,6 @@ class A:
     w: torch.Tensor
 
 
-@call_if_main()
 def test_serialize_deserialize():
 
     t = torch.tensor([1, 2, 3], dtype=torch.int32)
@@ -33,3 +33,7 @@ def test_serialize_deserialize():
     result = u.decoder(u.encoder())
     logger.info(u)
     logger.info(result)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/misc/test_serialize.py
+++ b/tests/misc/test_serialize.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import List
 
 import pytest
-from minisgl.core import SamplingParams
 import torch
+from minisgl.core import SamplingParams
 from minisgl.message import BatchBackendMsg, UserMsg
-from minisgl.message.utils import serialize_type, deserialize_type
+from minisgl.message.utils import deserialize_type, serialize_type
 from minisgl.utils import init_logger
 
 logger = init_logger(__name__)


### PR DESCRIPTION
Current testcases are managed as seperate scripts (run via `@call_if_main` decorators), and not very suitable given the pytest framework. There are also some heavy integration tests (require multiple GPUs, real HF models and tokenizers) that may be better to be defaulted skipped.

- Remove @call_if_main decorators, use standard test_ naming
- Add --run-integration flag in conftest.py to control integration tests
- Integration tests skip by default, run with --run-integration
- Add model availability check to scheduler test (configurable via MINISGL_TEST_MODEL rather than hardcoded model path)