### PR TITLE
[Fix] Avoid double-free in overlap_loop if Req is aborted while finishing

### DIFF
--- a/python/minisgl/scheduler/scheduler.py
+++ b/python/minisgl/scheduler/scheduler.py
@@ -66,6 +66,7 @@ class Scheduler(SchedulerIOMixin):
 
         # some alias for easy access
         self.finished_reqs: Set[Req] = set()
+        self.pending_aborts: Set[Req] = set()  # reqs to free after _process_last_data
         self.tokenizer = load_tokenizer(config.model_path)
         self.eos_token_id = self.tokenizer.eos_token_id
         self.token_pool = self.table_manager.token_pool
@@ -103,6 +104,7 @@ class Scheduler(SchedulerIOMixin):
                 ongoing_data = (forward_input, self._forward(forward_input))
 
         self._process_last_data(last_data)
+        self._free_pending_aborts(ongoing_data)
         return ongoing_data
 
     def normal_loop(self) -> None:
@@ -116,6 +118,7 @@ class Scheduler(SchedulerIOMixin):
             ongoing_data = (forward_input, self._forward(forward_input))
 
         self._process_last_data(ongoing_data)
+        self._free_pending_aborts(ongoing_data)
 
     @torch.inference_mode()
     def run_forever(self) -> NoReturn:
@@ -188,11 +191,12 @@ class Scheduler(SchedulerIOMixin):
                 )
             self.prefill_manager.add_one_req(msg)
         elif isinstance(msg, AbortBackendMsg):
-            logger.debug_rank0("Aborting request %d", msg.uid)
+            logger.debug_rank0("Queueing abort for request %d", msg.uid)
             req_to_free = self.prefill_manager.abort_req(msg.uid)
             req_to_free = req_to_free or self.decode_manager.abort_req(msg.uid)
+            # Immediately remove from managers to prevent scheduling, but defer resource freeing
             if req_to_free is not None:
-                self._free_req_resources(req_to_free)
+                self.pending_aborts.add(req_to_free)
         else:
             logger.error(f"Unknown message type: {type(msg)}")
             raise NotImplementedError
@@ -200,6 +204,24 @@ class Scheduler(SchedulerIOMixin):
     def _free_req_resources(self, req: Req) -> None:
         self.table_manager.free(req.table_idx)
         self.cache_manager.cache_req(req, finished=True)
+
+    def _free_pending_aborts(self, ongoing_data: ForwardData | None) -> None:
+        # Skip in-flight requests that are currently being forward-passed
+        if ongoing_data is not None:
+            ongoing_batch_uids = {req.uid for req in ongoing_data[0].batch.reqs}
+        else:
+            ongoing_batch_uids = set()
+
+        for req_to_free in self.pending_aborts.copy():
+            # Skip if req is in-flight in the overlapping batch
+            if req_to_free.uid in ongoing_batch_uids:
+                continue
+            # Remove if already freed by _process_last_data
+            if req_to_free in self.finished_reqs:
+                self.pending_aborts.discard(req_to_free)
+                continue
+            self._free_req_resources(req_to_free)
+            self.pending_aborts.discard(req_to_free)
 
     def _prepare_batch(self, batch: Batch) -> ForwardInput:
         self.engine.graph_runner.pad_batch(batch)

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -3,14 +3,118 @@ from __future__ import annotations
 import torch
 import multiprocessing as mp
 from transformers import AutoTokenizer
+from unittest.mock import MagicMock, patch
 
 from minisgl.distributed import DistributedInfo
 from minisgl.message import BaseBackendMsg, BaseTokenizerMsg, DetokenizeMsg, ExitMsg, UserMsg
 from minisgl.scheduler import Scheduler, SchedulerConfig
 from minisgl.utils import ZmqPullQueue, ZmqPushQueue, call_if_main, init_logger
-from minisgl.core import SamplingParams
+from minisgl.core import Batch, Req, SamplingParams
+from minisgl.engine import ForwardOutput
+from minisgl.engine.sample import BatchSamplingArgs
+from minisgl.message import AbortBackendMsg
+from minisgl.scheduler.scheduler import ForwardInput
 
 logger = init_logger(__name__)
