### PR TITLE
[Feature] Expert parallelism support for MoE models

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -18,6 +18,17 @@ python -m minisgl --model "Qwen/Qwen3-0.6B" --shell
 
 To scale performance across multiple GPUs, Mini-SGLang supports Tensor Parallelism (TP). You can enable distributed serving by specifying the number of GPUs with the `--tp n` argument, where `n` is the degree of parallelism.
 
+## Expert Parallelism
+
+For Mixture-of-Experts (MoE) models, Mini-SGLang supports Expert Parallelism (EP) in addition to Tensor Parallelism. While TP shards each expert's intermediate dimension across GPUs, EP distributes entire experts across GPUs — each rank holds `num_experts / ep_size` complete experts. Tokens are routed to the correct rank via NCCL all-to-all communication, computed locally, and combined back.
+
+EP is useful when expert weights are too large to fit with TP sharding alone, or when you want to trade communication pattern (all-to-all vs all-reduce) for memory savings. Currently, `ep_size` must equal `tp_size` or 1.
+
+```bash
+# Deploy Qwen3-30B-A3B with 4-way expert parallelism
+python -m minisgl --model "Qwen/Qwen3-30B-A3B" --tp 4 --ep-size 4
+```
+
 ## Supported Models
 
 Our framework currently supports the following dense model architectures:

--- a/python/minisgl/distributed/__init__.py
+++ b/python/minisgl/distributed/__init__.py
@@ -1,12 +1,23 @@
 from .impl import DistributedCommunicator, destroy_distributed, enable_pynccl_distributed
-from .info import DistributedInfo, get_tp_info, set_tp_info, try_get_tp_info
+from .info import (
+    DistributedInfo,
+    get_ep_info,
+    get_tp_info,
+    set_ep_info,
+    set_tp_info,
+    try_get_ep_info,
+    try_get_tp_info,
+)
 
 __all__ = [
     "DistributedInfo",
     "get_tp_info",
     "set_tp_info",
+    "try_get_tp_info",
+    "get_ep_info",
+    "set_ep_info",
+    "try_get_ep_info",
     "enable_pynccl_distributed",
     "DistributedCommunicator",
-    "try_get_tp_info",
     "destroy_distributed",
 ]

--- a/python/minisgl/distributed/impl.py
+++ b/python/minisgl/distributed/impl.py
@@ -70,6 +70,34 @@ class DistributedCommunicator:
         return self.plugins[-1].all_gather(x)
 
 
+_EP_GROUP: dist.ProcessGroup | None = None
+
+
+def set_ep_group(group: dist.ProcessGroup) -> None:
+    global _EP_GROUP
+    _EP_GROUP = group
+
+
+def get_ep_group() -> dist.ProcessGroup:
+    assert _EP_GROUP is not None, "EP group has not been initialized"
+    return _EP_GROUP
+
+
+def ep_all_to_all(
+    output: torch.Tensor,
+    input: torch.Tensor,
+    output_split_sizes: List[int],
+    input_split_sizes: List[int],
+) -> None:
+    dist.all_to_all_single(
+        output,
+        input,
+        output_split_sizes=output_split_sizes,
+        input_split_sizes=input_split_sizes,
+        group=_EP_GROUP,
+    )
+
+
 def enable_pynccl_distributed(
     tp_info: DistributedInfo, tp_cpu_group: torch.distributed.ProcessGroup, max_bytes: int
 ) -> None:
@@ -94,4 +122,6 @@ def destroy_distributed() -> None:
     """
     Destroy all the distributed communication plugins.
     """
+    global _EP_GROUP
     DistributedCommunicator.plugins = []
+    _EP_GROUP = None

--- a/python/minisgl/distributed/info.py
+++ b/python/minisgl/distributed/info.py
@@ -8,7 +8,7 @@ class DistributedInfo:  # should not export from here
     rank: int
     size: int
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         assert 0 <= self.rank < self.size
 
     def is_primary(self) -> bool:
@@ -16,6 +16,7 @@ class DistributedInfo:  # should not export from here
 
 
 _TP_INFO: DistributedInfo | None = None
+_EP_INFO: DistributedInfo | None = None
 
 
 def set_tp_info(rank: int, size: int) -> None:
@@ -35,4 +36,29 @@ def try_get_tp_info() -> DistributedInfo | None:
     return _TP_INFO
 
 
-__all__ = ["DistributedInfo", "set_tp_info", "get_tp_info", "try_get_tp_info"]
+def set_ep_info(rank: int, size: int) -> None:
+    global _EP_INFO
+    if _EP_INFO is not None:
+        raise RuntimeError("EP info has been set")
+    _EP_INFO = DistributedInfo(rank, size)
+
+
+def get_ep_info() -> DistributedInfo:
+    if _EP_INFO is None:
+        raise RuntimeError("EP info has not been set")
+    return _EP_INFO
+
+
+def try_get_ep_info() -> DistributedInfo | None:
+    return _EP_INFO
+
+
+__all__ = [
+    "DistributedInfo",
+    "set_tp_info",
+    "get_tp_info",
+    "try_get_tp_info",
+    "set_ep_info",
+    "get_ep_info",
+    "try_get_ep_info",
+]

