### PR TITLE
[Feture]Support for Qwen3 with TP=8 and optimized weight streaming speed

### DIFF
--- a/python/minisgl/attention/fi.py
+++ b/python/minisgl/attention/fi.py
@@ -109,7 +109,7 @@ class FlashInferBackend(BaseAttnBackend):
         # initialize some data members
         tp_size = get_tp_info().size
         self.qo_head_local = div_even(self.config.num_qo_heads, tp_size)
-        self.kv_head_local = div_even(self.config.num_kv_heads, tp_size)
+        self.kv_head_local = div_even(self.config.num_kv_heads, tp_size, allow_replicate=True)
 
         self.cached_ones_cpu: torch.Tensor = torch.tensor([], dtype=torch.int32, pin_memory=True)
         # for cuda graph

--- a/python/minisgl/engine/engine.py
+++ b/python/minisgl/engine/engine.py
@@ -143,14 +143,19 @@ class Engine:
                 for k, v in self.model.state_dict().items()
             }
         else:
-            return {k: v.to(self.dtype) for k, v in load_weight(config.model_path, self.device)}
+            return {
+                k: v.to(self.dtype)
+                for k, v in load_weight(
+                    config.model_path, self.device, num_kv_heads=config.model_config.num_kv_heads
+                )
+            }
 
     def _determine_num_pages(self, old_free_memory: int, config: EngineConfig) -> int:
         new_free_memory = self._sync_get_memory()[1]
         cache_per_page = (
             2  # key + value
             * config.model_config.head_dim
-            * div_even(config.model_config.num_kv_heads, config.tp_info.size)
+            * div_even(config.model_config.num_kv_heads, config.tp_info.size, allow_replicate=True)
             * config.page_size
             * self.dtype.itemsize
             * config.model_config.num_layers

--- a/python/minisgl/kvcache/mha_pool.py
+++ b/python/minisgl/kvcache/mha_pool.py
@@ -24,7 +24,7 @@ class MHAKVCache(BaseKVCachePool):
         device: torch.device,
     ) -> None:
         tp_info = get_tp_info()
