### PR TITLE
[Feature] Support stream=false in /v1/chat/completions

### DIFF
--- a/python/minisgl/server/api_server.py
+++ b/python/minisgl/server/api_server.py
@@ -278,10 +278,37 @@ async def v1_completions(req: OpenAICompletionRequest, request: Request):
         )
     )
 
-    return StreamingResponse(
-        state.stream_with_cancellation(state.stream_chat_completions(uid), request, uid),
-        media_type="text/event-stream",
-    )
+    if req.stream:
+        return StreamingResponse(
+            state.stream_with_cancellation(state.stream_chat_completions(uid), request, uid),
+            media_type="text/event-stream",
+        )
+
+    # Non-streaming: collect all chunks and return a single JSON response
+    full_content = ""
+    async for ack in state.wait_for_ack(uid):
+        full_content += ack.incremental_output
+        if ack.finished:
+            break
+
+    return {
+        "id": f"chatcmpl-{uid}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": req.model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": full_content},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+        },
+    }
 
 
 @app.get("/v1/models")


### PR DESCRIPTION
## Summary

Closes #51.

When `stream` is set to `false` (the default per OpenAI spec) in the request body, the server now returns a single OpenAI-compatible JSON response instead of always returning SSE chunks.

**Before:** All requests returned `text/event-stream` regardless of the `stream` field, breaking standard OpenAI client libraries.

**After:**
- `stream=true` → SSE chunks (existing behavior, unchanged)
- `stream=false` → One-shot JSON response matching OpenAI's `chat.completion` format

## Changes

- `python/minisgl/server/api_server.py`: Branch on `req.stream` in the `/v1/chat/completions` handler. For non-streaming requests, collect all incremental outputs via `wait_for_ack` and return a complete JSON response.

## Test plan

```bash
# Start server
python -m minisgl --model-path Qwen/Qwen3-0.6B --host 0.0.0.0 --port 8000

# Non-streaming (should return JSON)
curl -s http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"hi"}],"stream":false,"max_tokens":32}' | python -m json.tool

# Streaming (should return SSE, unchanged)
curl -N http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"hi"}],"stream":true,"max_tokens":32}'
```

Also verified with Python `openai` client:
```python
from openai import OpenAI
client = OpenAI(base_url="http://localhost:8000/v1", api_key="none")
resp = client.chat.completions.create(
    model="Qwen/Qwen3-0.6B",
    messages=[{"role": "user", "content": "hello"}],
    max_tokens=32,
    stream=False,
)
print(resp.choices[0].message.content)  # works without JSONDecodeError
```