### PR TITLE
[Fix] Fix race condition in flashinfer backend

### DIFF
--- a/python/minisgl/attention/fi.py
+++ b/python/minisgl/attention/fi.py
@@ -117,15 +117,19 @@ class FlashInferBackend(BaseAttnBackend):
         self.max_graph_bs = 0
         self.graph_wrappers: Dict[int, CUDAGraphBatchDecodeWithPagedKVCacheWrapper] = {}
         self.capture: FICaptureData | None = None
+        self.last_event = torch.cuda.Event()
+        self.last_event.record()
 
-    @staticmethod
-    def _initialize_metadata_once(metadata: FIMetadata) -> None:
+    def _initialize_metadata_once(self, metadata: FIMetadata) -> None:
         if metadata.initialized:
             return
 
         from flashinfer import BatchDecodeWithPagedKVCacheWrapper
 
         metadata.initialized = True
+        # FlashInfer planning reuses a pinned host staging buffer and launches an
+        # async H2D copy. Wait here before the next plan mutates that host buffer.
+        self.last_event.synchronize()
         if isinstance(metadata.wrapper, BatchDecodeWithPagedKVCacheWrapper):
             metadata.wrapper.plan(
                 indptr=metadata.cu_seqlens_k_cpu,
@@ -159,6 +163,7 @@ class FlashInferBackend(BaseAttnBackend):
                 non_blocking=True,
                 causal=True,
             )
+        self.last_event.record()
 
     def _get_ones_cpu(self, bs: int) -> torch.Tensor:
         if bs <= len(self.cached_ones_cpu):

--- a/python/minisgl/env.py
+++ b/python/minisgl/env.py
@@ -67,7 +67,6 @@ class EnvClassSingleton:
     # backend runtime
     FLASHINFER_USE_TENSOR_CORES = EnvOption()
     DISABLE_OVERLAP_SCHEDULING = EnvBool(False)
-    OVERLAP_EXTRA_SYNC = EnvBool(False)
     PYNCCL_MAX_BUFFER_SIZE = EnvMem(1024**3)
 
     def __new__(cls):

--- a/python/minisgl/scheduler/scheduler.py
+++ b/python/minisgl/scheduler/scheduler.py
@@ -227,8 +227,6 @@ class Scheduler(SchedulerIOMixin):
     def _forward(self, forward_input: ForwardInput) -> ForwardOutput:
         batch, sample_args, input_mapping, output_mapping = forward_input
         batch.input_ids = self.token_pool[input_mapping]
-        if ENV.OVERLAP_EXTRA_SYNC:  # NOTE: https://github.com/sgl-project/mini-sglang/issues/58
-            self.stream.synchronize()
         forward_output = self.engine.forward_batch(batch, sample_args)
         self.token_pool[output_mapping] = forward_output.next_tokens_gpu
         self.decode_manager.filter_reqs(forward_input.batch.reqs)


### PR DESCRIPTION
Sorry for all the mess in the past few months. This PR might fix the bug reported by #89, #102, #58 and #67 

I've read through the codebase of flashinfer fa2/fa3 attention kernel planning functions here https://github.com/flashinfer-ai/flashinfer/blob/f07faf964a4d4aecba92254161a4d4ae3079cf4c/include/flashinfer/attention/scheduler.cuh#L426-L492.

In plan function, it will

1. Copy some metadata on CPU to internal pin memory buffer.
2. Call `cudaMemcpyAsync` to transfer from internal pin memory buffer to internal device buffer.

When two plan functions are called sequentially, there might be a bug like this:

1. First `plan` is called, internal pin memory buffer modified, and `cudaMemcpyAsync` is launched (kernel launch is asynchronous, so it has not finished)
2. Second `plan` is called, internal pin memory buffer modified, but the last `cudaMemcpyAsync` has not finished.

In this case, the internal pin memory buffer is dirty and that's possibly why we got illegal memory access. This will only happen in overlap-scheduling mode because otherwise, the last batch must be finished before the next batch is prepared.

Apologize again for this mistake because I wasn't aware of the race condition in the underlying implementation. I should be more careful when integrating external kernels next time. Also this bug might also exists in other frameworks which integrates flashinfer attention (only before blackwell, for "fa2" and "fa3" backend), and we will investigate this later.

cc @gbdjxgp @itechbear @gameofdimension @GiggleWang please give this PR a try
