### PR TITLE
[Fix]Pad the last rank if vocab size is not divisible by tp_size

### DIFF
--- a/python/minisgl/layers/embedding.py
+++ b/python/minisgl/layers/embedding.py
@@ -105,6 +105,6 @@ class ParallelLMHead(VocabParallelEmbedding):
             return output_tensor.view(1, -1)[:, : self.num_embeddings]
 
         output_tensor = output_tensor.view((self.tp_size,) + input_shape)
-        output_tensor = output_tensor.movedim(0, -1)
+        output_tensor = output_tensor.permute(1, 0, 2).contiguous()
         output_tensor = output_tensor.reshape(input_shape[:1] + (self.tp_size * input_shape[1],))
         return output_tensor[:, : self.num_embeddings]

--- a/python/minisgl/models/weight.py
+++ b/python/minisgl/models/weight.py
@@ -36,7 +36,12 @@ def _shard_state_dict(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Te
             num_embeddings_per_partition = div_ceil(num_embeddings, n)
             vocab_start_idx = r * num_embeddings_per_partition
             vocab_end_idx = min((r + 1) * num_embeddings_per_partition, num_embeddings)
-            shard_state_dict[key] = value[vocab_start_idx:vocab_end_idx, :]
+            shard = value[vocab_start_idx:vocab_end_idx, :]
+            # Pad the last rank if vocab size is not divisible by tp_size
+            pad_rows = num_embeddings_per_partition - shard.shape[0]
+            if pad_rows > 0:
+                shard = torch.nn.functional.pad(shard, (0, 0, 0, pad_rows))
+            shard_state_dict[key] = shard
         else:
             shard_state_dict[key] = value
     return shard_state_dict

--- a/python/minisgl/models/weight.py
+++ b/python/minisgl/models/weight.py
@@ -47,7 +47,12 @@ def _shard_tensor(key: str, value: torch.Tensor, r: int, n: int, num_kv_heads: i
         num_embeddings_per_partition = div_ceil(num_embeddings, n)
         vocab_start_idx = r * num_embeddings_per_partition
         vocab_end_idx = min((r + 1) * num_embeddings_per_partition, num_embeddings)
-        return value[vocab_start_idx:vocab_end_idx, :].clone()
+        shard = value[vocab_start_idx:vocab_end_idx, :].clone()
+        # Pad the last rank if vocab size is not divisible by tp_size
+        pad_rows = num_embeddings_per_partition - shard.shape[0]
+        if pad_rows > 0:
+            shard = torch.nn.functional.pad(shard, (0, 0, 0, pad_rows))
+        return shard
     else:
         return value
 


### PR DESCRIPTION
Pad vocabulary size to a multiple of TP size to ensure shape alignment and avoid assertion errors when assigning self.weight on each TP rank.