-        local_kv_heads = div_even(num_kv_heads, tp_info.size)
+        local_kv_heads = div_even(num_kv_heads, tp_info.size, allow_replicate=True)
         self._kv_buffer = torch.empty(
             (2, num_layers, num_pages, page_size, local_kv_heads, head_dim),
             device=device,

--- a/python/minisgl/layers/attention.py
+++ b/python/minisgl/layers/attention.py
@@ -31,7 +31,7 @@ class AttentionLayer(StateLessOP):
         self.head_dim = head_dim
         tp_size = get_tp_info().size
         self.num_qo_heads = div_even(num_qo_heads, tp_size)
-        self.num_kv_heads = div_even(num_kv_heads, tp_size)
+        self.num_kv_heads = div_even(num_kv_heads, tp_size, allow_replicate=True)
         self.qo_attn_dim = self.num_qo_heads * head_dim
         self.kv_attn_dim = self.num_kv_heads * head_dim
         self.rotary = get_rope(

--- a/python/minisgl/layers/linear.py
+++ b/python/minisgl/layers/linear.py
@@ -79,12 +79,12 @@ class LinearQKVMerged(_LinearTPImpl):
     ):
         tp_info = get_tp_info()
 
-        GQA_ratio = div_even(num_qo_heads, num_kv_heads)
-        local_num_kv = div_even(num_kv_heads, tp_info.size)
+        local_num_qo = div_even(num_qo_heads, tp_info.size)
+        local_num_kv = div_even(num_kv_heads, tp_info.size, allow_replicate=True)
         full_isize = hidden_size
-        full_osize = (GQA_ratio + 2) * num_kv_heads * head_dim
+        full_osize = (num_qo_heads + 2 * num_kv_heads) * head_dim
         local_isize = hidden_size
-        local_osize = (GQA_ratio + 2) * local_num_kv * head_dim
+        local_osize = (local_num_qo + 2 * local_num_kv) * head_dim
         super().__init__(full_isize, full_osize, local_isize, local_osize, has_bias)
 
 

--- a/python/minisgl/models/weight.py
+++ b/python/minisgl/models/weight.py
@@ -82,11 +82,7 @@ def load_weight(
         with safetensors.safe_open(file, framework="pt", device=load_device) as f:
             for name in f.keys():
                 raw = f.get_tensor(name)
-                tensor = (
-                    _shard_tensor(name, raw, r, n, num_kv_heads=num_kv_heads)
-                    if tp
-                    else raw
-                )
+                tensor = (_shard_tensor(name, raw, r, n, num_kv_heads=num_kv_heads))
                 del raw
 
                 info = _get_merge_info(name)

--- a/python/minisgl/models/weight.py
+++ b/python/minisgl/models/weight.py
@@ -29,9 +29,16 @@ _SLOT_NAMES = {
 }
 
 
-def _shard_tensor(key: str, value: torch.Tensor, r: int, n: int) -> torch.Tensor:
+def _shard_tensor(
+    key: str, value: torch.Tensor, r: int, n: int, num_kv_heads: int | None = None
+) -> torch.Tensor:
     """Extract rank r's shard from a single tensor. Returns a contiguous copy."""
     if any(key.count(sub) for sub in _SPLIT_DIM_0):
+        is_kv_proj = any(key.count(sub) for sub in (".k_proj", ".v_proj"))
+        if is_kv_proj and num_kv_heads is not None and num_kv_heads < n:
+            head_dim = value.shape[0] // num_kv_heads
+            head_idx = r * num_kv_heads // n
+            return value[head_idx * head_dim : (head_idx + 1) * head_dim].clone()
         return value.chunk(n, dim=0)[r].clone()
     elif any(key.count(sub) for sub in _SPLIT_DIM_1):
         return value.chunk(n, dim=1)[r].clone()
@@ -53,7 +60,9 @@ def _get_merge_info(key: str):
     return None
 
 
-def load_weight(model_path: str, device: torch.device) -> Iterator[Tuple[str, torch.Tensor]]:
+def load_weight(
+    model_path: str, device: torch.device, num_kv_heads: int | None = None
+) -> Iterator[Tuple[str, torch.Tensor]]:
     """Streaming weight loader. Yields (name, tensor) pairs already sharded, merged,
     and on device. Peak CPU memory: one full tensor + a small merge buffer."""
     model_folder = download_hf_weight(model_path)
@@ -69,11 +78,15 @@ def load_weight(model_path: str, device: torch.device) -> Iterator[Tuple[str, to
     merge_buf: Dict[str, Dict[str, torch.Tensor]] = {}
 
     for file in tqdm(files, desc="Loading weights", disable=disable_tqdm):
-        load_device = "cpu" if tp else device_str
+        load_device = device_str
         with safetensors.safe_open(file, framework="pt", device=load_device) as f:
             for name in f.keys():
                 raw = f.get_tensor(name)
-                tensor = _shard_tensor(name, raw, r, n).to(device) if tp else raw
+                tensor = (
+                    _shard_tensor(name, raw, r, n, num_kv_heads=num_kv_heads)
+                    if tp
+                    else raw
+                )
                 del raw
 
                 info = _get_merge_info(name)

--- a/python/minisgl/utils/misc.py
+++ b/python/minisgl/utils/misc.py
@@ -17,8 +17,11 @@ def call_if_main(name: str = "__main__", discard: bool | None = None):
             return lambda f: (f() and None) or f
 
 
-def div_even(a: int, b: int) -> int:
-    """Divides two integers"""
+def div_even(a: int, b: int, allow_replicate: bool = False) -> int:
+    """Divides two integers. If allow_replicate=True, allows b > a when b % a == 0, returning 1."""
+    if allow_replicate and b > a:
+        assert b % a == 0, f"{b = } must be divisible by {a = } for KV head replication"
+        return 1
     assert a % b == 0, f"{a = } must be divisible by {b = }"
     return a // b
 


### PR DESCRIPTION
Since the Qwen MoE model has num_key_value_heads set to 4, using tp=8 triggers the error AssertionError: a = 4 must be divisible by b = 8, as shown in the screenshot below. To resolve this, we should implement KV head duplication.
<img width="1614" height="1022" alt="d81ed43a3c098db9465d867f05a694c8" src="https://github.com/user-attachments/assets/27c52cf8-5e2a-49c7-b818-f2c7ff510935" />
Specifically, for the Qwen3-30B-A3B configuration (num_attention_heads=16, num_kv_heads=4) at tp=8:

Q heads: The 16 heads are split normally, with each rank receiving 16/8=2 heads.
KV heads: Since 4 heads cannot be evenly split across 8 ranks, we duplicate them so that every 2 ranks share the same set of KV heads.
This duplication approach fixes the issue, as demonstrated in the result below.
<img width="1848" height="1246" alt="image" src="https://github.com/user-attachments/assets/0507d09e-da9c-4a58-9b03-31fb07d15f13" />

Furthermore, the weight streaming speed has been optimized. Previously, weight shards were loaded into CPU memory before being transferred to the GPU, creating an IO bottleneck due to the double data movement. With the old implementation, loading Qwen3-moe-30b at TP=8 took nearly 10 minutes, which was unacceptable

<img width="1264" height="930" alt="image" src="https://github.com/user-attachments/assets/e14efcfd-cb68-4c2f-b164-8f723159b4c5" />



With my optimizations, weights are now streamed to the GPU in chunks. This approach ensures high loading speeds while preventing (OOM). As shown in the figure below, I have successfully loaded the Qwen3-235B model using mini-sgl. The loading speed is significantly improved on an 8x H800 node.
<img width="1246" height="1038" alt="image" src="https://github.com/user-attachments/assets/570ce8a6-1c06-4998-9500-64997f9a93a5" />

<img width="1258" height="642" alt="6e2f34be94cef4a03fd90257bd9f5c03" src="https://github.com/user-attachments/assets/ebd676c7-20de-47da-9e04-0afa241593ba" />
<img width="1530" height="1710" alt="1a275b21f9093aa666689b27b586c6b7" src="https://github.com/user-attachments/assets/b0661ef2-dd63-4e3d-a2a8-03e999ec1ade" />