--- a/python/minisgl/engine/config.py
+++ b/python/minisgl/engine/config.py
@@ -28,10 +28,11 @@ class EngineConfig:
     use_dummy_weight: bool = False
     use_pynccl: bool = True
     max_seq_len_override: int | None = None
-    num_page_override: int | None = None  # if not None, will override the number of pages
+    num_page_override: int | None = None
+    ep_size: int = 1
 
     @cached_property
-    def hf_config(self):
+    def hf_config(self):  # type: ignore[override]
         return cached_load_hf_config(self.model_path)
 
     @cached_property

--- a/python/minisgl/engine/engine.py
+++ b/python/minisgl/engine/engine.py
@@ -144,7 +144,7 @@ class Engine:
             }
         else:
             return {
-                k: v.to(self.dtype) for k, v in load_weight(config.model_path, self.device).items()
+                k: v.to(self.dtype) for k, v in load_weight(config.model_path, self.device)
             }
 
     def _determine_num_pages(self, old_free_memory: int, config: EngineConfig) -> int:

--- a/python/minisgl/engine/engine.py
+++ b/python/minisgl/engine/engine.py
@@ -6,7 +6,12 @@ from typing import Any, Dict, NamedTuple, Tuple
 import torch
 from minisgl.attention import create_attention_backend
 from minisgl.core import Batch, Context, Req, set_global_ctx
-from minisgl.distributed import destroy_distributed, enable_pynccl_distributed, set_tp_info
+from minisgl.distributed import (
+    destroy_distributed,
+    enable_pynccl_distributed,
+    set_ep_info,
+    set_tp_info,
+)
 from minisgl.kvcache import create_kvcache_pool
 from minisgl.layers import set_rope_device
 from minisgl.models import create_model, load_weight
@@ -30,6 +35,7 @@ class Engine:
     def __init__(self, config: EngineConfig):
         assert not torch.cuda.is_initialized()
         set_tp_info(rank=config.tp_info.rank, size=config.tp_info.size)
+        set_ep_info(rank=config.tp_info.rank % max(config.ep_size, 1), size=config.ep_size)
         _adjust_config(config)
 
         self.device = torch.device(f"cuda:{config.tp_info.rank}")
@@ -110,7 +116,32 @@ class Engine:
         )
 
     def _init_communication(self, config: EngineConfig) -> torch.distributed.ProcessGroup:
-        if config.tp_info.size == 1 or config.use_pynccl:
+        if config.ep_size > 1:
+            # EP needs NCCL for all-to-all; use it as the main backend to avoid
+            # creating a second NCCL communicator (causes GPU memory imbalance).
+            torch.distributed.init_process_group(
+                backend="nccl",
+                rank=config.tp_info.rank,
+                world_size=config.tp_info.size,
+                timeout=timedelta(seconds=config.distributed_timeout),
+                init_method=config.distributed_addr,
+            )
+            tp_cpu_group = torch.distributed.new_group(backend="gloo")
+            assert tp_cpu_group is not None
+
+            from minisgl.distributed.impl import set_ep_group
+
+            ep_nccl_group = torch.distributed.group.WORLD
+            assert ep_nccl_group is not None
+            set_ep_group(ep_nccl_group)
+            logger.info_rank0(f"Expert parallelism enabled: ep_size={config.ep_size}")
+
+            if config.use_pynccl:
+                max_bytes = (
+                    config.max_forward_len * config.model_config.hidden_size * self.dtype.itemsize
+                )
+                enable_pynccl_distributed(config.tp_info, tp_cpu_group, max_bytes)
+        elif config.tp_info.size == 1 or config.use_pynccl:
             torch.distributed.init_process_group(
                 backend="gloo",
                 rank=config.tp_info.rank,
@@ -134,17 +165,28 @@ class Engine:
             )
             tp_cpu_group = torch.distributed.new_group(backend="gloo")
             assert tp_cpu_group is not None
+
         return tp_cpu_group
 
     def _load_weight_state_dict(self, config: EngineConfig) -> Dict[str, torch.Tensor]:
         if config.use_dummy_weight:
-            return {
-                k: torch.randn_like(v, device=self.device)
-                for k, v in self.model.state_dict().items()
-            }
+            result: Dict[str, torch.Tensor] = {}
+            for k, v in self.model.state_dict().items():
+                if "experts" in k:
+                    # state_dict() returns stacked [E, ...] but load_state_dict
+                    # expects per-expert keys that it torch.stacks back
+                    prefix, param = k.rsplit("experts.", 1)
+                    for i in range(v.shape[0]):
+                        result[f"{prefix}experts.{i}.{param}"] = torch.randn_like(
+                            v[i], device=self.device
+                        )
+                else:
+                    result[k] = torch.randn_like(v, device=self.device)
+            return result
         else:
             return {
-                k: v.to(self.dtype) for k, v in load_weight(config.model_path, self.device)
+                k: v.to(self.dtype)
+                for k, v in load_weight(config.model_path, self.device, ep_size=config.ep_size)
             }
 
     def _determine_num_pages(self, old_free_memory: int, config: EngineConfig) -> int:
