### PR TITLE
Optimize load_weight with per-file batch H2D and zero-copy CPU sharding

### DIFF
--- a/python/minisgl/engine/engine.py
+++ b/python/minisgl/engine/engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from datetime import timedelta
 from typing import Any, Dict, NamedTuple, Tuple
 
@@ -49,7 +50,10 @@ class Engine:
         set_rope_device(self.device)
         with torch.device("meta"), torch_dtype(config.dtype):
             self.model = create_model(config.model_config)
+        t0 = time.perf_counter()
         self.model.load_state_dict(self._load_weight_state_dict(config))
+        load_time = time.perf_counter() - t0
+        logger.info_rank0(f"Model weights loaded in {load_time:.2f}s")
 
         # ======================= KV cache initialization ========================
         self.num_pages = self._determine_num_pages(init_free_memory, config)

--- a/python/minisgl/models/weight.py
+++ b/python/minisgl/models/weight.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 import glob
+import logging
 import re
+import time
 from typing import Dict, Iterator, Tuple
 
 import safetensors
 import torch
 from minisgl.distributed import get_tp_info
-from minisgl.utils import cached_load_hf_config, div_ceil, download_hf_weight
+from minisgl.utils import cached_load_hf_config, div_ceil, download_hf_weight, init_logger
 from tqdm import tqdm
+
+logger = init_logger(__name__)
 
 _SPLIT_DIM_0 = [".q_proj", ".k_proj", ".v_proj", ".gate_proj", ".up_proj"]
 _SPLIT_DIM_1 = [".o_proj", ".down_proj"]
