### PR TITLE
[Feature] Better estimation policy

### DIFF
--- a/benchmark/offline/bench_wildchat.py
+++ b/benchmark/offline/bench_wildchat.py
@@ -1,68 +1,10 @@
-import shutil
 import time
-import urllib.request
-from pathlib import Path
 from random import seed
 
-import pyarrow.parquet as pq
+from minisgl.benchmark.wildchat import iter_filtered_wildchat_prompt_ids
 from minisgl.core import SamplingParams
 from minisgl.llm import LLM
 from transformers import AutoTokenizer
-
-LANGS = {"English", "Chinese"}
-
-BASE_DIR = Path(__file__).resolve().parent
-WILDCHAT_FIRST_SHARD = "train-00000-of-00086.parquet"
-WILDCHAT_BASE_URL = "https://huggingface.co/datasets/allenai/WildChat-4.8M/resolve/main/data/"
-
-
-def download_if_missing(url: str, path: Path) -> None:
-    if path.exists():
-        return
-    print(f"Downloading {url} -> {path}")
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with urllib.request.urlopen(url, timeout=300) as resp, path.open("wb") as out:
-        shutil.copyfileobj(resp, out)
-
-
-def iter_filtered_prompt_ids(tokenizer):
-    shard_path = BASE_DIR / WILDCHAT_FIRST_SHARD
-    download_if_missing(WILDCHAT_BASE_URL + WILDCHAT_FIRST_SHARD, shard_path)
-
-    parquet = pq.ParquetFile(shard_path)
-    for batch in parquet.iter_batches(batch_size=256, columns=["conversation"]):
-        prompts = []
-        for conv in batch.to_pydict()["conversation"]:
-            if not conv:
-                continue
-
-            first_user = None
-            for turn in conv:
-                if turn.get("role") == "user":
-                    first_user = turn
-                    break
-            if first_user is None:
-                continue
-
-            text = (first_user.get("content") or "").strip()
-            if not text:
-                continue
-            if first_user.get("language") not in LANGS:
-                continue
-            if bool(first_user.get("redacted")) or bool(first_user.get("toxic")):
-                continue
-            prompts.append(text)
-
-        if not prompts:
-            continue
-
-        for prompt in prompts:
-            ids = tokenizer.apply_chat_template(
-                [{"role": "user", "content": prompt}],
-                tokenize=True,
-                add_generation_prompt=True,
-            )
-            yield ids
 
 
 def print_len_stats(name: str, lengths: list[int]) -> None:
@@ -87,7 +29,7 @@ def main() -> None:
     tokenizer = AutoTokenizer.from_pretrained(MODEL)
 
     prompt_token_ids = []
-    for ids in iter_filtered_prompt_ids(tokenizer):
+    for ids in iter_filtered_wildchat_prompt_ids(tokenizer):
         prompt_token_ids.append(ids)
         if len(prompt_token_ids) >= NUM_SEQS:
             break

--- a/benchmark/online/bench_qwen.py
+++ b/benchmark/online/bench_qwen.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import asyncio
 import os
 import random
@@ -34,7 +35,25 @@ def download_qwen_trace(url: str) -> str:
     return str(file_path)
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark MiniSGL with Qwen trace replay.")
+    parser.add_argument(
+        "--prompt-mode",
+        choices=["dummy", "random", "real"],
+        default="dummy",
+        help="Prompt source mode.",
+    )
+    parser.add_argument(
+        "--max-new-tokens",
+        type=int,
+        default=4096,
+        help="Only takes effect when --prompt-mode=real.",
+    )
+    return parser.parse_args()
+
+
 async def main():
+    args = parse_args()
     random.seed(42)  # reproducibility
     PORT = 1919
     N = 1000
@@ -42,11 +61,23 @@ async def main():
     async with OpenAI(base_url=f"http://127.0.0.1:{PORT}/v1", api_key="") as client:
         MODEL = await get_model_name(client)
         tokenizer = AutoTokenizer.from_pretrained(MODEL)
-        TRACES = read_qwen_trace(download_qwen_trace(URL), tokenizer, n=N, dummy=True)
-        logger.info(f"Start benchmarking with {N} requests using model {MODEL}...")
+        TRACES = read_qwen_trace(
+            download_qwen_trace(URL),
+            tokenizer,
+            n=N,
+            prompt_mode=args.prompt_mode,
+            max_new_tokens=args.max_new_tokens,
+        )
+
+        logger.info(f"Start benchmarking with {len(TRACES)} requests using model {MODEL}...")
         for scale in SCALES:
             traces = scale_traces(TRACES, scale)