@@ -217,8 +259,8 @@ def _align_up_32(num: int) -> int:
     return (num + 31) // 32 * 32
 
 
-def _adjust_config(config: EngineConfig):
-    def override(attr: str, value: Any):  # this is dangerous, use with caution
+def _adjust_config(config: EngineConfig) -> None:
+    def override(attr: str, value: Any) -> None:  # this is dangerous, use with caution
         object.__setattr__(config, attr, value)
 
     if config.attention_backend == "auto":
@@ -231,5 +273,15 @@ def _adjust_config(config: EngineConfig):
         logger.warning_rank0("Page size is overridden to 64 for TRTLLM backend")
 
     if config.model_config.is_moe and config.moe_backend == "auto":
-        override("moe_backend", "fused")
+        override("moe_backend", "ep" if config.ep_size > 1 else "fused")
         logger.info_rank0(f"Auto-selected MoE backend: {config.moe_backend}")
+
+    if config.ep_size > 1:
+        assert config.model_config.is_moe, "Expert parallelism requires a MoE model"
+        assert config.model_config.num_experts % config.ep_size == 0, (
+            f"num_experts ({config.model_config.num_experts}) "
+            f"must be divisible by ep_size ({config.ep_size})"
+        )
+        if config.cuda_graph_max_bs is None or config.cuda_graph_max_bs > 0:
+            override("cuda_graph_max_bs", 0)
+            logger.info_rank0("CUDA graphs disabled (incompatible with EP all-to-all)")

--- a/python/minisgl/layers/moe.py
+++ b/python/minisgl/layers/moe.py
@@ -1,6 +1,6 @@
 import torch
 from minisgl.core import get_global_ctx
-from minisgl.distributed import DistributedCommunicator, get_tp_info
+from minisgl.distributed import DistributedCommunicator, get_tp_info, try_get_ep_info
 from minisgl.utils import div_even
 
 from .base import BaseOP
@@ -26,23 +26,24 @@ class MoELayer(BaseOP):
         self._comm = DistributedCommunicator()
 
         tp_info = get_tp_info()
-        self.tp_size = tp_size = tp_info.size
+        ep_info = try_get_ep_info()
+
+        self.tp_size = tp_info.size
+        self.ep_size = ep_info.size if ep_info is not None else 1
         self.renormalize = renormalize
         self.activation = activation
         self.apply_router_weight_on_input = apply_router_weight_on_input
-        intermediate_size_per_partition = div_even(intermediate_size, tp_size)
-        self.gate_up_proj = torch.empty(
-            num_experts,
-            2 * intermediate_size_per_partition,
-            hidden_size,
-        )
-        self.down_proj = torch.empty(
-            num_experts,
-            hidden_size,
-            intermediate_size_per_partition,
-        )
 
-    def forward(self, hidden_states: torch.Tensor, router_logits: torch.Tensor):
+        if self.ep_size > 1:
+            num_local_experts = div_even(num_experts, self.ep_size)
+            self.gate_up_proj = torch.empty(num_local_experts, 2 * intermediate_size, hidden_size)
+            self.down_proj = torch.empty(num_local_experts, hidden_size, intermediate_size)
+        else:
+            intermediate_per_tp = div_even(intermediate_size, tp_info.size)
+            self.gate_up_proj = torch.empty(num_experts, 2 * intermediate_per_tp, hidden_size)
+            self.down_proj = torch.empty(num_experts, hidden_size, intermediate_per_tp)
+
+    def forward(self, hidden_states: torch.Tensor, router_logits: torch.Tensor) -> torch.Tensor:
         ctx = get_global_ctx()
         final_hidden_states = ctx.moe_backend.forward(
             hidden_states=hidden_states,
@@ -54,6 +55,6 @@ class MoELayer(BaseOP):
             activation=self.activation,
             apply_router_weight_on_input=self.apply_router_weight_on_input,
         )
-        if self.tp_size > 1:
+        if self.ep_size == 1 and self.tp_size > 1:
             final_hidden_states = self._comm.all_reduce(final_hidden_states)
         return final_hidden_states

--- a/python/minisgl/models/weight.py
+++ b/python/minisgl/models/weight.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import glob
-from typing import Dict
+from typing import Dict, Iterator, Tuple
 
 import safetensors
 import torch
@@ -9,80 +9,80 @@ from tqdm import tqdm
 from minisgl.distributed import get_tp_info
 from minisgl.utils import div_ceil, download_hf_weight
 
+_SPLIT_DIM_0 = [".q_proj", ".k_proj", ".v_proj", ".gate_proj", ".up_proj"]
+_SPLIT_DIM_1 = [".o_proj", ".down_proj"]
 