@@ -52,6 +56,28 @@ def _shard_tensor(key: str, value: torch.Tensor, r: int, n: int, num_kv_heads: i
         return value
 
 
+def _shard_tensor_view(key: str, value: torch.Tensor, r: int, n: int, num_kv_heads: int):
+    """Like _shard_tensor but returns zero-copy views. For dim-1 splits, returns
+    .contiguous() since H2D requires contiguous memory. No .clone() on dim-0."""
+    if any(key.count(sub) for sub in _SPLIT_DIM_0):
+        is_kv_proj = any(key.count(sub) for sub in (".k_proj", ".v_proj"))
+        if is_kv_proj and num_kv_heads is not None and num_kv_heads < n:
+            head_dim = value.shape[0] // num_kv_heads
+            head_idx = r * num_kv_heads // n
+            return value[head_idx * head_dim : (head_idx + 1) * head_dim]
+        return value.chunk(n, dim=0)[r]
+    elif any(key.count(sub) for sub in _SPLIT_DIM_1):
+        return value.chunk(n, dim=1)[r].contiguous()
+    elif key.count("lm_head") or key.count("embed_tokens"):
+        num_embeddings = value.shape[0]
+        num_embeddings_per_partition = div_ceil(num_embeddings, n)
+        vocab_start_idx = r * num_embeddings_per_partition
+        vocab_end_idx = min((r + 1) * num_embeddings_per_partition, num_embeddings)
+        return value[vocab_start_idx:vocab_end_idx, :]
+    else:
+        return value
+
+
 def _get_merge_info(key: str):
     """If key belongs to a merge group, return (merged_key, slot, all_slots). Else None."""
     for suffix, (fused_suffix, slots) in _MERGE_GROUPS.items():
@@ -72,53 +98,188 @@ def _get_expert_stack_info(key: str) -> tuple[str, int] | None:
     return f"{match.group('prefix')}.{packed_name}", int(match.group("idx"))
 
 
-def load_weight(model_path: str, device: torch.device) -> Iterator[Tuple[str, torch.Tensor]]:
-    """Streaming weight loader. Yields (name, tensor) pairs already sharded, merged,
-    and on device. Peak CPU memory: one full tensor + a small merge buffer."""
-    from .config import ModelConfig
+class MergeAccumulator:
+    """Accumulates merge groups (QKV, gate_up) and expert stacks.
 
+    Decoupled from the loading loop so merge/stack can happen on GPU tensors
+    after H2D, rather than on CPU mmap tensors (which would trigger page faults).
+    """
+
+    def __init__(self, is_moe: bool = False, num_experts: int = 0):
+        self.is_moe = is_moe
+        self.num_experts = num_experts
+        self._merge_buf: Dict[str, Dict[str, torch.Tensor]] = {}
+        self._expert_buf: Dict[str, Dict[int, torch.Tensor]] = {}
+
+    def process(self, name: str, tensor: torch.Tensor) -> list[tuple[str, torch.Tensor]]:
+        """Feed a (name, tensor) pair. Returns a list of finalized (name, tensor) pairs.
+        Returns [] if the tensor is buffered (waiting for merge/stack partners)."""
+
+        # --- Step 1: merge groups (QKV / gate_up) ---
+        merge_info = _get_merge_info(name)
+        if merge_info is not None:
+            merged_key, slot, all_slots = merge_info
+            self._merge_buf.setdefault(merged_key, {})[slot] = tensor
+            if not all(s in self._merge_buf[merged_key] for s in all_slots):
+                return []
+            parts = [self._merge_buf[merged_key][s] for s in all_slots]
+            del self._merge_buf[merged_key]
+            name, tensor = merged_key, torch.cat(parts, dim=0)
+
+        # --- Step 2: expert stacking ---
+        if self.is_moe:
+            expert_info = _get_expert_stack_info(name)
+            if expert_info is not None:
+                packed_key, expert_idx = expert_info
+                slots = self._expert_buf.setdefault(packed_key, {})
+                slots[expert_idx] = tensor
+                if len(slots) != self.num_experts:
+                    return []
+                experts = [slots[idx] for idx in range(self.num_experts)]
+                del self._expert_buf[packed_key]
+                return [(packed_key, torch.stack(experts, dim=0))]
+
+        return [(name, tensor)]
+
+    def assert_complete(self):
+        """Call after all tensors are processed. Raises if any groups are incomplete."""
+        assert not self._merge_buf, f"Incomplete merge groups: {list(self._merge_buf.keys())}"
+        assert not self._expert_buf, f"Incomplete expert tensors: {list(self._expert_buf.keys())}"
+
+
+def _load_sharded_by_file(
+    model_path: str,
+    tp_rank: int,
+    tp_size: int,
+    num_kv_heads: int,
+) -> Iterator[list[tuple[str, torch.Tensor]]]:
+    """Yield one batch of ``(name, cpu_view)`` per safetensors file.
+
+    Tensors are loaded with ``device="cpu"`` and sharded via zero-copy views
+    (``_shard_tensor_view``).  No merge or expert stacking is done here —
+    that is the caller's responsibility (typically via ``MergeAccumulator``
+    on GPU tensors after H2D).
+
+    .. warning::
+
+        Yielded tensors are **mmap-backed views**.  Each batch is yielded
+        *inside* the ``safe_open`` context manager so the mmap stays alive,
+        but the caller **must** fully consume a batch before advancing the
+        generator to the next file.  Holding references across iterations
+        leads to use-after-unmap.
+    """
     model_folder = download_hf_weight(model_path)
-    config = ModelConfig.from_hf(cached_load_hf_config(model_path))
     files = glob.glob(f"{model_folder}/*.safetensors")
     files = [f for f in files if not f.endswith("consolidated.safetensors")] or files
-    tp_info = get_tp_info()
 
-    # Buffer for merge groups: merged_key -> {slot: tensor}
-    merge_buf: Dict[str, Dict[str, torch.Tensor]] = {}
-    expert_buf: Dict[str, Dict[int, torch.Tensor]] = {}
-    for file in tqdm(files, desc="Loading weights", disable=not tp_info.is_primary()):
-        with safetensors.safe_open(file, framework="pt", device=str(device)) as f:
+    for file in tqdm(files, desc="Loading weights", disable=(tp_rank != 0)):
+        batch: list[tuple[str, torch.Tensor]] = []
+        with safetensors.safe_open(file, framework="pt", device="cpu") as f:
             for name in f.keys():
-                # Strip multimodal wrapper prefix, skip vision/projector weights
                 if name.startswith(("vision_tower.", "multi_modal_projector.")):
                     continue
                 raw = f.get_tensor(name)
                 name = name.removeprefix("language_model.")
-                tensor = _shard_tensor(name, raw, tp_info.rank, tp_info.size, config.num_kv_heads)
-                del raw
+                view = _shard_tensor_view(name, raw, tp_rank, tp_size, num_kv_heads)
+                batch.append((name, view))
+            yield batch  # IMPORTANT: yield INSIDE `with` block to keep mmap alive
 
-                if (info := _get_merge_info(name)) is None:
-                    out = (name, tensor)
-                else:
-                    merged_key, slot, all_slots = info
-                    merge_buf.setdefault(merged_key, {})[slot] = tensor
-                    if not all(s in merge_buf[merged_key] for s in all_slots):
-                        continue
-                    parts = [merge_buf[merged_key][s] for s in all_slots]
-                    del merge_buf[merged_key]
-                    out = (merged_key, torch.cat(parts, dim=0))
 
-                if config.is_moe and (expert_info := _get_expert_stack_info(out[0])) is not None:
-                    packed_key, expert_idx = expert_info
-                    slots = expert_buf.setdefault(packed_key, {})
-                    slots[expert_idx] = out[1]
-                    if len(slots) != config.num_experts:
-                        continue
-                    experts = [slots[idx] for idx in range(config.num_experts)]
-                    del expert_buf[packed_key]
-                    yield packed_key, torch.stack(experts, dim=0)
-                else:  # Normal dense model
-                    yield out[0], out[1]
+def load_weight(model_path: str, device: torch.device) -> Iterator[Tuple[str, torch.Tensor]]:
+    """Streaming weight loader with per-file batch H2D optimization.
 
-    assert not merge_buf, f"Incomplete merge groups in checkpoint: {list(merge_buf.keys())}"
-    assert not expert_buf, f"Incomplete expert tensors in checkpoint: {list(expert_buf.keys())}"
+    Pipeline: CPU zero-copy shard views → per-file flat GPU buffer → batch copy →
+    GPU-side merge/stack → yield (name, tensor).
+
+    Compared to the old per-tensor safetensors H2D path, this reduces cudaMalloc
+    calls from ~N_tensors to ~N_files and avoids CPU page fault storms by keeping
+    shard/merge on GPU.
+    """
+    from .config import ModelConfig
+
+    config = ModelConfig.from_hf(cached_load_hf_config(model_path))
+    tp_info = get_tp_info()
+    accumulator = MergeAccumulator(is_moe=config.is_moe, num_experts=config.num_experts)
+    is_gpu = device.type == "cuda"
+    detailed_timing = logger.isEnabledFor(logging.DEBUG)
+
+    t_total = time.perf_counter()
+    t_alloc = 0.0
+    t_h2d = 0.0
+    t_merge = 0.0
+    num_files = 0
+
+    for cpu_batch in _load_sharded_by_file(
+        model_path, tp_info.rank, tp_info.size, config.num_kv_heads
+    ):
+        if not cpu_batch:
+            continue
+        num_files += 1
+
+        if is_gpu:
+            # --- Per-file flat buffer allocation ---
+            if detailed_timing:
+                t0 = time.perf_counter()
+            total_bytes = 0
+            for _, t in cpu_batch:
+                align = t.element_size()
+                total_bytes = (total_bytes + align - 1) // align * align
+                total_bytes += t.nelement() * t.element_size()
+            flat_buf = torch.empty(total_bytes, dtype=torch.uint8, device=device)
+            if detailed_timing:
+                t_alloc += time.perf_counter() - t0
+
+            # Slice flat_buf into per-tensor views and batch copy
+            if detailed_timing:
+                t0 = time.perf_counter()
+            gpu_tensors = []
+            offset = 0
+            for name, cpu_view in cpu_batch:
+                align = cpu_view.element_size()
+                offset = (offset + align - 1) // align * align
+                nbytes = cpu_view.nelement() * cpu_view.element_size()
+                gpu_flat_view = flat_buf[offset : offset + nbytes]
+                gpu_tensor = gpu_flat_view.view(cpu_view.dtype).reshape(cpu_view.shape)
+                gpu_tensor.copy_(cpu_view)  # H2D copy
+                gpu_tensors.append((name, gpu_tensor))
+                offset += nbytes
+            if detailed_timing:
+                t_h2d += time.perf_counter() - t0
+
+            # GPU-side merge/stack; clone passthrough tensors to cut flat_buf reference.
+            # torch.cat/torch.stack (from MergeAccumulator) allocate new storage,
+            # so only passthrough tensors remain views of flat_buf and need .clone().
+            # We detect this by comparing untyped_storage().data_ptr(): all views
+            # sliced from the same torch.empty() share a single underlying storage
+            # object, so their storage base address is identical.
+            if detailed_timing:
+                t0 = time.perf_counter()
+            for name, gpu_t in gpu_tensors:
+                for final_name, final_t in accumulator.process(name, gpu_t):
+                    if (
+                        final_t.untyped_storage().data_ptr()
+                        == flat_buf.untyped_storage().data_ptr()
+                    ):
+                        final_t = final_t.clone()
+                    yield final_name, final_t
+            if detailed_timing:
+                t_merge += time.perf_counter() - t0
+
+            del flat_buf  # free per-file buffer immediately
+        else:
+            # CPU path (for testing / non-GPU environments)
+            for name, cpu_view in cpu_batch:
+                tensor = cpu_view.to(device)
+                for final_name, final_t in accumulator.process(name, tensor):
+                    yield final_name, final_t
+
+    accumulator.assert_complete()
+    t_total = time.perf_counter() - t_total
+    if is_gpu and tp_info.is_primary():
+        logger.info(f"load_weight: {num_files} files, total={t_total:.2f}s")
+        if detailed_timing:
+            logger.debug(
+                f"load_weight breakdown: alloc={t_alloc:.2f}s, "
+                f"h2d={t_h2d:.2f}s, merge={t_merge:.2f}s, "
+                f"mmap+shard={t_total - t_alloc - t_h2d - t_merge:.2f}s"
+            )

--- a/tests/models/test_weight.py
+++ b/tests/models/test_weight.py
@@ -1,0 +1,290 @@
+# tests/models/test_weight.py
+"""Unit tests for weight loading utilities."""
+import torch
+import pytest
+
+# We'll test the internal functions directly
+from minisgl.models.weight import _shard_tensor, _shard_tensor_view
+from minisgl.models.weight import MergeAccumulator
+from safetensors.torch import save_file
+from minisgl.models.weight import _load_sharded_by_file
+from unittest.mock import patch, MagicMock
+from minisgl.models.weight import load_weight
+import minisgl.distributed.info as di
+
+
+class TestShardTensorView:
+    """Tests for _shard_tensor_view: zero-copy CPU view sharding."""
+
+    def test_dim0_split_returns_view_not_copy(self):
+        """dim-0 shard should be a view (shares storage), not a clone."""
+        t = torch.randn(8, 4)
+        result = _shard_tensor_view(".q_proj.weight", t, r=0, n=2, num_kv_heads=None)
+        assert result.shape == (4, 4)
+        assert result.data_ptr() == t.data_ptr()  # same storage = view
+
+    def test_dim0_split_values_match_shard_tensor(self):
+        """dim-0 view should have the same values as the clone-based _shard_tensor."""
+        t = torch.randn(8, 4)
+        view = _shard_tensor_view(".q_proj.weight", t, r=1, n=2, num_kv_heads=None)
+        clone = _shard_tensor(".q_proj.weight", t, r=1, n=2, num_kv_heads=None)
+        torch.testing.assert_close(view, clone)
+
+    def test_dim1_split_is_contiguous(self):
+        """dim-1 shard must be contiguous (required for H2D copy)."""
+        t = torch.randn(4, 8)
+        result = _shard_tensor_view(".o_proj.weight", t, r=0, n=2, num_kv_heads=None)
+        assert result.shape == (4, 4)
+        assert result.is_contiguous()
+
+    def test_dim1_split_values_match_shard_tensor(self):
+        """dim-1 view should have the same values as the clone-based _shard_tensor."""
+        t = torch.randn(4, 8)
+        view = _shard_tensor_view(".o_proj.weight", t, r=1, n=2, num_kv_heads=None)
+        clone = _shard_tensor(".o_proj.weight", t, r=1, n=2, num_kv_heads=None)
+        torch.testing.assert_close(view, clone)
+
+    def test_kv_proj_with_fewer_heads_than_tp(self):
+        """KV proj with num_kv_heads < tp_size should replicate correctly."""
+        t = torch.randn(128, 64)  # 2 heads * head_dim=64
+        for r in range(4):
+            view = _shard_tensor_view(".k_proj.weight", t, r=r, n=4, num_kv_heads=2)
+            clone = _shard_tensor(".k_proj.weight", t, r=r, n=4, num_kv_heads=2)
+            torch.testing.assert_close(view, clone)
+
+    def test_embedding_shard(self):
+        """Embedding/lm_head shard should return a view."""
+        t = torch.randn(32000, 128)
+        result = _shard_tensor_view("lm_head.weight", t, r=0, n=4, num_kv_heads=None)
+        assert result.shape[0] == 8000
+        assert result.shape[1] == 128
+
+    def test_unsplit_tensor_returns_same_object(self):
+        """Tensors that don't match any split pattern should be returned as-is."""
+        t = torch.randn(4, 4)
+        result = _shard_tensor_view("model.norm.weight", t, r=0, n=2, num_kv_heads=None)
+        assert result is t
+
+
+class TestMergeAccumulator:
+    """Tests for MergeAccumulator: GPU-side merge and expert stacking."""
+
+    def _make_acc(self, is_moe=False, num_experts=0):
+        return MergeAccumulator(is_moe=is_moe, num_experts=num_experts)
+
+    def test_passthrough_normal_tensor(self):
+        """Non-merge, non-expert tensor should pass through immediately."""
+        acc = self._make_acc()
+        t = torch.randn(4, 4)
+        results = acc.process("model.layers.0.input_layernorm.weight", t)
+        assert len(results) == 1
+        assert results[0] == ("model.layers.0.input_layernorm.weight", t)
+
+    def test_qkv_merge(self):
+        """q/k/v tensors should merge into a single qkv_proj via torch.cat."""
+        acc = self._make_acc()
+        q = torch.randn(8, 4)
+        k = torch.randn(4, 4)
+        v = torch.randn(4, 4)
+        r1 = acc.process("model.layers.0.self_attn.q_proj.weight", q)
+        assert r1 == []  # not complete yet
+        r2 = acc.process("model.layers.0.self_attn.k_proj.weight", k)
+        assert r2 == []
+        r3 = acc.process("model.layers.0.self_attn.v_proj.weight", v)
+        assert len(r3) == 1
+        name, merged = r3[0]
+        assert name == "model.layers.0.self_attn.qkv_proj.weight"
+        torch.testing.assert_close(merged, torch.cat([q, k, v], dim=0))
+
+    def test_gate_up_merge(self):
+        """gate/up tensors should merge into gate_up_proj."""
+        acc = self._make_acc()
+        gate = torch.randn(8, 4)
+        up = torch.randn(8, 4)
+        r1 = acc.process("model.layers.0.mlp.gate_proj.weight", gate)
+        assert r1 == []
+        r2 = acc.process("model.layers.0.mlp.up_proj.weight", up)
+        assert len(r2) == 1
+        name, merged = r2[0]
+        assert name == "model.layers.0.mlp.gate_up_proj.weight"
+        torch.testing.assert_close(merged, torch.cat([gate, up], dim=0))
+
+    def test_expert_stack(self):
+        """Expert tensors should be stacked when all experts are collected."""
+        acc = self._make_acc(is_moe=True, num_experts=2)
+        gate0, up0, gate1, up1 = [torch.randn(4, 4) for _ in range(4)]
+        r = acc.process("model.layers.0.experts.0.gate_proj.weight", gate0)
+        assert r == []
+        r = acc.process("model.layers.0.experts.0.up_proj.weight", up0)
+        assert r == []
+        r = acc.process("model.layers.0.experts.1.gate_proj.weight", gate1)
+        assert r == []
+        r = acc.process("model.layers.0.experts.1.up_proj.weight", up1)
+        assert len(r) == 1
+        name, stacked = r[0]
+        assert name == "model.layers.0.experts.gate_up_proj"
+        assert stacked.shape[0] == 2
+        expected = torch.stack(
+            [torch.cat([gate0, up0], dim=0), torch.cat([gate1, up1], dim=0)], dim=0
+        )
+        torch.testing.assert_close(stacked, expected)
+
+    def test_assert_on_incomplete_merge(self):
+        """assert_complete should raise if merge groups are incomplete."""
+        acc = self._make_acc()
+        acc.process("model.layers.0.self_attn.q_proj.weight", torch.randn(4, 4))
+        with pytest.raises(AssertionError, match="Incomplete merge"):
+            acc.assert_complete()
+
+    def test_assert_on_complete(self):
+        """assert_complete should pass when all groups are flushed."""
+        acc = self._make_acc()
+        acc.process("model.layers.0.self_attn.q_proj.weight", torch.randn(4, 4))
+        acc.process("model.layers.0.self_attn.k_proj.weight", torch.randn(4, 4))
+        acc.process("model.layers.0.self_attn.v_proj.weight", torch.randn(4, 4))
+        acc.assert_complete()  # should not raise
+
+
+class TestLoadShardedByFile:
+    """Tests for _load_sharded_by_file: per-file CPU view batching."""
+
+    @pytest.fixture
+    def model_dir(self, tmp_path):
+        """Create a minimal 2-file safetensors model with config."""
+        # File 1: embed + layer 0 attention
+        save_file(
+            {
+                "model.embed_tokens.weight": torch.randn(32, 16),
+                "model.layers.0.self_attn.q_proj.weight": torch.randn(16, 16),
+                "model.layers.0.self_attn.k_proj.weight": torch.randn(8, 16),
+                "model.layers.0.self_attn.v_proj.weight": torch.randn(8, 16),
+            },
+            tmp_path / "model-00001-of-00002.safetensors",
+        )
+        # File 2: layer 0 MLP + norm + lm_head
+        save_file(
+            {
+                "model.layers.0.mlp.gate_proj.weight": torch.randn(32, 16),
+                "model.layers.0.mlp.up_proj.weight": torch.randn(32, 16),
+                "model.layers.0.mlp.down_proj.weight": torch.randn(16, 32),
+                "model.layers.0.input_layernorm.weight": torch.randn(16),
+                "lm_head.weight": torch.randn(32, 16),
+            },
+            tmp_path / "model-00002-of-00002.safetensors",
+        )
+        return tmp_path
+
+    def test_yields_per_file_batches(self, model_dir):
+        """Should yield one batch per safetensors file."""
+        batches = list(_load_sharded_by_file(str(model_dir), tp_rank=0, tp_size=1, num_kv_heads=8))
+        assert len(batches) == 2
+
+    def test_tensors_are_cpu(self, model_dir):
+        """All yielded tensors should be on CPU."""
+        for batch in _load_sharded_by_file(str(model_dir), tp_rank=0, tp_size=1, num_kv_heads=8):
+            for name, tensor in batch:
+                assert tensor.device == torch.device("cpu"), f"{name} is not on CPU"
+
+    def test_dim0_views_are_sharded(self, model_dir):
+        """With tp_size=2, dim-0 tensors should be half the original size."""
+        for batch in _load_sharded_by_file(str(model_dir), tp_rank=0, tp_size=2, num_kv_heads=8):
+            for name, tensor in batch:
+                if "q_proj" in name:
+                    assert tensor.shape[0] == 8  # 16 / 2
+                elif "gate_proj" in name:
+                    assert tensor.shape[0] == 16  # 32 / 2
+
+    def test_skips_vision_tower_keys(self, model_dir):
+        """Keys starting with vision_tower.* should be skipped."""
+        save_file(
+            {"vision_tower.encoder.weight": torch.randn(4, 4)},
+            model_dir / "vision.safetensors",
+        )
+        all_names = []
+        for batch in _load_sharded_by_file(str(model_dir), tp_rank=0, tp_size=1, num_kv_heads=8):
+            all_names.extend(name for name, _ in batch)
+        assert not any("vision_tower" in n for n in all_names)
+
+
+class TestLoadWeightIntegration:
+    """Integration tests: load_weight pipeline produces correct results."""
+
+    @pytest.fixture
+    def model_dir(self, tmp_path):
+        """Create minimal model with QKV merge scenario."""
+        save_file(
+            {
+                "model.embed_tokens.weight": torch.randn(32, 16),
+                "model.layers.0.self_attn.q_proj.weight": torch.randn(16, 16),
+                "model.layers.0.self_attn.k_proj.weight": torch.randn(8, 16),
+                "model.layers.0.self_attn.v_proj.weight": torch.randn(8, 16),
+                "model.layers.0.self_attn.o_proj.weight": torch.randn(16, 16),
+                "model.layers.0.mlp.gate_proj.weight": torch.randn(32, 16),
+                "model.layers.0.mlp.up_proj.weight": torch.randn(32, 16),
+                "model.layers.0.mlp.down_proj.weight": torch.randn(16, 32),
+                "model.layers.0.input_layernorm.weight": torch.randn(16),
+                "model.layers.0.post_attention_layernorm.weight": torch.randn(16),
+                "model.norm.weight": torch.randn(16),
+                "lm_head.weight": torch.randn(32, 16),
+            },
+            tmp_path / "model.safetensors",
+        )
+        return tmp_path
+
+    @pytest.fixture
+    def mock_tp_info(self):
+        """Mock TP info for rank 0, size 1."""
+        old = di._TP_INFO
+        di._TP_INFO = di.DistributedInfo(rank=0, size=1)
+        yield di._TP_INFO
+        di._TP_INFO = old
+
+    @pytest.fixture
+    def mock_config(self):
+        """Mock ModelConfig."""
+        cfg = MagicMock()
+        cfg.num_kv_heads = 8
+        cfg.is_moe = False
+        cfg.num_experts = 0
+        return cfg
+
+    def test_yields_merged_qkv(self, model_dir, mock_tp_info, mock_config):
+        """QKV projections should be merged into qkv_proj."""
+        with (
+            patch("minisgl.models.weight.download_hf_weight", return_value=str(model_dir)),
+            patch("minisgl.models.weight.cached_load_hf_config"),
+            patch("minisgl.models.config.ModelConfig.from_hf", return_value=mock_config),
+        ):
+            results = dict(load_weight(str(model_dir), torch.device("cpu")))
+        assert "model.layers.0.self_attn.qkv_proj.weight" in results
+        assert "model.layers.0.self_attn.q_proj.weight" not in results
+
+    def test_yields_merged_gate_up(self, model_dir, mock_tp_info, mock_config):
+        """gate/up projections should be merged into gate_up_proj."""
+        with (
+            patch("minisgl.models.weight.download_hf_weight", return_value=str(model_dir)),
+            patch("minisgl.models.weight.cached_load_hf_config"),
+            patch("minisgl.models.config.ModelConfig.from_hf", return_value=mock_config),
+        ):
+            results = dict(load_weight(str(model_dir), torch.device("cpu")))
+        assert "model.layers.0.mlp.gate_up_proj.weight" in results
+        assert "model.layers.0.mlp.gate_proj.weight" not in results
+
+    def test_all_tensors_on_target_device(self, model_dir, mock_tp_info, mock_config):
+        """All yielded tensors should be on the target device."""
+        with (
+            patch("minisgl.models.weight.download_hf_weight", return_value=str(model_dir)),
+            patch("minisgl.models.weight.cached_load_hf_config"),
+            patch("minisgl.models.config.ModelConfig.from_hf", return_value=mock_config),
+        ):
+            for name, tensor in load_weight(str(model_dir), torch.device("cpu")):
+                assert tensor.device == torch.device("cpu"), f"{name} wrong device"
+
+    def test_no_incomplete_groups(self, model_dir, mock_tp_info, mock_config):
+        """All merge groups should be complete (no assertion errors)."""
+        with (
+            patch("minisgl.models.weight.download_hf_weight", return_value=str(model_dir)),
+            patch("minisgl.models.weight.cached_load_hf_config"),
+            patch("minisgl.models.config.ModelConfig.from_hf", return_value=mock_config),
+        ):
+            list(load_weight(str(model_dir), torch.device("cpu")))


### PR DESCRIPTION
## TL;DR

Current `load_weight` gets **slower** at higher TP (7.15s at TP=4 vs 6.37s at TP=1 for Qwen3-32B) because `_shard_tensor`'s `.clone()` triggers mmap page fault storms. This PR replaces the per-tensor `device="cuda"` path with: zero-copy CPU views → per-file flat GPU buffer → batch H2D → GPU-side merge. Result: **TP=4 drops from 7.15s to 2.74s (2.6x)**. Drop-in replacement, no API change, 21 tests added.

## Background

The weight loading path has gone through several iterations:

- **#83** switched from CPU to GPU loading (`device="cuda"` in `safe_open`), reducing load time from 90s to 14s by eliminating the explicit CPU→GPU transfer.
- **#93** found that #83 caused OOM under TP — each rank loaded the full unsharded model onto GPU before sharding. The fix was to switch back to streaming: load each tensor, shard it via `_shard_tensor` (with `.clone()`), and yield immediately. This solved OOM but introduced a new performance issue.
- **#101** added Qwen3 TP=8 KV head replication and further streaming optimizations.

As @DarkSharpness noted when merging #93: *"For now, this could be a good work-around. Eventually we need some better weight loader."*

This PR addresses that need.

## Motivation

The current `load_weight` (from #93/#101) has a subtle performance problem that gets **worse** as TP increases:

**The symptom:** TP=4 loading is slower than TP=1 (7.15s vs 6.37s for Qwen3-32B), which is counterintuitive — each rank should transfer less data, not more.

**The root cause:** `_shard_tensor` calls `.clone()` on every tensor. When safetensors opens with `device="cuda"`, tensors are backed by mmap. The `.clone()` forces the OS to page-fault every byte from disk into CPU memory before copying — a **page fault storm**. At TP=4, all 4 ranks trigger these faults concurrently on the same files, creating severe contention. This is why #93's streaming fix actually made TP>1 slower than the pre-#93 approach for models that fit in GPU memory.

Secondary issue: each `f.get_tensor()` with `device="cuda"` triggers a separate `cudaMalloc`. For a 32B model with 707 tensors, that's 707 individual GPU allocations.

## Approach

Refactor the weight loading pipeline into three decoupled stages:

```
safetensors (mmap, device="cpu")
  → _shard_tensor_view()         # zero-copy CPU views, no .clone()
  → _load_sharded_by_file()     # yield one batch per file
  → per-file flat GPU buffer    # 1 cudaMalloc per file instead of per tensor
  → gpu_tensor.copy_(cpu)   # batch H2D
  → MergeAccumulator        # QKV/gate_up merge + expert stack on GPU
  → yield (name, tensor)
```

**Key changes:**

| Component | What it does |
|-----------|-------------|
| `_shard_tensor_view()` | Like `_shard_tensor` but returns views instead of `.clone()`. Eliminates CPU page faults on mmap tensors. dim-1 splits use `.contiguous()` since H2D requires contiguous memory. |
| `MergeAccumulator` | Decouples QKV merge (`torch.cat`), gate\_up merge, and expert stacking (`torch.stack`) from the loading loop. Runs on GPU tensors after H2D, not on CPU mmap tensors. |
| `_load_sharded_by_file()` | Yields batches of CPU views grouped by safetensors file. `yield` is inside the `safe_open` context to keep mmap alive. Private function — mmap-backed views expire when the generator advances. |
| Flat GPU buffer | Allocates one `torch.empty(total_bytes, dtype=uint8, device=cuda)` per file, slices it into per-tensor views, then batch-copies. Reduces `cudaMalloc` from ~707 to ~17 calls. |
| `.clone()` guard | After merge, only passthrough tensors (views of flat buffer) are `.clone()`'d to cut the reference. `torch.cat`/`torch.stack` results already have independent storage. |

## Compatibility

- The public signature `load_weight(model_path, device) -> Iterator[Tuple[str, Tensor]]` is unchanged — this is a drop-in replacement.
- The OOM fix from #93 is preserved: we process per-file, not per-model. Peak GPU memory is one file's flat buffer (~4GB) + merge buffers.
- KV head replication from #101 is preserved in `_shard_tensor_view`.

## Results

**Test environment:** 8× NVIDIA H20 (96GB HBM3 each), CUDA 12.9, Driver 535.161.07, PCIe Gen5

**Model:** Qwen3-32B (bf16, 17 safetensors files, 707 tensors)

| Config | Before | After | Speedup |
|--------|--------|-------|---------|
| TP=1 | 6.37s | 6.22s | 1.02x |
| TP=4 | 7.15s | 2.74s | **2.6x** |

**TP=1** is PCIe-bandwidth-bound (~11 GB/s for 65GB), so the optimization has minimal impact.

**TP=4** reveals the real win: the baseline actually gets *slower* than TP=1 (7.15s vs 6.37s) because `.clone()` page faults scale with TP rank count. The optimized version eliminates this entirely, and each rank only transfers 1/4 of the data.

Breakdown at TP=4:

| Stage | Before | After |
|-------|--------|-------|
| mmap + shard | 6.34s (page fault storm) | 0.76s (zero-copy views) |
| H2D transfer | (included above) | 1.91s |
| GPU alloc | (707 cudaMalloc) | 0.01s (17 cudaMalloc) |
| merge | 0.01s | 0.04s |

## Testing

- 21 unit tests added covering all new components
- `TestShardTensorView` (7 tests): verifies zero-copy behavior, value correctness vs `_shard_tensor`, contiguity for dim-1, KV head replication, embedding shards
- `TestMergeAccumulator` (6 tests): QKV merge, gate\_up merge, expert stacking with value verification, passthrough, incomplete group assertion
- `TestLoadShardedByFile` (4 tests): per-file batching, CPU device, TP sharding, vision key filtering
- `TestLoadWeightIntegration` (4 tests): end-to-end regression tests for merged outputs, device placement, group completeness

## Changes

Single squashed commit: `feat(weight): optimize load_weight with per-file batch H2D and zero-copy sharding`

**Files changed:**

| File | Changes |
|------|---------|
| `python/minisgl/models/weight.py` | +`_shard_tensor_view`, +`MergeAccumulator`, +`_load_sharded_by_file`, rewrite `load_weight`, add timing instrumentation |
| `python/minisgl/engine/engine.py` | Add total load time logging |
| `tests/models/test_weight.py` | New: 21 unit tests across 4 test classes |