+
+
+def test_overlap_loop_double_free():
+    """Regression test: _free_req_resources should be called exactly once when a request
+    is both aborted and finished (EOS) in the same overlap_loop iteration.
+
+    Bug: _process_one_msg (abort path) calls _free_req_resources immediately, then
+    _process_last_data (finish path) calls it again because abort doesn't add req to
+    finished_reqs. After fix: abort queues req in pending_aborts, and _free_pending_aborts
+    skips it since it's already in finished_reqs.
+    """
+    # Patch Engine, CUDA streams, tokenizer, global_ctx, and logger to avoid real hardware
+    mock_global_ctx = MagicMock()
+    mock_global_ctx.page_size = 1
+    with (
+        patch("minisgl.engine.Engine") as MockEngine,
+        patch("torch.cuda.Stream") as MockCudaStream,
+        patch("torch.cuda.set_stream"),
+        patch("torch.cuda.stream") as mock_cuda_stream_ctx,
+        patch("minisgl.scheduler.scheduler.load_tokenizer") as mock_load_tokenizer,
+        patch("minisgl.core.get_global_ctx", return_value=mock_global_ctx),
+        patch("minisgl.scheduler.scheduler.logger") as mock_logger,
+    ):
+        # Set up minimal Engine mock
+        mock_engine = MagicMock()
+        mock_engine.device = torch.device("cpu")
+        mock_engine.stream = MagicMock()
+        mock_engine.tp_cpu_group = MagicMock()
+        mock_engine.page_table = torch.zeros((17, 2048), dtype=torch.int32, device="cpu")
+        mock_engine.num_pages = 16
+        MockEngine.return_value = mock_engine
+
+        # Make torch.cuda.Stream() return a mock
+        MockCudaStream.return_value = MagicMock()
+        mock_cuda_stream_ctx.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_cuda_stream_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Set up tokenizer mock with EOS token id = 2
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.eos_token_id = 2
+        mock_load_tokenizer.return_value = mock_tokenizer
+
+        # Create scheduler in offline_mode (skips ZMQ setup)
+        config = SchedulerConfig(
+            model_path="/fake",
+            tp_info=DistributedInfo(0, 1),
+            dtype=torch.bfloat16,
+            max_running_req=16,
+            page_size=1,
+            offline_mode=True,
+        )
+        scheduler_instance = Scheduler(config)
+
+        # Mock receive_msg to return AbortBackendMsg for uid=42
+        scheduler_instance.receive_msg = MagicMock(return_value=[AbortBackendMsg(uid=42)])
+        scheduler_instance.send_result = MagicMock()
+
+        # Create a Req with uid=42 that will finish with EOS (next_token == eos_token_id)
+        req = Req(
+            input_ids=torch.tensor([1, 2, 3], dtype=torch.int32),
+            table_idx=0,
+            cached_len=2,
+            output_len=2,
+            uid=42,
+            sampling_params=SamplingParams(max_tokens=10),
+            cache_handle=MagicMock(),
+        )
+
+        # Put req in decode_manager so abort can find it
+        scheduler_instance.decode_manager.running_reqs.add(req)
+        scheduler_instance.eos_token_id = 2
+
+        # Build last_data: (ForwardInput, ForwardOutput) where req finishes with EOS
+        batch = Batch(reqs=[req], phase="decode")
+        next_tokens_cpu = torch.tensor([2], dtype=torch.int32)  # eos_token_id = 2
+        forward_output = ForwardOutput(
+            next_tokens_gpu=MagicMock(),
+            next_tokens_cpu=next_tokens_cpu,
+            copy_done_event=MagicMock(),
+        )
+        sample_args = BatchSamplingArgs(temperatures=MagicMock())
+        forward_input = ForwardInput(
+            batch=batch,
+            sample_args=sample_args,
+            input_tuple=(MagicMock(), MagicMock()),
+            write_tuple=(MagicMock(), MagicMock()),
+        )
+        last_data = (forward_input, forward_output)
+
+        # Mock _free_req_resources to track call count
+        scheduler_instance._free_req_resources = MagicMock()
+
+        # Run overlap_loop with the EOS-finishing req in last_data
+        scheduler_instance.overlap_loop(last_data)
+
+        # Assert exactly one call (bug state: call_count == 2)
+        assert (
+            scheduler_instance._free_req_resources.call_count == 1
+        ), f"Expected 1 call (_free_req_resources called {scheduler_instance._free_req_resources.call_count} times = double-free bug)."
 
 
 @torch.inference_mode()


### PR DESCRIPTION
Fix double-free (and what appears to be a UAF) race condition in `Scheduler.overlap_loop`.

## Problem

```python
    def overlap_loop(self, last_data: ForwardData | None) -> ForwardData | None:
        """
        The main loop of overlapping scheduling and execution.

        It will overlap the execution of current batch and processing of last batch's results,
        which can effectively hide CPU latency and improve GPU utilization.
        """
        blocking = not (
            last_data is not None  # don't block if we have a batch to be processed
            or self.prefill_manager.runnable
            or self.decode_manager.runnable
        )
        for msg in self.receive_msg(blocking=blocking):
            self._process_one_msg(msg)

        forward_input = self._schedule_next_batch()
        ongoing_data = None
        if forward_input is not None:
            with self.engine_stream_ctx:  # run the batch in the engine's stream
                self.engine.stream.wait_stream(self.stream)
                ongoing_data = (forward_input, self._forward(forward_input))

        self._process_last_data(last_data)
        return ongoing_data
```

The `_process_one_msg` may abort a `Req` that is in-flight (in `last_data`), thus freeing its corresponding resource (the `table_idx`). Then such race conditions may happen:
- If the `Req` is finishing (e.g. just decoded an EOS token), it will be double-freed in `self._process_last_data(last_data)`.
- If `forward_input = self._schedule_next_batch()` assigns a new prefill Req/ChunkedReq, it may be assigned the same `table_idx` just freed, while the original `Req` is still in-flight (to be handled by `_process_last_data`). While this is actually not a UAF condition since `_process_last_data` only calls cpu-side `Req.append_host`, it still creates unstable semantic where two living `Req` objects are sharing the same `table_idx` and makes the code vulnerable.

## Fix

The fix defers aborted-request's resource freeing until after `_process_last_data` (which populates finished_reqs and finishes the previous in-flight batch). `_process_one_msg` just removes the `Req` from the managers so the request won't be scheduled for the next batch.
  To-be-aborted reqs are queued in pending_aborts. The freeing procedure skips any reqs just finished or in-flight.

## Test

This commit also contains a testcase of the double-free scenario. The testcase fails without the fix.