### PR TITLE
[Feature] Add usage token counting and finish_reason to API responses

### DIFF
--- a/python/minisgl/message/frontend.py
+++ b/python/minisgl/message/frontend.py
@@ -27,3 +27,6 @@ class UserReply(BaseFrontendMsg):
     uid: int
     incremental_output: str
     finished: bool
+    finish_reason: str = ""
+    prompt_tokens: int = 0
+    completion_tokens: int = 0

--- a/python/minisgl/message/tokenizer.py
+++ b/python/minisgl/message/tokenizer.py
@@ -29,6 +29,9 @@ class DetokenizeMsg(BaseTokenizerMsg):
     uid: int
     next_token: int
     finished: bool
+    finish_reason: str = ""
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
 
 
 @dataclass

--- a/python/minisgl/scheduler/scheduler.py
+++ b/python/minisgl/scheduler/scheduler.py
@@ -151,9 +151,24 @@ class Scheduler(SchedulerIOMixin):
                 req.append_host(next_token.unsqueeze(0))
                 next_token = int(next_token.item())
                 finished = not req.can_decode
+                finish_reason = "length" if finished else ""
                 if not req.sampling_params.ignore_eos:
-                    finished |= next_token == self.eos_token_id
-                reply.append(DetokenizeMsg(uid=req.uid, next_token=next_token, finished=finished))
+                    if next_token == self.eos_token_id:
+                        finished = True
+                        finish_reason = "stop"
+                prompt_tokens = 0
+                completion_tokens = 0
+                if finished:
+                    prompt_tokens = req.max_device_len - req.output_len
+                    completion_tokens = req.device_len - prompt_tokens
+                reply.append(DetokenizeMsg(
+                    uid=req.uid,
+                    next_token=next_token,
+                    finished=finished,
+                    finish_reason=finish_reason,
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                ))
 
                 # NOTE: overlap scheduling may make the request freed twice, skip second free
                 if finished and req not in self.finished_reqs:

--- a/python/minisgl/server/api_server.py
+++ b/python/minisgl/server/api_server.py
@@ -160,6 +160,9 @@ class FrontendManager:
 
     async def stream_chat_completions(self, uid: int):
         first_chunk = True
+        finish_reason = "stop"
+        prompt_tokens = 0
+        completion_tokens = 0
         async for ack in self.wait_for_ack(uid):
             delta = {}
             if first_chunk:
@@ -170,19 +173,26 @@ class FrontendManager:
 
             chunk = {
                 "id": f"cmpl-{uid}",
-                "object": "text_completion.chunk",
+                "object": "chat.completion.chunk",
                 "choices": [{"delta": delta, "index": 0, "finish_reason": None}],
             }
             yield f"data: {json.dumps(chunk)}\n\n".encode()
 
             if ack.finished:
+                finish_reason = ack.finish_reason or "stop"
+                prompt_tokens = ack.prompt_tokens
+                completion_tokens = ack.completion_tokens
                 break
 
-        # send final finish_reason
         end_chunk = {
             "id": f"cmpl-{uid}",
-            "object": "text_completion.chunk",
-            "choices": [{"delta": {}, "index": 0, "finish_reason": "stop"}],
+            "object": "chat.completion.chunk",
+            "choices": [{"delta": {}, "index": 0, "finish_reason": finish_reason}],
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": prompt_tokens + completion_tokens,
+            },
         }
         yield f"data: {json.dumps(end_chunk)}\n\n".encode()
         yield b"data: [DONE]\n\n"

--- a/python/minisgl/tokenizer/server.py
+++ b/python/minisgl/tokenizer/server.py
@@ -76,6 +76,9 @@ def tokenize_worker(
                             uid=msg.uid,
                             incremental_output=reply,
                             finished=msg.finished,
+                            finish_reason=msg.finish_reason,
+                            prompt_tokens=msg.prompt_tokens,
+                            completion_tokens=msg.completion_tokens,
                         )
                         for msg, reply in zip(detokenize_msg, replies, strict=True)
                     ]


### PR DESCRIPTION
## Summary

- Propagate `finish_reason` ("stop" / "length") and token usage (`prompt_tokens`, `completion_tokens`) through the full message pipeline
- Fix `object` field in streaming chunks from incorrect `"text_completion.chunk"` to `"chat.completion.chunk"` per OpenAI spec

## Motivation

The OpenAI Chat Completions API specifies that:
1. `finish_reason` should be `"stop"` when generation ended due to EOS token, and `"length"` when `max_tokens` was reached
2. `usage` should report actual token counts for billing/monitoring
3. Streaming chunk `object` field should be `"chat.completion.chunk"`

Currently mini-sglang hardcodes `finish_reason: "stop"` and returns zeros for usage. This PR fixes both.

## Changes

| File | Change |
|------|--------|
| `message/tokenizer.py` | Add `finish_reason`, `prompt_tokens`, `completion_tokens` to `DetokenizeMsg` |
| `message/frontend.py` | Add same fields to `UserReply` |
| `scheduler/scheduler.py` | Compute finish reason and token counts at request completion |
| `tokenizer/server.py` | Forward new fields from `DetokenizeMsg` to `UserReply` |
| `server/api_server.py` | Use real values in streaming response; fix `object` field |

## Design

Token counts are computed in the scheduler where `Req` state is available:
- `prompt_tokens = req.max_device_len - req.output_len` (original input length)
- `completion_tokens = req.device_len - prompt_tokens` (tokens generated)

These are only populated in the final message (when `finished=True`) to avoid per-token overhead.

## Test plan

```bash
# Start server
python -m minisgl --model-path Qwen/Qwen3-0.6B --host 0.0.0.0 --port 8000

# Test streaming - verify finish_reason and usage in final chunk
curl -N http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"hi"}],"stream":true,"max_tokens":5}'
# Expected: last data chunk has "finish_reason": "length" and "usage": {...}

# Test EOS stop
curl -N http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"Say hi"}],"stream":true,"max_tokens":512}'
# Expected: "finish_reason": "stop" when model naturally stops
```