### PR TITLE
fix(doc): document -1 sentinel in ForwardInput.write_tuple

### DIFF
--- a/python/minisgl/scheduler/scheduler.py
+++ b/python/minisgl/scheduler/scheduler.py
@@ -36,7 +36,7 @@ class ForwardInput(NamedTuple):
     batch: Batch
     sample_args: BatchSamplingArgs
     input_tuple: Indice2D  # (token_mapping, positions)
-    write_tuple: Indice2D  # (req_mapping, seq_lens or 0)
+    write_tuple: Indice2D  # (req_mapping, seq_lens or -1)
 
 
 ForwardData: TypeAlias = "Tuple[ForwardInput, ForwardOutput]"


### PR DESCRIPTION
## Summary

- The inline comment on `ForwardInput.write_tuple` in `scheduler.py` documented the sentinel value as `0`, but `_make_write_tuple` actually uses `-1` for finished requests that cannot decode.

## Reference

`_make_write_tuple` function:

```python
    write_list = [(req.device_len if req.can_decode else -1) for req in batch.reqs]
```