### PR TITLE
[Fix] refresh radix split prefix timestamp

### DIFF
--- a/python/minisgl/kvcache/radix_cache.py
+++ b/python/minisgl/kvcache/radix_cache.py
@@ -222,6 +222,7 @@ class RadixPrefixCache(BasePrefixCache):
             # need to split the node if not fully matched
             if match_len != node.length:
                 node = node.split_at(match_len)
+                node.timestamp = tic
                 return node, prefix_len
 
             # update timestamp for accessed node


### PR DESCRIPTION
## Summary
- Refresh the matched prefix node timestamp after `RadixTreeNode.split_at()` is triggered by a partial radix-cache match.
- Keeps LRU eviction ordering consistent for the prefix that was actually matched by the current request.

## Discussion
When a partial radix-cache match splits an existing node, the split produces two logical pieces:
- the new parent node, which represents the matched prefix and is returned as the cache hit;
- the remaining child node, which represents the unmatched suffix of the original node.

SGLang refreshes the child before splitting, so both resulting nodes effectively become recently accessed. This PR takes a narrower approach for Mini-SGLang: only the split-out parent is refreshed, because it is the portion actually matched by the current lookup. The remaining child keeps its previous timestamp, avoiding marking an unmatched suffix as recently used.

## Notes
- The branch contains a single commit and only changes `python/minisgl/kvcache/radix_cache.py`.