### PR TITLE
[Fix] Stabilize decode batch request order across TP ranks

### DIFF
--- a/python/minisgl/scheduler/decode.py
+++ b/python/minisgl/scheduler/decode.py
@@ -32,7 +32,7 @@ class DecodeManager:
     def schedule_next_batch(self) -> Batch | None:
         if not self.runnable:
             return None
-        return Batch(reqs=list(self.running_reqs), phase="decode")
+        return Batch(reqs=sorted(self.running_reqs, key=lambda req: req.uid), phase="decode")
 
     @property
     def runnable(self) -> bool:


### PR DESCRIPTION
### Motivation

A TP correctness issue was encountered while developing another feature (<https://github.com/sgl-project/mini-sglang/pull/97>) DecodeManager stored running requests in a set, and schedule_next_batch() materialized decode batches directly from list(self.running_reqs), so batch row order depended on Python set iteration, which could lead to inconsistencies.

### Description

Decode batches are now materialized in a deterministic order by sorting requests on req.uid when constructing the decode Batch.

