### PR TITLE
[Fix] Support stream=false in /v1/chat/completions (#51)

### DIFF
--- a/python/minisgl/server/api_server.py
+++ b/python/minisgl/server/api_server.py
@@ -278,10 +278,41 @@ async def v1_completions(req: OpenAICompletionRequest, request: Request):
         )
     )
 
-    return StreamingResponse(
-        state.stream_with_cancellation(state.stream_chat_completions(uid), request, uid),
-        media_type="text/event-stream",
-    )
+    if req.stream:
+        return StreamingResponse(
+            state.stream_with_cancellation(state.stream_chat_completions(uid), request, uid),
+            media_type="text/event-stream",
+        )
+    else:
+        # Non-streaming response: collect all output and return as JSON
+        full_content = ""
+        async for ack in state.wait_for_ack(uid):
+            full_content += ack.incremental_output
+            if ack.finished:
+                break
+
+        response = {
+            "id": f"cmpl-{uid}",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": req.model,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": full_content,
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": -1,  # TODO: track actual token counts
+                "completion_tokens": -1,
+                "total_tokens": -1,
+            },
+        }
+        return response
 
 
 @app.get("/v1/models")


### PR DESCRIPTION
The `stream` parameter in `/v1/chat/completions` request is ignored, causing the endpoint to always return SSE streaming responses. This PR fixes #51 by properly handling `stream=false` to return a complete JSON response.