-            results = await benchmark_trace(client, traces, MODEL)
+            results = await benchmark_trace(
+                client,
+                traces,
+                MODEL,
+                ignore_eos=args.prompt_mode != "real",
+            )
             process_benchmark_results(results)
         logger.info("Benchmarking completed.")
 

--- a/python/minisgl/benchmark/client.py
+++ b/python/minisgl/benchmark/client.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Tuple, overload
 
+from minisgl.benchmark.wildchat import collect_filtered_wildchat_prompts
 from minisgl.utils import UNSET, Unset, init_logger
 from openai import AsyncOpenAI as OpenAI
 from pydantic import BaseModel
@@ -208,12 +209,13 @@ async def benchmark_one(
     pbar: Console | bool = True,
     extra_body: Dict[str, Any] | None = None,
     input_length: int | None = None,  # a hack to force input length
+    ignore_eos: bool = True,
 ) -> RawResult:
     if isinstance(pbar, bool):
         pbar = make_console(1, output_length, use_pbar=pbar)
     with pbar.inflight(1):
         kwargs = {
-            "ignore_eos": True,
+            "ignore_eos": ignore_eos,
             "top_k": 1,
         }
         # this is an internal kwargs that might work for our system
@@ -257,6 +259,7 @@ async def benchmark_one_batch(
     extra_body: Dict[str, Any] | None = None,
     input_lengths: List[int | None] | None = None,
     pbar: Console | bool = True,
+    ignore_eos: bool = True,
 ) -> List[RawResult]:
     if isinstance(output_lengths, int):
         output_lengths = [output_lengths] * len(prompts)