-def _shard_state_dict(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
-    shard_state_dict: Dict[str, torch.Tensor] = {}
-    tp_info = get_tp_info()
-    r = tp_info.rank
-    n = tp_info.size
-    SPLIT_DIM_0_LIST = [
-        ".q_proj",
-        ".k_proj",
-        ".v_proj",
-        ".gate_proj",
-        ".up_proj",
-    ]
-    SPLIT_DIM_1_LIST = [
-        ".o_proj",
-        ".down_proj",
-    ]
-    for key, value in state_dict.items():
-        if any(key.count(sub) for sub in SPLIT_DIM_0_LIST):
-            shard_state_dict[key] = value.chunk(n, dim=0)[r]
-        elif any(key.count(sub) for sub in SPLIT_DIM_1_LIST):
-            shard_state_dict[key] = value.chunk(n, dim=1)[r]
-        elif key.count("lm_head") or key.count("embed_tokens"):
-            num_embeddings = value.shape[0]
-            num_embeddings_per_partition = div_ceil(num_embeddings, n)
-            vocab_start_idx = r * num_embeddings_per_partition
-            vocab_end_idx = min((r + 1) * num_embeddings_per_partition, num_embeddings)
-            shard_state_dict[key] = value[vocab_start_idx:vocab_end_idx, :]
-        else:
-            shard_state_dict[key] = value
-    return shard_state_dict
+# Merge groups: individual projections -> fused projection
+_MERGE_GROUPS = {
+    ".q_proj": (".qkv_proj", ("q", "k", "v")),
+    ".k_proj": (".qkv_proj", ("q", "k", "v")),
+    ".v_proj": (".qkv_proj", ("q", "k", "v")),
+    ".gate_proj": (".gate_up_proj", ("gate", "up")),
+    ".up_proj": (".gate_up_proj", ("gate", "up")),
+}
+_SLOT_NAMES = {
+    ".q_proj": "q", ".k_proj": "k", ".v_proj": "v",
+    ".gate_proj": "gate", ".up_proj": "up",
+}
 
 
-def _merge_state_dict(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
-    filtered_state_dict: Dict[str, torch.Tensor] = {}
-    for key in list(state_dict.keys()):
-        if key.count(".q_proj"):
-            q_proj = state_dict[key]
-            k_proj = state_dict[key.replace(".q_proj", ".k_proj")]
-            v_proj = state_dict[key.replace(".q_proj", ".v_proj")]
-            new_key = key.replace(".q_proj", ".qkv_proj")
-            filtered_state_dict[new_key] = torch.cat([q_proj, k_proj, v_proj], dim=0)
-            del state_dict[key]
-            del state_dict[key.replace(".q_proj", ".k_proj")]
-            del state_dict[key.replace(".q_proj", ".v_proj")]
-        elif key.count(".gate_proj"):
-            gate_proj = state_dict[key]
-            up_proj = state_dict[key.replace(".gate_proj", ".up_proj")]
-            new_key = key.replace(".gate_proj", ".gate_up_proj")
-            filtered_state_dict[new_key] = torch.cat([gate_proj, up_proj], dim=0)
-            del state_dict[key]
-            del state_dict[key.replace(".gate_proj", ".up_proj")]
-        elif key.count(".k_proj") or key.count(".v_proj") or key.count("up_proj"):
-            continue
-        else:
-            filtered_state_dict[key] = state_dict[key]
-    return filtered_state_dict
+def _shard_tensor(key: str, value: torch.Tensor, r: int, n: int) -> torch.Tensor:
+    """Extract rank r's shard from a single tensor. Returns a contiguous copy."""
+    if any(key.count(sub) for sub in _SPLIT_DIM_0):
+        return value.chunk(n, dim=0)[r].clone()
+    elif any(key.count(sub) for sub in _SPLIT_DIM_1):
+        return value.chunk(n, dim=1)[r].clone()
+    elif key.count("lm_head") or key.count("embed_tokens"):
+        num_embeddings = value.shape[0]
+        num_embeddings_per_partition = div_ceil(num_embeddings, n)
+        vocab_start_idx = r * num_embeddings_per_partition
+        vocab_end_idx = min((r + 1) * num_embeddings_per_partition, num_embeddings)
+        return value[vocab_start_idx:vocab_end_idx, :].clone()
+    else:
+        return value
 
 
-def load_weight(model_path: str, device: torch.device) -> Dict[str, torch.Tensor]:
+def _get_merge_info(key: str):
+    """If key belongs to a merge group, return (merged_key, slot, all_slots). Else None."""
+    for suffix, (fused_suffix, slots) in _MERGE_GROUPS.items():
+        if key.count(suffix):
+            return key.replace(suffix, fused_suffix), _SLOT_NAMES[suffix], slots
+    return None
+
+
+def load_weight(model_path: str, device: torch.device) -> Iterator[Tuple[str, torch.Tensor]]:
+    """Streaming weight loader. Yields (name, tensor) pairs already sharded, merged,
+    and on device. Peak CPU memory: one full tensor + a small merge buffer."""
     model_folder = download_hf_weight(model_path)
-    files = glob.glob(f"{model_folder}/*.safetensors")
-    state_dict: Dict[str, torch.Tensor] = {}
+    files = sorted(glob.glob(f"{model_folder}/*.safetensors"))
 
     tp_info = get_tp_info()
-    disable_tqdm = (tp_info.rank != 0) if tp_info.size > 1 else False
+    r, n = tp_info.rank, tp_info.size
+    tp = n > 1
+    disable_tqdm = (r != 0) if tp else False
     device_str = str(device)
 
-    for file in tqdm(sorted(files), desc="Loading weights", disable=disable_tqdm):
-        with safetensors.safe_open(file, framework="pt", device=device_str) as f:
+    # Buffer for merge groups: merged_key -> {slot: tensor}
+    merge_buf: Dict[str, Dict[str, torch.Tensor]] = {}
+
+    for file in tqdm(files, desc="Loading weights", disable=disable_tqdm):
+        load_device = "cpu" if tp else device_str
+        with safetensors.safe_open(file, framework="pt", device=load_device) as f:
             for name in f.keys():
-                state_dict[name] = f.get_tensor(name)
+                raw = f.get_tensor(name)
+                tensor = _shard_tensor(name, raw, r, n).to(device) if tp else raw
+                del raw
 
-    if tp_info.size > 1:
-        state_dict = _shard_state_dict(state_dict)
+                info = _get_merge_info(name)
+                if info is None:
+                    yield name, tensor
+                    continue
 
-    return _merge_state_dict(state_dict)
+                merged_key, slot, all_slots = info
+                merge_buf.setdefault(merged_key, {})[slot] = tensor
+                if all(s in merge_buf[merged_key] for s in all_slots):
+                    parts = [merge_buf[merged_key][s] for s in all_slots]
+                    del merge_buf[merged_key]
+                    yield merged_key, torch.cat(parts, dim=0)
+
+    assert not merge_buf, f"Incomplete merge groups in checkpoint: {list(merge_buf.keys())}"

--- a/python/minisgl/models/weight.py
+++ b/python/minisgl/models/weight.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
 import glob
-from typing import Dict, Iterator, Tuple
+import re
+from typing import Dict, Iterator, Set, Tuple
 
 import safetensors
 import torch
-from tqdm import tqdm
-from minisgl.distributed import get_tp_info
+from minisgl.distributed import get_ep_info, get_tp_info
 from minisgl.utils import div_ceil, download_hf_weight
+from tqdm import tqdm
 
 _SPLIT_DIM_0 = [".q_proj", ".k_proj", ".v_proj", ".gate_proj", ".up_proj"]
 _SPLIT_DIM_1 = [".o_proj", ".down_proj"]
 
-# Merge groups: individual projections -> fused projection
 _MERGE_GROUPS = {
     ".q_proj": (".qkv_proj", ("q", "k", "v")),
     ".k_proj": (".qkv_proj", ("q", "k", "v")),
@@ -21,14 +21,20 @@ _MERGE_GROUPS = {
     ".up_proj": (".gate_up_proj", ("gate", "up")),
 }
 _SLOT_NAMES = {
-    ".q_proj": "q", ".k_proj": "k", ".v_proj": "v",
-    ".gate_proj": "gate", ".up_proj": "up",
+    ".q_proj": "q",
+    ".k_proj": "k",
+    ".v_proj": "v",
+    ".gate_proj": "gate",
+    ".up_proj": "up",
 }
 
+_EXPERT_KEY_RE = re.compile(r"experts\.(\d+)\.")
 
-def _shard_tensor(key: str, value: torch.Tensor, r: int, n: int) -> torch.Tensor:
-    """Extract rank r's shard from a single tensor. Returns a contiguous copy."""
-    if any(key.count(sub) for sub in _SPLIT_DIM_0):
+
+def _shard_tensor(key: str, value: torch.Tensor, r: int, n: int, ep_size: int) -> torch.Tensor:
+    if _EXPERT_KEY_RE.search(key) and ep_size > 1:
+        return value
+    elif any(key.count(sub) for sub in _SPLIT_DIM_0):
         return value.chunk(n, dim=0)[r].clone()
     elif any(key.count(sub) for sub in _SPLIT_DIM_1):
         return value.chunk(n, dim=1)[r].clone()
@@ -42,17 +48,37 @@ def _shard_tensor(key: str, value: torch.Tensor, r: int, n: int) -> torch.Tensor
         return value
 
 
-def _get_merge_info(key: str):
-    """If key belongs to a merge group, return (merged_key, slot, all_slots). Else None."""
+def _get_merge_info(key: str) -> Tuple[str, str, Tuple[str, ...]] | None:
     for suffix, (fused_suffix, slots) in _MERGE_GROUPS.items():
         if key.count(suffix):
             return key.replace(suffix, fused_suffix), _SLOT_NAMES[suffix], slots
     return None
 
 
-def load_weight(model_path: str, device: torch.device) -> Iterator[Tuple[str, torch.Tensor]]:
-    """Streaming weight loader. Yields (name, tensor) pairs already sharded, merged,
-    and on device. Peak CPU memory: one full tensor + a small merge buffer."""
+def _build_ep_skip_set(files: list[str], ep_size: int) -> Tuple[Set[str], int]:
+    ep_info = get_ep_info()
+    max_idx = -1
+    expert_keys: list[tuple[str, int]] = []
+    for file in files:
+        with safetensors.safe_open(file, framework="pt") as f:
+            for name in f.keys():
+                m = _EXPERT_KEY_RE.search(name)
+                if m:
+                    idx = int(m.group(1))
+                    max_idx = max(max_idx, idx)
+                    expert_keys.append((name, idx))
+    if max_idx < 0:
+        return set(), 0
+
+    num_local = (max_idx + 1) // ep_size
+    local_start = ep_info.rank * num_local
+    skip = {name for name, idx in expert_keys if not (local_start <= idx < local_start + num_local)}
+    return skip, local_start
+
+
+def load_weight(
+    model_path: str, device: torch.device, ep_size: int = 1
+) -> Iterator[Tuple[str, torch.Tensor]]:
     model_folder = download_hf_weight(model_path)
     files = sorted(glob.glob(f"{model_folder}/*.safetensors"))
 
@@ -62,20 +88,34 @@ def load_weight(model_path: str, device: torch.device) -> Iterator[Tuple[str, to
     disable_tqdm = (r != 0) if tp else False
     device_str = str(device)
 
-    # Buffer for merge groups: merged_key -> {slot: tensor}
+    skip_keys: Set[str] = set()
+    ep_local_start = 0
+    if ep_size > 1:
+        skip_keys, ep_local_start = _build_ep_skip_set(files, ep_size)
+
     merge_buf: Dict[str, Dict[str, torch.Tensor]] = {}
 
     for file in tqdm(files, desc="Loading weights", disable=disable_tqdm):
         load_device = "cpu" if tp else device_str
         with safetensors.safe_open(file, framework="pt", device=load_device) as f:
             for name in f.keys():
+                if name in skip_keys:
+                    continue
+
                 raw = f.get_tensor(name)
-                tensor = _shard_tensor(name, raw, r, n).to(device) if tp else raw
+                tensor = _shard_tensor(name, raw, r, n, ep_size).to(device) if tp else raw
                 del raw
 
-                info = _get_merge_info(name)
+                out_name = name
+                if ep_size > 1:
+                    m = _EXPERT_KEY_RE.search(name)
+                    if m:
+                        local_idx = int(m.group(1)) - ep_local_start
+                        out_name = name[: m.start(1)] + str(local_idx) + name[m.end(1) :]
+
+                info = _get_merge_info(out_name)
                 if info is None:
-                    yield name, tensor
+                    yield out_name, tensor
                     continue
 
                 merged_key, slot, all_slots = info

--- a/python/minisgl/moe/__init__.py
+++ b/python/minisgl/moe/__init__.py
@@ -17,10 +17,17 @@ SUPPORTED_MOE_BACKENDS = Registry[MoeBackendCreator]("MoE Backend")
 
 
 @SUPPORTED_MOE_BACKENDS.register("fused")
-def create_fused_moe_backend():
+def create_fused_moe_backend() -> BaseMoeBackend:
     from .fused import FusedMoe
 
     return FusedMoe()
+
+
+@SUPPORTED_MOE_BACKENDS.register("ep")
+def create_ep_moe_backend() -> BaseMoeBackend:
+    from .ep import EPMoe
+
+    return EPMoe()
 
 
 def create_moe_backend(backend: str) -> BaseMoeBackend:

--- a/python/minisgl/moe/ep.py
+++ b/python/minisgl/moe/ep.py
@@ -1,0 +1,87 @@
+import torch
+import torch.distributed as dist
+from minisgl.distributed import get_ep_info
+from minisgl.distributed.impl import ep_all_to_all, get_ep_group
+from minisgl.moe.base import BaseMoeBackend
+from minisgl.moe.fused import fused_experts_impl, fused_topk
+
+
+class EPMoe(BaseMoeBackend):
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        gating_output: torch.Tensor,
+        topk: int,
+        renormalize: bool,
+        activation: str = "silu",
+        apply_router_weight_on_input: bool = False,
+    ) -> torch.Tensor:
+        ep_size = get_ep_info().size
+        num_tokens, hidden_size = hidden_states.shape
+        num_local_experts = w1.shape[0]
+        num_pairs = num_tokens * topk
+
+        topk_weights, topk_ids = fused_topk(
+            hidden_states=hidden_states,
+            gating_output=gating_output,
+            topk=topk,
+            renormalize=renormalize,
+        )
+
+        flat_ids = topk_ids.view(-1)
+        dest_rank = flat_ids.to(torch.int64) // num_local_experts
+        local_ids = (flat_ids % num_local_experts).to(torch.int32)
+
+        token_idx = (
+            torch.arange(num_tokens, device=hidden_states.device)
+            .unsqueeze(1)
+            .expand(-1, topk)
+            .reshape(-1)
+        )
+
+        sort_idx = torch.argsort(dest_rank, stable=True)
+        sorted_token_idx = token_idx[sort_idx]
+        sorted_local_ids = local_ids[sort_idx]
+
+        send_hidden = hidden_states[sorted_token_idx].contiguous()
+        send_counts = torch.bincount(dest_rank, minlength=ep_size)
+
+        recv_counts = torch.empty_like(send_counts)
+        dist.all_to_all_single(recv_counts, send_counts, group=get_ep_group())
+
+        send_splits = send_counts.tolist()
+        recv_splits = recv_counts.tolist()
+        total_recv = sum(recv_splits)
+
+        recv_hidden = hidden_states.new_empty(total_recv, hidden_size)
+        ep_all_to_all(recv_hidden, send_hidden, recv_splits, send_splits)
+
+        recv_ids = sorted_local_ids.new_empty(total_recv)
+        ep_all_to_all(recv_ids, sorted_local_ids, recv_splits, send_splits)
+
+        if total_recv > 0:
+            unit_weights = torch.ones(
+                total_recv, 1, dtype=torch.float32, device=hidden_states.device
+            )
+            local_out = fused_experts_impl(
+                recv_hidden,
+                w1,
+                w2,
+                unit_weights,
+                recv_ids.unsqueeze(1),
+                activation=activation,
+                apply_router_weight_on_input=False,
+            )
+        else:
+            local_out = hidden_states.new_empty(0, hidden_size)
+
+        combined = hidden_states.new_empty(num_pairs, hidden_size)
+        ep_all_to_all(combined, local_out, send_splits, recv_splits)
+
+        result = hidden_states.new_empty(num_pairs, hidden_size)
+        result[sort_idx] = combined
+        result = result.view(num_tokens, topk, hidden_size)
+        weights = topk_weights.to(hidden_states.dtype).unsqueeze(-1)
+        return (result * weights).sum(dim=1)

--- a/python/minisgl/server/args.py
+++ b/python/minisgl/server/args.py
@@ -52,15 +52,6 @@ class ServerArgs(SchedulerConfig):
 
 
 def parse_args(args: List[str], run_shell: bool = False) -> Tuple[ServerArgs, bool]:
-    """
-    Parse command line arguments and return an EngineConfig.
-
-    Args:
-        args: Command line arguments (e.g., sys.argv[1:])
-
-    Returns:
-        EngineConfig instance with parsed arguments
-    """
     from minisgl.attention import validate_attn_backend
     from minisgl.kvcache import SUPPORTED_CACHE_MANAGER
     from minisgl.moe import SUPPORTED_MOE_BACKENDS
@@ -80,7 +71,7 @@ def parse_args(args: List[str], run_shell: bool = False) -> Tuple[ServerArgs, bo
         type=str,
         default="auto",
         choices=["auto", "float16", "bfloat16", "float32"],
-        help="Data type for model weights and activations. 'auto' will use FP16 for FP32/FP16 models and BF16 for BF16 models.",
+        help="Data type for model weights and activations.",
     )
 
     parser.add_argument(
@@ -89,6 +80,14 @@ def parse_args(args: List[str], run_shell: bool = False) -> Tuple[ServerArgs, bo
         type=int,
         default=1,
         help="The tensor parallelism size.",
+    )
+
+    parser.add_argument(
+        "--expert-parallel-size",
+        "--ep-size",
+        type=int,
+        default=1,
+        help="The expert parallelism size. Must equal tp-size or 1.",
     )
 
     parser.add_argument(
@@ -113,7 +112,7 @@ def parse_args(args: List[str], run_shell: bool = False) -> Tuple[ServerArgs, bo
         help="The fraction of GPU memory to use for KV cache.",
     )
 
-    assert ServerArgs.use_dummy_weight == False
+    assert ServerArgs.use_dummy_weight is False
     parser.add_argument(
         "--dummy-weight",
         action="store_true",
@@ -121,7 +120,7 @@ def parse_args(args: List[str], run_shell: bool = False) -> Tuple[ServerArgs, bo
         help="Use dummy weights for testing.",
     )
 
-    assert ServerArgs.use_pynccl == True
+    assert ServerArgs.use_pynccl is True
     parser.add_argument(
         "--disable-pynccl",
         action="store_false",
@@ -150,7 +149,7 @@ def parse_args(args: List[str], run_shell: bool = False) -> Tuple[ServerArgs, bo
         "--graph",
         type=int,
         default=ServerArgs.cuda_graph_max_bs,
-        help="The maximum batch size for CUDA graph capture. None means auto-tuning based on the GPU memory.",
+        help="The maximum batch size for CUDA graph capture.",
     )
 
     parser.add_argument(
@@ -158,7 +157,7 @@ def parse_args(args: List[str], run_shell: bool = False) -> Tuple[ServerArgs, bo
         "--tokenizer-count",
         type=int,
         default=ServerArgs.num_tokenizer,
-        help="The number of tokenizer processes to launch. 0 means the tokenizer is shared with the detokenizer.",
+        help="The number of tokenizer processes to launch.",
     )
 
     parser.add_argument(
@@ -190,8 +189,7 @@ def parse_args(args: List[str], run_shell: bool = False) -> Tuple[ServerArgs, bo
         "--attn",
         type=validate_attn_backend,
         default=ServerArgs.attention_backend,
-        help="The attention backend to use. If two backends are specified,"
-        " the first one is used for prefill and the second one for decode.",
+        help="The attention backend to use.",
     )
 
     parser.add_argument(
@@ -199,7 +197,7 @@ def parse_args(args: List[str], run_shell: bool = False) -> Tuple[ServerArgs, bo
         type=str,
         default="huggingface",
         choices=["huggingface", "modelscope"],
-        help="The source to download model from. Either 'huggingface' or 'modelscope'.",
+        help="The source to download model from.",
     )
 
     parser.add_argument(
@@ -223,10 +221,8 @@ def parse_args(args: List[str], run_shell: bool = False) -> Tuple[ServerArgs, bo
         help="Run the server in shell mode.",
     )
 
-    # Parse arguments
     kwargs = parser.parse_args(args).__dict__.copy()
 
-    # resolve some arguments
     run_shell |= kwargs.pop("shell_mode")
     if run_shell:
         kwargs["cuda_graph_max_bs"] = 1
@@ -259,8 +255,16 @@ def parse_args(args: List[str], run_shell: bool = False) -> Tuple[ServerArgs, bo
         "float32": torch.float32,
     }
     kwargs["dtype"] = DTYPE_MAP[dtype_str] if isinstance(dtype_str, str) else dtype_str
-    kwargs["tp_info"] = DistributedInfo(0, kwargs["tensor_parallel_size"])
+
+    tp_size = kwargs["tensor_parallel_size"]
+    ep_size = kwargs["expert_parallel_size"]
+    assert (
+        ep_size == 1 or ep_size == tp_size
+    ), f"ep_size ({ep_size}) must be 1 or equal to tp_size ({tp_size})"
+    kwargs["tp_info"] = DistributedInfo(0, tp_size)
+    kwargs["ep_size"] = ep_size
     del kwargs["tensor_parallel_size"]
+    del kwargs["expert_parallel_size"]
 
     result = ServerArgs(**kwargs)
     logger = init_logger(__name__)


### PR DESCRIPTION
This adds expert parallelism (EP) for MoE models. The approach follows SGLang's [EP design](https://github.com/sgl-project/sglang/blob/main/docs/advanced_features/expert_parallelism.md) — dispatch tokens to the rank that owns the target expert via all-to-all, compute locally using the existing fused MoE kernels from #59, then combine results back.

Depends on #93 for the streaming weight loader (which also handles EP expert partitioning).

### How it works

Instead of TP-sharding every expert's intermediate dimension, EP gives each rank `num_experts / ep_size` complete experts. The forward pass for each MoE layer then does:

1. Run the replicated gate to get top-k expert IDs (same as before)
2. Sort token-expert pairs by destination rank, exchange via `all_to_all_single`
3. Run `fused_experts_impl` locally on received tokens
4. Send results back via another all-to-all
5. Un-permute and apply routing weights

No new kernels — steps 1 and 3 reuse `fused_topk` and `fused_experts_impl` directly.

A few things worth calling out:
- When EP is active, NCCL is used as the main process group backend (not gloo). I tried creating a separate NCCL subgroup on top of gloo, but that causes a ~72 GiB memory imbalance across ranks from NCCL's internal buffer allocation. Using NCCL as the world group and creating a gloo subgroup for CPU coordination avoids this entirely.
- PyNCCL still gets layered on top for TP all-reduce, so attention layers use the same fast path as before.
- CUDA graphs are auto-disabled since the all-to-all token counts vary per batch.

### What changed

1 new file, 9 modified, 1 doc update:

| File | What |
|---|---|
| `moe/ep.py` | New EP backend |
| `distributed/info.py` | EP rank/size (same pattern as TP) |
| `distributed/__init__.py` | Exports |
| `distributed/impl.py` | EP NCCL group + all-to-all wrapper |
| `engine/config.py` | `ep_size` field |
| `engine/engine.py` | NCCL init, backend selection, CUDA graph disable, MoE dummy weight fix |
| `layers/moe.py` | EP weight shapes (fewer full-width experts) |
| `models/weight.py` | EP expert partitioning (on top of #93) |
| `moe/__init__.py` | Register EP backend |
| `server/args.py` | `--ep-size` flag |
| `docs/features.md` | EP section |

### Constraints

- `ep_size` must equal `tp_size` or 1 (they share the same NCCL world group)
- `num_experts % ep_size == 0`

### Testing

Ran on Qwen3-30B-A3B with `--tp 4 --ep-size 4` on 4×H200:

- Compared greedy outputs (temperature=0, top_k=1) against TP-only on 5 prompts at 32 tokens each — all identical.
- Verified dummy weight mode (server + API), shell mode (multi-turn with real weights).

### Usage
```bash
python -m minisgl --model "Qwen/Qwen3-30B-A3B" --tp 4 --ep-size 4
```