### PR TITLE
[Fix] Incorrect use_pynccl condition in Engine._init_communication()

### DIFF
--- a/python/minisgl/engine/engine.py
+++ b/python/minisgl/engine/engine.py
@@ -110,7 +110,7 @@ class Engine:
         )
 
     def _init_communication(self, config: EngineConfig) -> torch.distributed.ProcessGroup:
-        if config.tp_info.size == 1 or config.use_pynccl:
+        if config.tp_info.size == 1 or not config.use_pynccl:
             torch.distributed.init_process_group(
                 backend="gloo",
                 rank=config.tp_info.rank,


### PR DESCRIPTION
## Summary

This PR fixes a reversed condition in `Engine._init_communication()`.

`use_pynccl` is controlled by the negative CLI flag `--disable-pynccl`, so its semantics are:

- default: `use_pynccl=True`
- when `--disable-pynccl` is passed: `use_pynccl=False`

However, the current code checks:

```python
if config.tp_info.size == 1 or config.use_pynccl:
    torch.distributed.init_process_group(
        backend="gloo",
        rank=config.tp_info.rank,
        world_size=config.tp_info.size,
        timeout=timedelta(seconds=config.distributed_timeout),
        init_method=config.distributed_addr,
    )
else:
     torch.distributed.init_process_group(
        backend="nccl",
        rank=config.tp_info.rank,
        world_size=config.tp_info.size,
        timeout=timedelta(seconds=config.distributed_timeout),
        init_method=config.distributed_addr,
    )
```
which makes the runtime behavior inconsistent with the flag semantics.