@@ -275,6 +278,7 @@ async def benchmark_one_batch(
             pbar=pbar,
             extra_body=extra_body,
             input_length=input_length,
+            ignore_eos=ignore_eos,
         )
         for prompt, output_length, input_length in zip(
             prompts, output_lengths, input_lengths, strict=True
@@ -290,6 +294,7 @@ async def benchmark_trace(
     model: str,
     *,
     pbar: Console | bool = True,
+    ignore_eos: bool = True,
 ) -> List[RawResult]:
     if isinstance(pbar, bool):
         sum_output_len = sum(msg.output_length for msg in msgs)
@@ -301,7 +306,13 @@ async def benchmark_trace(
         target = start + msg.timestamp - offset
         await asyncio.sleep(max(0, target - time.perf_counter()))
         return await benchmark_one(
-            client, msg.message, msg.output_length, model, pbar=pbar, input_length=msg.input_length
+            client,
+            msg.message,
+            msg.output_length,
+            model,
+            pbar=pbar,
+            input_length=msg.input_length,
+            ignore_eos=ignore_eos,
         )
 
     tasks = [benchmark_timed(msg) for msg in msgs]
@@ -408,7 +419,8 @@ def read_qwen_trace(
     file_path: str,
     tokenizer: Any,
     n: int | None = None,
-    dummy: bool = False,
+    prompt_mode: str = "dummy",
+    max_new_tokens: int = 4096,
 ) -> List[BenchmarkTrace]:
     class JSONInput(BaseModel):
         chat_id: int
@@ -425,12 +437,28 @@ def read_qwen_trace(
         if n is not None:
             lines = lines[:n]
     objs = [JSONInput.model_validate_json(line) for line in lines]
-    if dummy:
+    if prompt_mode == "dummy":
         prompt = generate_prompt(tokenizer, max(obj.input_length for obj in objs))
         ids = tokenizer.encode(prompt, add_special_tokens=False)
         _get_prompt = lambda obj: tokenizer.decode(ids[: obj.input_length])
-    else:
+    elif prompt_mode == "random":
         _get_prompt = lambda obj: generate_prompt(tokenizer, obj.input_length)
+    elif prompt_mode == "real":
+        prompts = collect_filtered_wildchat_prompts(len(objs))
+        if len(prompts) == 0:
+            raise ValueError("No WildChat prompts available.")
+
+        return [
+            BenchmarkTrace(
+                timestamp=obj.timestamp,
+                message=prompts[i % len(prompts)],
+                # input_length=_get_input_length(prompts[i % len(prompts)]),
+                output_length=max_new_tokens,
+            )
+            for i, obj in enumerate(objs)
+        ]
+    else:
+        raise ValueError(f"Unknown prompt_mode: {prompt_mode}")
     return [
         BenchmarkTrace(
             timestamp=obj.timestamp,

--- a/python/minisgl/benchmark/wildchat.py
+++ b/python/minisgl/benchmark/wildchat.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import shutil
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import pyarrow.parquet as pq
+
+LANGS = {"English", "Chinese"}
+WILDCHAT_FIRST_SHARD = "train-00000-of-00086.parquet"
+WILDCHAT_BASE_URL = "https://huggingface.co/datasets/allenai/WildChat-4.8M/resolve/main/data/"
+BENCHMARK_DIR = Path(__file__).resolve().parents[3] / "benchmark"
+DEFAULT_WILDCHAT_SHARD_PATH = BENCHMARK_DIR / "offline" / WILDCHAT_FIRST_SHARD
+
+
+def download_if_missing(url: str, path: Path) -> None:
+    if path.exists():
+        return
+    print(f"Downloading {url} -> {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with urllib.request.urlopen(url, timeout=300) as resp, path.open("wb") as out:
+        shutil.copyfileobj(resp, out)
+
+
+def iter_filtered_wildchat_prompts(shard_path: Path = DEFAULT_WILDCHAT_SHARD_PATH):
+    download_if_missing(WILDCHAT_BASE_URL + WILDCHAT_FIRST_SHARD, shard_path)
+
+    parquet = pq.ParquetFile(shard_path)
+    for batch in parquet.iter_batches(batch_size=256, columns=["conversation"]):
+        prompts = []
+        for conv in batch.to_pydict()["conversation"]:
+            if not conv:
+                continue
+
+            first_user = None
+            for turn in conv:
+                if turn.get("role") == "user":
+                    first_user = turn
+                    break
+            if first_user is None:
+                continue
+
+            text = (first_user.get("content") or "").strip()
+            if not text:
+                continue
+            if first_user.get("language") not in LANGS:
+                continue
+            if bool(first_user.get("redacted")) or bool(first_user.get("toxic")):
+                continue
+            prompts.append(text)
+
+        if not prompts:
+            continue
+
+        for prompt in prompts:
+            yield prompt
+
+
+def collect_filtered_wildchat_prompts(
+    n: int | None = None,
+    shard_path: Path = DEFAULT_WILDCHAT_SHARD_PATH,
+) -> list[str]:
+    prompts = []
+    for prompt in iter_filtered_wildchat_prompts(shard_path):
+        prompts.append(prompt)
+        if n is not None and len(prompts) >= n:
+            break
+    return prompts
+
+
+def iter_filtered_wildchat_prompt_ids(
+    tokenizer: Any,
+    shard_path: Path = DEFAULT_WILDCHAT_SHARD_PATH,
+):
+    for prompt in iter_filtered_wildchat_prompts(shard_path):
+        yield tokenizer.apply_chat_template(
+            [{"role": "user", "content": prompt}],
+            tokenize=True,
+            add_generation_prompt=True,
+        )

--- a/python/minisgl/core.py
+++ b/python/minisgl/core.py
@@ -28,17 +28,21 @@ class SamplingParams:
 @dataclass(eq=False)
 class Req:
     input_ids: torch.Tensor  # cpu tensor
+    prompt_len: int
     table_idx: int
     cached_len: int
     output_len: int
     uid: int
     sampling_params: SamplingParams
     cache_handle: BaseCacheHandle
+    is_retracted: bool = False
 
     def __post_init__(self) -> None:
         assert self.input_ids.is_cpu
         self.device_len = len(self.input_ids)
-        self.max_device_len = len(self.input_ids) + self.output_len
+        self.max_device_len = (
+            max(self.device_len, self.prompt_len) + self.output_len
+        )
         assert 0 <= self.cached_len < self.device_len <= self.max_device_len
 
     @property

--- a/python/minisgl/engine/engine.py
+++ b/python/minisgl/engine/engine.py
@@ -88,6 +88,7 @@ class Engine:
         # ======================= Graph capture initialization ========================
         self.dummy_req = Req(
             input_ids=torch.tensor([0], dtype=torch.int32, device="cpu"),
+            prompt_len=1,
             table_idx=config.max_running_req,
             cached_len=0,
             output_len=1,

--- a/python/minisgl/env.py
+++ b/python/minisgl/env.py
@@ -68,6 +68,12 @@ class EnvClassSingleton:
     FLASHINFER_USE_TENSOR_CORES = EnvOption()
     DISABLE_OVERLAP_SCHEDULING = EnvBool(False)
     PYNCCL_MAX_BUFFER_SIZE = EnvMem(1024**3)
+    SCHEDULE_CONSERVATIVENESS = EnvFloat(1.0)
+    INIT_NEW_TOKEN_RATIO = EnvFloat(0.7)
+    MIN_NEW_TOKEN_RATIO_FACTOR = EnvFloat(0.14)
+    NEW_TOKEN_RATIO_DECAY_STEPS = EnvInt(600)
+    CLIP_MAX_NEW_TOKENS = EnvInt(4096)
+    RETRACT_DECODE_STEPS = EnvInt(20)
 
     def __new__(cls):
         # single instance

--- a/python/minisgl/scheduler/decode.py
+++ b/python/minisgl/scheduler/decode.py
@@ -1,15 +1,99 @@
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
-from typing import Iterable, Set
+from typing import TYPE_CHECKING, Iterable, Set
 
 from minisgl.core import Batch, Req
+from minisgl.env import ENV
+from minisgl.utils import alloc_delta
+
+if TYPE_CHECKING:
+    from .cache import CacheManager
+    from .prefill import PrefillManager
+    from .table import TableManager
+
+
+@dataclass
+class _EstimatePolicy:
+    page_size: int
+    init_new_token_ratio: float = field(init=False)
+    min_new_token_ratio: float = field(init=False)
+    new_token_ratio_decay: float = field(init=False)
+    new_token_ratio: float = field(init=False)
+    clip_max_new_tokens: int = field(init=False)
+    retract_decode_steps: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.init_new_token_ratio = min(
+            ENV.INIT_NEW_TOKEN_RATIO.value * ENV.SCHEDULE_CONSERVATIVENESS.value, 1.0
+        )
+        self.min_new_token_ratio = min(
+            self.init_new_token_ratio * ENV.MIN_NEW_TOKEN_RATIO_FACTOR.value, 1.0
+        )
+        self.new_token_ratio_decay = (
+            self.init_new_token_ratio - self.min_new_token_ratio
+        ) / ENV.NEW_TOKEN_RATIO_DECAY_STEPS.value
+        self.new_token_ratio = self.init_new_token_ratio
+        self.clip_max_new_tokens = ENV.CLIP_MAX_NEW_TOKENS.value
+        self.retract_decode_steps = ENV.RETRACT_DECODE_STEPS.value
+
+    def reset(self) -> None:
+        self.new_token_ratio = self.init_new_token_ratio
+
+    def estimated_inflight_tokens(self, reqs: Iterable[Req]) -> int:
+        reserved_size = 0
+        for req in reqs:
+            if req.sampling_params.ignore_eos:
+                tail_est = req.remain_len
+            else:
+                tail_est = math.ceil(
+                    min(req.remain_len, self.clip_max_new_tokens) * self.new_token_ratio
+                )
+            reserved_size += alloc_delta(
+                req.cached_len, req.extend_len + tail_est, self.page_size
+            )
+        return reserved_size
+
+    def on_decode_success(self) -> None:
+        self.new_token_ratio = max(
+            self.min_new_token_ratio,
+            self.new_token_ratio - self.new_token_ratio_decay,
+        )
+
+    def on_retract(self, reqs: Iterable[Req]) -> None:
+        reqs = list(reqs)
+        decoded_tokens = sum(len(req.input_ids) - req.prompt_len for req in reqs)
+        total_tokens = sum(req.max_device_len - req.prompt_len for req in reqs)
+        self.new_token_ratio = min(
+            1.0,
+            (decoded_tokens + self.retract_decode_steps * len(reqs)) / total_tokens,
+        )
 
 
 @dataclass
 class DecodeManager:
+    EstimatePolicy = _EstimatePolicy
+
     page_size: int
+    cache_manager: CacheManager
+    table_manager: TableManager
     running_reqs: Set[Req] = field(default_factory=set)
+    estimate_policy: "DecodeManager.EstimatePolicy" = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.estimate_policy = self.EstimatePolicy(self.page_size)
+
+    def reset_new_token_ratio(self) -> None:
+        self.estimate_policy.reset()
+
+    @property
+    def clip_max_new_tokens(self) -> int:
+        return self.estimate_policy.clip_max_new_tokens
+
+    @property
+    def estimated_inflight_tokens(self) -> int:
+        return self.estimate_policy.estimated_inflight_tokens(self.running_reqs)
 
     def filter_reqs(self, reqs: Iterable[Req]) -> None:
         self.running_reqs = {req for req in self.running_reqs.union(reqs) if req.can_decode}
@@ -24,15 +108,52 @@ class DecodeManager:
                 return req
         return None
 
-    @property
-    def inflight_tokens(self) -> int:
-        tokens_reserved = (self.page_size - 1) * len(self.running_reqs)  # 1 page reserved
-        return sum(req.remain_len for req in self.running_reqs) + tokens_reserved
+    def _check_decode_mem(self, available_size: int, steps: int = 1) -> bool:
+        need = sum(
+            alloc_delta(
+                req.cached_len,
+                min(req.remain_len + req.extend_len, steps),
+                self.page_size,
+            )
+            for req in self.running_reqs
+        )
+        return need <= available_size
 
-    def schedule_next_batch(self) -> Batch | None:
+    def schedule_next_batch(
+        self,
+        prefill_manager: PrefillManager,
+    ) -> Batch | None:
         if not self.runnable:
             return None
-        return Batch(reqs=list(self.running_reqs), phase="decode")
+        if self._check_decode_mem(self.cache_manager.available_size):
+            self.estimate_policy.on_decode_success()
+            return Batch(reqs=list(self.running_reqs), phase="decode")
+
+        retracted_reqs = []
+        while not self._check_decode_mem(
+            self.cache_manager.available_size,
+            steps=self.estimate_policy.retract_decode_steps,
+        ):
+            if len(self.running_reqs) == 1:
+                req = next(iter(self.running_reqs))
+                raise RuntimeError(
+                    f"Decode OOM ! retract_decode_steps={self.estimate_policy.retract_decode_steps}, "
+                    f"cached_len={req.cached_len}"
+                )
+            req = min(
+                self.running_reqs,
+                key=lambda req: (len(req.input_ids) - req.prompt_len, -req.prompt_len, req.uid),
+            )
+            self.running_reqs.remove(req)
+            req.is_retracted = True
+            self.table_manager.free(req.table_idx)
+            self.cache_manager.cache_req(req, finished=True)
+            retracted_reqs.append(req)
+        prefill_manager.requeue_reqs(retracted_reqs)
+
+        batch = Batch(reqs=list(self.running_reqs), phase="decode")
+        self.estimate_policy.on_retract(batch.reqs)
+        return batch
 
     @property
     def runnable(self) -> bool:

--- a/python/minisgl/scheduler/prefill.py
+++ b/python/minisgl/scheduler/prefill.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, List, Tuple
 
 import torch
 from minisgl.core import Batch, Req
-from minisgl.utils import init_logger
+from minisgl.utils import alloc_delta, init_logger
 
 from .utils import PendingReq
 
@@ -33,24 +33,41 @@ class ChunkedReq(Req):
 class PrefillAdder:
     token_budget: int
     reserved_size: int
+    clip_max_new_tokens: int
     cache_manager: CacheManager
     table_manager: TableManager
 
-    def _try_allocate_one(self, req: PendingReq) -> Tuple[BaseCacheHandle, int] | None:
+    def _get_required_size(self, req: PendingReq, cached_len: int, chunk_size: int) -> int:
+        if cached_len + chunk_size < req.input_len:
+            added_len = chunk_size
+        elif req.sampling_params.ignore_eos:
+            added_len = chunk_size + req.output_len
+        else:
+            added_len = chunk_size + min(req.output_len, self.clip_max_new_tokens)
+        return alloc_delta(cached_len, added_len, self.cache_manager.page_size)
+
+    def _can_add_one(self, req: PendingReq, cached_len: int) -> int | None:
+        chunk_size = min(self.token_budget, req.input_len - cached_len)
+        required_size = self._get_required_size(req, cached_len, chunk_size)
+        return (
+            None
+            if required_size + self.reserved_size > self.cache_manager.available_size
+            else required_size
+        )
+
+    def _try_allocate_one(self, req: PendingReq) -> Tuple[BaseCacheHandle, int, int] | None:
         if self.table_manager.available_size == 0:
             return None
 
         # TODO: consider host cache match case
         handle = self.cache_manager.match_req(req).cuda_handle
         cached_len = handle.cached_len
-        # TODO: better estimate policy
-        extend_len = req.input_len - cached_len
-        estimated_len = extend_len + req.output_len
-
-        if estimated_len + self.reserved_size > self.cache_manager.available_size:
+        required_size = self._can_add_one(req, cached_len)
+        if required_size is None:
             return None
         self.cache_manager.lock(handle)
-        if estimated_len + self.reserved_size > self.cache_manager.available_size:
+        required_size = self._can_add_one(req, cached_len)
+        if required_size is None:
             return self.cache_manager.unlock(handle)
 
         table_idx = self.table_manager.allocate()
@@ -60,7 +77,7 @@ class PrefillAdder:
             device_ids.copy_(req.input_ids[:cached_len].pin_memory(), non_blocking=True)
             page_entry.copy_(handle.get_matched_indices())
 
-        return handle, table_idx
+        return handle, table_idx, required_size
 
     def _add_one_req(
         self,
@@ -68,19 +85,21 @@ class PrefillAdder:
         cache_handle: BaseCacheHandle,
         table_idx: int,
         cached_len: int,
+        required_size: int,
     ) -> Req:
         remain_len = pending_req.input_len - cached_len
         chunk_size = min(self.token_budget, remain_len)
         is_chunked = chunk_size < remain_len
         CLS = ChunkedReq if is_chunked else Req
         self.token_budget -= chunk_size
-        self.reserved_size += remain_len + pending_req.output_len
+        self.reserved_size += required_size
         # NOTE: update the tokens ids only; new pages will be allocated in the scheduler
         _slice = slice(cached_len, cached_len + chunk_size)
         device_ids = self.table_manager.token_pool[table_idx, _slice]
         device_ids.copy_(pending_req.input_ids[_slice].pin_memory(), non_blocking=True)
         return CLS(
             input_ids=pending_req.input_ids[: cached_len + chunk_size],
+            prompt_len=pending_req.prompt_len,
             table_idx=table_idx,
             cached_len=cached_len,
             output_len=pending_req.output_len,
@@ -94,20 +113,25 @@ class PrefillAdder:
             return None
 
         if chunked_req := pending_req.chunked_req:
+            required_size = self._can_add_one(pending_req, chunked_req.cached_len)
+            if required_size is None:
+                return None
             return self._add_one_req(
                 pending_req=pending_req,
                 cache_handle=chunked_req.cache_handle,
                 table_idx=chunked_req.table_idx,
                 cached_len=chunked_req.cached_len,
+                required_size=required_size,
             )
 
         if resource := self._try_allocate_one(pending_req):
-            cache_handle, table_idx = resource
+            cache_handle, table_idx, required_size = resource
             return self._add_one_req(
                 pending_req=pending_req,
                 cache_handle=cache_handle,
                 table_idx=table_idx,
                 cached_len=cache_handle.cached_len,
+                required_size=required_size,
             )
 
         return None
@@ -121,16 +145,26 @@ class PrefillManager:
     pending_list: List[PendingReq] = field(default_factory=list)
 
     def add_one_req(self, req: UserMsg) -> None:
-        self.pending_list.append(PendingReq(req.uid, req.input_ids, req.sampling_params))
+        self.pending_list.append(
+            PendingReq(
+                uid=req.uid,
+                input_ids=req.input_ids,
+                sampling_params=req.sampling_params,
+                prompt_len=len(req.input_ids),
+            )
+        )
 
-    def schedule_next_batch(self, prefill_budget: int) -> Batch | None:
+    def schedule_next_batch(
+        self,
+        prefill_budget: int,
+    ) -> Batch | None:
         if len(self.pending_list) == 0:
             return None
 
-        # estimated offset due to in-flight decode
         adder = PrefillAdder(
             token_budget=prefill_budget,
-            reserved_size=self.decode_manager.inflight_tokens,
+            reserved_size=self.decode_manager.estimated_inflight_tokens,
+            clip_max_new_tokens=self.decode_manager.clip_max_new_tokens,
             cache_manager=self.cache_manager,
             table_manager=self.table_manager,
         )
@@ -156,6 +190,27 @@ class PrefillManager:
                 self.pending_list.pop(i)
                 return req.chunked_req
         return None
+
+    def requeue_reqs(self, reqs: List[Req]) -> None:
+        if not reqs:
+            return
+        idx = next(
+            (i for i, pending in enumerate(self.pending_list) if pending.chunked_req is None),
+            len(self.pending_list),
+        )
+        self.pending_list[idx:idx] = [
+            PendingReq(
+                uid=req.uid,
+                # NOTE: overlap may have one delayed token not appended on host yet.
+                input_ids=req.input_ids,
+                sampling_params=replace(
+                    req.sampling_params,
+                    max_tokens=req.max_device_len - len(req.input_ids),
+                ),
+                prompt_len=req.prompt_len,
+            )
+            for req in reqs
+        ]
 
     @property
     def runnable(self) -> bool:

--- a/python/minisgl/scheduler/scheduler.py
+++ b/python/minisgl/scheduler/scheduler.py
@@ -59,7 +59,11 @@ class Scheduler(SchedulerIOMixin):
         self.cache_manager = CacheManager(
             self.engine.num_pages, config.page_size, self.engine.page_table, config.cache_type
         )
-        self.decode_manager = DecodeManager(config.page_size)
+        self.decode_manager = DecodeManager(
+            config.page_size,
+            self.cache_manager,
+            self.table_manager,
+        )
         self.prefill_manager = PrefillManager(
             self.cache_manager, self.table_manager, self.decode_manager
         )
@@ -79,6 +83,7 @@ class Scheduler(SchedulerIOMixin):
         """Called when the scheduler is idle to perform background tasks."""
         logger.info_rank0("Scheduler is idle, waiting for new reqs...")
         self.cache_manager.check_integrity()
+        self.decode_manager.reset_new_token_ratio()
 
     def overlap_loop(self, last_data: ForwardData | None) -> ForwardData | None:
         """
@@ -145,6 +150,8 @@ class Scheduler(SchedulerIOMixin):
         new_finished_reqs: Set[Req] = set()
         with self.cache_manager.lazy_free_region():
             for i, req in enumerate(batch.reqs):
+                if req.is_retracted:
+                    continue
                 if isinstance(req, ChunkedReq):
                     continue
                 next_token = next_tokens_cpu[i]
@@ -218,10 +225,9 @@ class Scheduler(SchedulerIOMixin):
 
     def _schedule_next_batch(self) -> ForwardInput | None:
         # TODO: support other policies: e.g. DECODE first
-        batch = (
-            self.prefill_manager.schedule_next_batch(self.prefill_budget)
-            or self.decode_manager.schedule_next_batch()
-        )
+        batch = self.prefill_manager.schedule_next_batch(
+            self.prefill_budget
+        ) or self.decode_manager.schedule_next_batch(self.prefill_manager)
         return self._prepare_batch(batch) if batch else None
 
     def _forward(self, forward_input: ForwardInput) -> ForwardOutput:

--- a/python/minisgl/scheduler/utils.py
+++ b/python/minisgl/scheduler/utils.py
@@ -16,6 +16,7 @@ class PendingReq:
     uid: int
     input_ids: torch.Tensor
     sampling_params: SamplingParams
+    prompt_len: int
     chunked_req: ChunkedReq | None = None
 
     @property

--- a/python/minisgl/utils/__init__.py
+++ b/python/minisgl/utils/__init__.py
@@ -1,7 +1,16 @@
 from .arch import is_arch_supported, is_sm90_supported, is_sm100_supported
 from .hf import cached_load_hf_config, download_hf_weight, load_tokenizer
 from .logger import init_logger
-from .misc import UNSET, Unset, align_ceil, align_down, call_if_main, div_ceil, div_even
+from .misc import (
+    UNSET,
+    Unset,
+    align_ceil,
+    align_down,
+    call_if_main,
+    div_ceil,
+    div_even,
+    alloc_delta,
+)
 from .mp import (
     ZmqAsyncPullQueue,
     ZmqAsyncPushQueue,
@@ -26,6 +35,7 @@ __all__ = [
     "div_ceil",
     "align_ceil",
     "align_down",
+    "alloc_delta",
     "UNSET",
     "Unset",
     "torch_dtype",

--- a/python/minisgl/utils/misc.py
+++ b/python/minisgl/utils/misc.py
@@ -41,6 +41,11 @@ def align_down(a: int, b: int) -> int:
     return (a // b) * b
 
 
+def alloc_delta(base_len: int, add_len: int, page_size: int) -> int:
+    """Returns the additional page-aligned allocation need."""
+    return align_ceil(base_len + add_len, page_size) - align_ceil(base_len, page_size)
+
+
 class Unset:
     pass
 


### PR DESCRIPTION
### Motivation

1. Current prefill admission relies on rough token-level estimates instead of actual page-based KV allocation.
2. That estimate is too conservative under real workloads, which wastes KV cache space, increases queueing, and hurts TTFT, as demonstrated by PR (<https://github.com/sgl-project/mini-sglang/pull/81>).
3. We want admission to be closer to real memory usage while still keeping decode safe when the estimate is temporarily too optimistic.

### Description

This PR ports a better estimation policy from SGLang and integrates it into Mini-SGLang's scheduler.

Core scheduler changes:

- Make prefill admission page-aware instead of reserving memory with rough token counts.
- Introduce a dynamic estimate policy centered around `new_token_ratio`.
- Add decode-side memory checks before scheduling decode batches.
- Retract decode requests when necessary and requeue them as fresh pending prefill work.
- Make overlap scheduling retraction-safe by skipping retracted requests in delayed result processing.
- Reset the estimate state when the scheduler becomes idle.

Tuning knobs added in this PR:

- `MINISGL_SCHEDULE_CONSERVATIVENESS`
- `MINISGL_INIT_NEW_TOKEN_RATIO`
- `MINISGL_MIN_NEW_TOKEN_RATIO_FACTOR`
- `MINISGL_NEW_TOKEN_RATIO_DECAY_STEPS`
- `MINISGL_CLIP_MAX_NEW_TOKENS`
- `MINISGL_RETRACT_DECODE_STEPS`

Benchmark tooling changes:

- Add shared WildChat prompt utilities for both online and offline benchmarks.
- Extend `bench_qwen.py` / benchmark client to support `dummy`, `random`, and `real` prompt modes.
- Add benchmark plumbing for `ignore_eos`, which makes online replay more realistic for the real-prompt setup used here.

### Benchmark Result

Benchmark setup:

- Hardware: 1x NVIDIA GeForce RTX 4090
- Driver / CUDA: 550.127.05 / 12.4
- Model: `Qwen/Qwen3-0.6B`
- Online replay: `python benchmark/online/bench_qwen.py --prompt-mode real --max-new-tokens 4096`
- Offline replay: `python benchmark/offline/bench_wildchat.py`

#### Online Qwen Trace Replay

<img width="1183" height="387" alt="image" src="https://github.com/user-attachments/assets/76c2e85f-4547-4e16-8942-f6231cc33959" />

<img width="1654" height="852" alt="image" src="https://github.com/user-attachments/assets/612d950e-1c15-454e-8145-3f67e8a7a6ba" />

Comments:

- At `0.4` and `1.0`, the new policy substantially reduces queue pressure and improves TTFT, E2E, total duration, and throughput.
- TPOT is worse at `0.4` and `1.0`, which is expected. This policy intentionally spends more decode headroom to make prefill admission less conservative and reduce queueing under pressure.
- At `1.6`, the system is already close to steady-state saturation. Throughput and duration are effectively flat, TTFT still improves sharply, while E2E and TPOT are roughly neutral to slightly worse.
- Overall, this tradeoff is worthwhile: the policy meaningfully improves admission efficiency, queue pressure, TTFT, and throughput under realistic load, while the TPOT regression remains an expected and acceptable cost of less conservative scheduling.

#### Offline WildChat Replay

<img width="948" height="155" alt="image" src="https://github.com/user-attachments/assets/dca7dbf7-8682-42ad-af08-cc35e115d8d3" />

Comments:

- On the offline WildChat replay, the feature improves throughput by `15.71%` and reduces total runtime by `11.35%`.

### Checklist

- [x] Basic feature w/o overlap schedule.
- [x] Adaptation for overlap schedule.
- [x] Online benchmark w/ wildchat real-world prompt.
- [x] Format code with pre-commit.
- [x] Pass all unit tests.
- [x] Provide speed benchmark results.
- [x] Follow the minisgl code style.