### PR TITLE
[Feature] Support Qwen3.5 text model

### DIFF
--- a/python/minisgl/attention/__init__.py
+++ b/python/minisgl/attention/__init__.py
@@ -65,7 +65,12 @@ def create_attention_backend(
         backend = p_backend  # both are the same, fall through to single backend
         logger.warning(f"P/D attention backends are the same: {backend}, using single backend.")
 
-    return SUPPORTED_ATTENTION_BACKENDS[backend](config)
+    ret = SUPPORTED_ATTENTION_BACKENDS[backend](config)
+    if config.has_linear_layers:
+        from .gdn import HybridLinearBackend
+
+        return HybridLinearBackend(ret)
+    return ret
 
 
 __all__ = [

--- a/python/minisgl/attention/base.py
+++ b/python/minisgl/attention/base.py
@@ -18,7 +18,14 @@ class BaseAttnMetadata(ABC):
 class BaseAttnBackend(ABC):
     @abstractmethod
     def forward(
-        self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, layer_id: int, batch: Batch
+        self,
+        q: torch.Tensor | None = None,
+        k: torch.Tensor | None = None,
+        v: torch.Tensor | None = None,
+        layer=None,
+        forward_batch=None,
+        save_kv_cache: bool = True,
+        **kwargs,
     ) -> torch.Tensor: ...
 
     @abstractmethod
@@ -33,6 +40,9 @@ class BaseAttnBackend(ABC):
     @abstractmethod
     def prepare_for_replay(self, batch: Batch) -> None: ...
 
+    def on_table_slot_allocated(self, slot: int) -> None:
+        del slot
+
 
 class HybridBackend(BaseAttnBackend):
     def __init__(
@@ -44,10 +54,31 @@ class HybridBackend(BaseAttnBackend):
         self.decode_backend = decode_backend
 
     def forward(
-        self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, layer_id: int, batch: Batch
+        self,
+        q: torch.Tensor | None = None,
+        k: torch.Tensor | None = None,
+        v: torch.Tensor | None = None,
+        layer=None,
+        forward_batch=None,
+        save_kv_cache: bool = True,
+        **kwargs,
     ) -> torch.Tensor:
-        backend = self.prefill_backend if batch.is_prefill else self.decode_backend
-        return backend.forward(q, k, v, layer_id, batch)
+        if forward_batch is None:
+            raise ValueError("forward_batch is required for attention dispatch.")
+        backend = (
+            self.prefill_backend
+            if forward_batch.forward_mode.is_prefill()
+            else self.decode_backend
+        )
+        return backend.forward(
+            q=q,
+            k=k,
+            v=v,
+            layer=layer,
+            forward_batch=forward_batch,
+            save_kv_cache=save_kv_cache,
+            **kwargs,
+        )
 
     def prepare_metadata(self, batch: Batch) -> None:
         backend = self.prefill_backend if batch.is_prefill else self.decode_backend
@@ -61,3 +92,7 @@ class HybridBackend(BaseAttnBackend):
 
     def prepare_for_replay(self, batch: Batch) -> None:
         self.decode_backend.prepare_for_replay(batch)
+
+    def on_table_slot_allocated(self, slot: int) -> None:
+        self.prefill_backend.on_table_slot_allocated(slot)
+        self.decode_backend.on_table_slot_allocated(slot)

--- a/python/minisgl/attention/fa.py
+++ b/python/minisgl/attention/fa.py
@@ -46,15 +46,26 @@ class FlashAttentionBackend(BaseAttnBackend):
         self.version = 4 if is_sm100_supported() else 3
 
     def forward(
-        self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, layer_id: int, batch: Batch
+        self,
+        q: torch.Tensor | None = None,
+        k: torch.Tensor | None = None,
+        v: torch.Tensor | None = None,
+        layer=None,
+        forward_batch=None,
+        save_kv_cache: bool = True,
+        **kwargs,
     ) -> torch.Tensor:
+        if q is None or k is None or v is None or layer is None or forward_batch is None:
+            raise ValueError("q/k/v/layer/forward_batch are required for FlashAttentionBackend.")
+        batch = forward_batch.batch
         metadata = batch.attn_metadata
         assert isinstance(metadata, FAMetadata)
-        self.kvcache.store_kv(k, v, batch.out_loc, layer_id)
+        if save_kv_cache:
+            self.kvcache.store_kv(k, v, batch.out_loc, layer.layer_id)
         return _fa_sgl_impl(
             q=q,
-            k_cache=self.kvcache.k_cache(layer_id),
-            v_cache=self.kvcache.v_cache(layer_id),
+            k_cache=self.kvcache.k_cache(layer.layer_id),
+            v_cache=self.kvcache.v_cache(layer.layer_id),
             page_table=metadata.page_table,
             cache_seqlens=metadata.cache_seqlens,
             cu_seqlens_q=metadata.cu_seqlens_q,

--- a/python/minisgl/attention/fi.py
+++ b/python/minisgl/attention/fi.py
@@ -174,16 +174,31 @@ class FlashInferBackend(BaseAttnBackend):
         return self.cached_ones_cpu[:bs]
 
     def forward(
-        self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, layer_id: int, batch: Batch
+        self,
+        q: torch.Tensor | None = None,
+        k: torch.Tensor | None = None,
+        v: torch.Tensor | None = None,
+        layer=None,
+        forward_batch=None,
+        save_kv_cache: bool = True,
+        **kwargs,
     ) -> torch.Tensor:
+        if q is None or k is None or v is None or layer is None or forward_batch is None:
+            raise ValueError("q/k/v/layer/forward_batch are required for FlashInferBackend.")
+        batch = forward_batch.batch
+
         def _flatten_cache(cache: torch.Tensor) -> torch.Tensor:  # treat page = 1
             return cache.view(-1, 1, cache.shape[2], cache.shape[3])
 
         metadata = batch.attn_metadata
         assert isinstance(metadata, FIMetadata)
         self._initialize_metadata_once(metadata)
-        self.kvcache.store_kv(k, v, batch.out_loc, layer_id)
-        kv_cache = (self.kvcache.k_cache(layer_id), self.kvcache.v_cache(layer_id))
+        if save_kv_cache:
+            self.kvcache.store_kv(k, v, batch.out_loc, layer.layer_id)
+        kv_cache = (
+            self.kvcache.k_cache(layer.layer_id),
+            self.kvcache.v_cache(layer.layer_id),
+        )
         kv_cache = (_flatten_cache(kv_cache[0]), _flatten_cache(kv_cache[1]))
         return metadata.wrapper.run(q=q, paged_kv_cache=kv_cache)
 

--- a/python/minisgl/attention/gdn.py
+++ b/python/minisgl/attention/gdn.py
@@ -1,0 +1,617 @@
+from __future__ import annotations
+
+import weakref
+from dataclasses import dataclass
+from typing import Dict, List
+
+import torch
+import torch.nn.functional as F
+from minisgl.core import Req, get_global_ctx
+from minisgl.kvcache import BaseCacheHandle
+from minisgl.kernel.triton.causal_conv1d import (
+    PAD_SLOT_ID,
+    causal_conv1d_update as triton_causal_conv1d_update,
+)
+from minisgl.kernel.triton.gdn_decode import packed_decode as gdn_packed_decode
+
+from .base import BaseAttnBackend
+
+
+@dataclass
+class _LayerRuntime:
+    conv_cache: torch.Tensor
+    ssm_cache: torch.Tensor
+
+
+@dataclass
+class _LayerStateSnapshot:
+    conv_cache: torch.Tensor
+    ssm_cache: torch.Tensor
+
+
+class GDNAttnBackend:
+    """Backend executor for GDN linear attention path."""
+
+    def __init__(self) -> None:
+        self._runtime: Dict[int, _LayerRuntime] = {}
+        self._capture_active_bs: int | None = None
+        self._capture_state_indices_i32: Dict[int, torch.Tensor] = {}
+        self._prefix_state_cache: weakref.WeakKeyDictionary[
+            object, Dict[int, _LayerStateSnapshot]
+        ] = weakref.WeakKeyDictionary()
+
+    def _get_prefix_node(self, handle: BaseCacheHandle) -> object | None:
+        return getattr(handle, "node", None)
+
+    def has_prefix_cache_state(self, handle: BaseCacheHandle) -> bool:
+        node = self._get_prefix_node(handle)
+        if node is None:
+            return True
+        return node in self._prefix_state_cache
+
+    def on_prefix_cache_store(self, req: Req, handle: BaseCacheHandle) -> None:
+        node = self._get_prefix_node(handle)
+        if node is None:
+            return
+        slot = req.table_idx
+        node_states: Dict[int, _LayerStateSnapshot] = {}
+        for layer_id, rt in self._runtime.items():
+            if slot < 0 or slot >= rt.ssm_cache.shape[0]:
+                continue
+            node_states[layer_id] = _LayerStateSnapshot(
+                conv_cache=rt.conv_cache[slot].clone(),
+                ssm_cache=rt.ssm_cache[slot].clone(),
+            )
+        if node_states:
+            self._prefix_state_cache[node] = node_states
+
+    def on_prefix_cache_match(self, handle: BaseCacheHandle, slot: int) -> None:
+        node = self._get_prefix_node(handle)
+        if node is None:
+            return
+        node_states = self._prefix_state_cache.get(node)
+        if not node_states:
+            return
+        for layer_id, state in node_states.items():
+            rt = self._runtime.get(layer_id)
+            if rt is None or slot < 0 or slot >= rt.ssm_cache.shape[0]:
+                continue
+            if rt.conv_cache.shape[-1] != state.conv_cache.shape[-1]:
+                continue
+            rt.conv_cache[slot].copy_(state.conv_cache.to(device=rt.conv_cache.device))
+            rt.ssm_cache[slot].copy_(
+                state.ssm_cache.to(device=rt.ssm_cache.device, dtype=rt.ssm_cache.dtype)
+            )
+
+    def _ensure_runtime(self, layer, x: torch.Tensor) -> _LayerRuntime:
+        ctx = get_global_ctx()
+        num_slots = ctx.page_table.shape[0]
+
+        conv_weights = layer.conv_weights
+        if not isinstance(conv_weights, torch.Tensor):
+            raise ValueError("conv_weights must be a Tensor in RadixLinearAttention.")
+        conv_kernel = conv_weights.shape[-1]
+        hist_len = max(0, conv_kernel - 1)
+
+        rt = self._runtime.get(layer.layer_id)
+        need_realloc = (
+            rt is None
+            or rt.conv_cache.shape[0] != num_slots
+            or rt.conv_cache.shape[-1] != hist_len
+            or rt.conv_cache.device != x.device
+            or rt.conv_cache.dtype != x.dtype
+        )
+        if need_realloc:
+            rt = _LayerRuntime(
+                conv_cache=torch.zeros(
+                    num_slots,
+                    layer.q_dim + layer.k_dim + layer.v_dim,
+                    hist_len,
+                    dtype=x.dtype,
+                    device=x.device,
+                ),
+                ssm_cache=torch.zeros(
+                    num_slots,
+                    layer.num_v_heads,
+                    layer.head_v_dim,
+                    layer.head_k_dim,
+                    dtype=torch.float32,
+                    device=x.device,
+                ),
+            )
+            self._runtime[layer.layer_id] = rt
+            return rt
+
+        if rt.ssm_cache.device != x.device:
+            rt.ssm_cache = rt.ssm_cache.to(device=x.device)
+        return rt
+
+    def _clear_slot_in_runtime(self, rt: _LayerRuntime, slot: int) -> None:
+        if slot < 0 or slot >= rt.ssm_cache.shape[0]:
+            return
+        if rt.conv_cache.shape[-1] > 0:
+            rt.conv_cache[slot].zero_()
+        rt.ssm_cache[slot].zero_()
+
+    def on_table_slot_allocated(self, slot: int) -> None:
+        for rt in self._runtime.values():
+            self._clear_slot_in_runtime(rt, slot)
+
+    def _get_decode_state_indices(
+        self,
+        reqs: List[Req],
+        device: torch.device,
+        forward_batch,
+    ) -> torch.Tensor:
+        del forward_batch
+        # During CUDA graph capture we must avoid creating new CUDA tensors.
+        if self._capture_active_bs == len(reqs):
+            state_i32 = self._capture_state_indices_i32.get(len(reqs))
+            if state_i32 is None:
+                raise RuntimeError(
+                    "Missing cached decode state indices during capture. "
+                    "prepare_for_capture() must run before graph capture."
+                )
+            return state_i32
+        return torch.tensor([req.table_idx for req in reqs], dtype=torch.int32, device=device)
+
+    def init_capture_graph(self, bs_list: List[int]) -> None:
+        self._capture_active_bs = None
+        self._capture_state_indices_i32 = {}
+
+    def prepare_for_capture(self, batch) -> None:
+        self._capture_active_bs = batch.size
+        bs = batch.size
+        reqs = getattr(batch, "padded_reqs", batch.reqs)
+        device = get_global_ctx().page_table.device
+        state_i32 = self._capture_state_indices_i32.get(bs)
+        if state_i32 is None or state_i32.device != device:
+            state_i32 = torch.empty(bs, dtype=torch.int32, device=device)
+            self._capture_state_indices_i32[bs] = state_i32
+        for i, req in enumerate(reqs):
+            state_i32[i] = req.table_idx
+
+    def prepare_for_replay(self, batch) -> None:
+        bs = batch.padded_size
+        state_i32 = self._capture_state_indices_i32.get(bs)
+        reqs = getattr(batch, "padded_reqs", batch.reqs)
+        if state_i32 is None:
+            state_i32 = torch.empty(bs, dtype=torch.int32, device=get_global_ctx().page_table.device)
+            self._capture_state_indices_i32[bs] = state_i32
+        for i, req in enumerate(reqs):
+            state_i32[i] = req.table_idx
+        self._capture_active_bs = None
+
+    def _apply_conv(
+        self,
+        token_states: torch.Tensor,
+        slot: int,
+        conv_weight: torch.Tensor,
+        rt: _LayerRuntime,
+    ) -> torch.Tensor:
+        if conv_weight.shape[-1] <= 1:
+            return token_states
+
+        conv_hist = rt.conv_cache[slot]
+        hist_len = conv_hist.shape[-1]
+
+        if token_states.shape[0] == 1:
+            full = torch.cat([conv_hist, token_states[0].unsqueeze(-1)], dim=-1)
+            out = (full * conv_weight.squeeze(1)).sum(dim=-1)
+            out = F.silu(out)
+            if hist_len > 0:
+                conv_hist[:, :-1] = conv_hist[:, 1:]
+                conv_hist[:, -1] = token_states[0]
+            return out.unsqueeze(0)
+
+        inp = torch.cat([conv_hist, token_states.transpose(0, 1)], dim=-1).unsqueeze(0)
+        out = F.conv1d(inp, conv_weight, bias=None, groups=conv_weight.shape[0])
+        out = out.squeeze(0).transpose(0, 1)
+        out = F.silu(out)
+
+        if hist_len > 0:
+            if token_states.shape[0] >= hist_len:
+                conv_hist.copy_(token_states[-hist_len:].transpose(0, 1))
+            else:
+                conv_hist.copy_(
+                    torch.cat(
+                        [conv_hist[:, token_states.shape[0] :], token_states.transpose(0, 1)],
+                        dim=1,
+                    )
+                )
+        return out
+
+    def _apply_conv_batch(
+        self,
+        mixed_qkv: torch.Tensor,
+        reqs: List[Req],
+        conv_weight: torch.Tensor,
+        rt: _LayerRuntime,
+    ) -> torch.Tensor:
+        conv_qkv = torch.empty_like(mixed_qkv)
+        offset = 0
+        for req in reqs:
+            length = req.extend_len
+            if length == 0:
+                continue
+            seg = mixed_qkv[offset : offset + length]
+            conv_qkv[offset : offset + length] = self._apply_conv(
+                seg, req.table_idx, conv_weight, rt
+            )
+            offset += length
+        return conv_qkv
+
+    def _apply_conv_decode_batch(
+        self,
+        mixed_qkv: torch.Tensor,
+        conv_weight: torch.Tensor,
+        rt: _LayerRuntime,
+        state_indices_i32: torch.Tensor,
+    ) -> torch.Tensor:
+        if conv_weight.shape[-1] <= 1:
+            return mixed_qkv
+
+        weight_2d = conv_weight.squeeze(1) if conv_weight.ndim == 3 else conv_weight
+        if not mixed_qkv.is_cuda:
+            slots = state_indices_i32.to(dtype=torch.int64)
+            conv_hist = rt.conv_cache.index_select(0, slots)
+            full = torch.cat([conv_hist, mixed_qkv.unsqueeze(-1)], dim=-1)
+            out = (full * weight_2d.unsqueeze(0)).sum(dim=-1)
+            out = F.silu(out)
+            hist_len = conv_hist.shape[-1]
+            if hist_len > 0:
+                if hist_len == 1:
+                    updated_hist = mixed_qkv.unsqueeze(-1)
+                else:
+                    updated_hist = torch.cat(
+                        [conv_hist[:, :, 1:], mixed_qkv.unsqueeze(-1)], dim=-1
+                    )
+                rt.conv_cache.index_copy_(0, slots, updated_hist)
+            return out
+
+        return triton_causal_conv1d_update(
+            x=mixed_qkv,
+            conv_state=rt.conv_cache,
+            weight=weight_2d.contiguous(),
+            bias=None,
+            activation="silu",
+            conv_state_indices=state_indices_i32,
+            pad_slot_id=PAD_SLOT_ID,
+        )
+
+    def forward_decode(
+        self,
+        q: torch.Tensor | None = None,
+        k: torch.Tensor | None = None,
+        v: torch.Tensor | None = None,
+        layer=None,
+        forward_batch=None,
+        save_kv_cache: bool = True,
+        mixed_qkv: torch.Tensor | None = None,
+        a: torch.Tensor | None = None,
+        b: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        del q, k, v, save_kv_cache, kwargs
+        if layer is None or forward_batch is None:
+            raise ValueError("layer and forward_batch are required for GDN decode.")
+        if mixed_qkv is None or a is None or b is None:
+            raise ValueError("mixed_qkv, a and b are required for GDN decode.")
+
+        reqs = forward_batch.reqs
+        if not reqs:
+            return mixed_qkv.new_empty((1, 0, layer.num_v_heads, layer.head_v_dim))
+        conv_weight = layer.conv_weights
+        if not isinstance(conv_weight, torch.Tensor):
+            raise ValueError("conv_weights must be a Tensor in RadixLinearAttention.")
+        if layer.A_log is None or layer.dt_bias is None:
+            raise ValueError("A_log/dt_bias are required in RadixLinearAttention.")
+
+        rt = self._ensure_runtime(layer, mixed_qkv)
+        state_indices_i32 = self._get_decode_state_indices(reqs, mixed_qkv.device, forward_batch)
+        conv_qkv = self._apply_conv_decode_batch(
+            mixed_qkv,
+            conv_weight,
+            rt,
+            state_indices_i32=state_indices_i32,
+        )
+        core = gdn_packed_decode(
+            mixed_qkv=conv_qkv.contiguous(),
+            a=a.contiguous(),
+            b=b.contiguous(),
+            A_log=layer.A_log.contiguous(),
+            dt_bias=layer.dt_bias.contiguous(),
+            state=rt.ssm_cache,
+            state_indices=state_indices_i32,
+            num_q_heads=layer.num_q_heads,
+            num_v_heads=layer.num_v_heads,
+            head_k_dim=layer.head_k_dim,
+            head_v_dim=layer.head_v_dim,
+            scale=layer.head_k_dim**-0.5,
+        )
+        return core.unsqueeze(0)
+
+    def forward_extend(
+        self,
+        q: torch.Tensor | None = None,
+        k: torch.Tensor | None = None,
+        v: torch.Tensor | None = None,
+        layer=None,
+        forward_batch=None,
+        save_kv_cache: bool = True,
+        mixed_qkv: torch.Tensor | None = None,
+        a: torch.Tensor | None = None,
+        b: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        del q, k, v, save_kv_cache, kwargs
+        if layer is None or forward_batch is None:
+            raise ValueError("layer and forward_batch are required for GDN extend.")
+        if mixed_qkv is None or a is None or b is None:
+            raise ValueError("mixed_qkv, a and b are required for GDN extend.")
+
+        reqs = forward_batch.reqs
+        if not reqs:
+            return mixed_qkv.new_empty((1, 0, layer.num_v_heads, layer.head_v_dim))
+
+        conv_weight = layer.conv_weights
+        if not isinstance(conv_weight, torch.Tensor):
+            raise ValueError("conv_weights must be a Tensor in RadixLinearAttention.")
+        if layer.A_log is None or layer.dt_bias is None:
+            raise ValueError("A_log/dt_bias are required in RadixLinearAttention.")
+
+        rt = self._ensure_runtime(layer, mixed_qkv)
+        conv_qkv = self._apply_conv_batch(mixed_qkv, reqs, conv_weight, rt)
+        out = torch.empty(
+            conv_qkv.shape[0],
+            layer.num_v_heads,
+            layer.head_v_dim,
+            dtype=conv_qkv.dtype,
+            device=conv_qkv.device,
+        )
+        req_layout: list[tuple[int, int, int]] = []
+        max_extend_len = 0
+        offset = 0
+        for req in reqs:
+            length = req.extend_len
+            if length > 0:
+                req_layout.append((req.table_idx, offset, length))
+                max_extend_len = max(max_extend_len, length)
+            offset += length
+
+        for step in range(max_extend_len):
+            token_indices = [start + step for _, start, length in req_layout if step < length]
+            if not token_indices:
+                continue
+            indices = torch.tensor(token_indices, dtype=torch.int64, device=conv_qkv.device)
+            state_slots = [slot for slot, _, length in req_layout if step < length]
+            state_indices = torch.tensor(state_slots, dtype=torch.int32, device=conv_qkv.device)
+            core_step = gdn_packed_decode(
+                mixed_qkv=conv_qkv.index_select(0, indices).contiguous(),
+                a=a.index_select(0, indices).contiguous(),
+                b=b.index_select(0, indices).contiguous(),
+                A_log=layer.A_log.contiguous(),
+                dt_bias=layer.dt_bias.contiguous(),
+                state=rt.ssm_cache,
+                state_indices=state_indices,
+                num_q_heads=layer.num_q_heads,
+                num_v_heads=layer.num_v_heads,
+                head_k_dim=layer.head_k_dim,
+                head_v_dim=layer.head_v_dim,
+                scale=layer.head_k_dim**-0.5,
+            )
+            out.index_copy_(0, indices, core_step.to(dtype=out.dtype))
+        return out.unsqueeze(0)
+
+    def forward(
+        self,
+        q: torch.Tensor | None = None,
+        k: torch.Tensor | None = None,
+        v: torch.Tensor | None = None,
+        layer=None,
+        forward_batch=None,
+        save_kv_cache: bool = True,
+        mixed_qkv: torch.Tensor | None = None,
+        a: torch.Tensor | None = None,
+        b: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        if layer is None or forward_batch is None:
+            raise ValueError("layer and forward_batch are required for GDN forward.")
+        if mixed_qkv is None or a is None or b is None:
+            raise ValueError("mixed_qkv, a and b are required for GDN forward.")
+
+        reqs = forward_batch.reqs
+        if not reqs:
+            return mixed_qkv.new_empty((1, 0, layer.num_v_heads, layer.head_v_dim))
+
+        if forward_batch.forward_mode.is_idle():
+            return mixed_qkv.new_empty((mixed_qkv.shape[0], layer.num_v_heads, layer.head_v_dim))
+        if forward_batch.forward_mode.is_decode():
+            return self.forward_decode(
+                q=q,
+                k=k,
+                v=v,
+                layer=layer,
+                forward_batch=forward_batch,
+                save_kv_cache=save_kv_cache,
+                mixed_qkv=mixed_qkv,
+                a=a,
+                b=b,
+                **kwargs,
+            )
+        return self.forward_extend(
+            q=q,
+            k=k,
+            v=v,
+            layer=layer,
+            forward_batch=forward_batch,
+            save_kv_cache=save_kv_cache,
+            mixed_qkv=mixed_qkv,
+            a=a,
+            b=b,
+            **kwargs,
+        )
+
+
+class HybridLinearBackend(BaseAttnBackend):
+    """Dispatches full attention and GDN linear attention like sglang hybrid backend."""
+
+    def __init__(self, full_backend: BaseAttnBackend):
+        self.full_backend = full_backend
+        self.gdn_backend = GDNAttnBackend()
+
+    def on_table_slot_allocated(self, slot: int) -> None:
+        self.gdn_backend.on_table_slot_allocated(slot)
+
+    def has_prefix_cache_state(self, handle: BaseCacheHandle) -> bool:
+        return self.gdn_backend.has_prefix_cache_state(handle)
+
+    def on_prefix_cache_store(self, req: Req, handle: BaseCacheHandle) -> None:
+        self.gdn_backend.on_prefix_cache_store(req, handle)
+
+    def on_prefix_cache_match(self, handle: BaseCacheHandle, slot: int) -> None:
+        self.gdn_backend.on_prefix_cache_match(handle, slot)
+
+    def forward(
+        self,
+        q: torch.Tensor | None = None,
+        k: torch.Tensor | None = None,
+        v: torch.Tensor | None = None,
+        layer=None,
+        forward_batch=None,
+        save_kv_cache: bool = True,
+        mixed_qkv: torch.Tensor | None = None,
+        a: torch.Tensor | None = None,
+        b: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        if layer is None or forward_batch is None:
+            raise ValueError("layer and forward_batch are required for hybrid attention backend.")
+        if forward_batch.forward_mode.is_idle():
+            if mixed_qkv is not None:
+                return mixed_qkv.new_empty(
+                    (mixed_qkv.shape[0], layer.num_v_heads, layer.head_v_dim)
+                )
+            if q is None:
+                raise ValueError("q is required in idle mode for full attention path.")
+            return q.new_empty((q.shape[0], layer.tp_q_head_num * layer.v_head_dim))
+        if forward_batch.forward_mode.is_decode():
+            return self.forward_decode(
+                q=q,
+                k=k,
+                v=v,
+                layer=layer,
+                forward_batch=forward_batch,
+                save_kv_cache=save_kv_cache,
+                mixed_qkv=mixed_qkv,
+                a=a,
+                b=b,
+                **kwargs,
+            )
+        return self.forward_extend(
+            q=q,
+            k=k,
+            v=v,
+            layer=layer,
+            forward_batch=forward_batch,
+            save_kv_cache=save_kv_cache,
+            mixed_qkv=mixed_qkv,
+            a=a,
+            b=b,
+            **kwargs,
+        )
+
+    def forward_decode(
+        self,
+        q: torch.Tensor | None = None,
+        k: torch.Tensor | None = None,
+        v: torch.Tensor | None = None,
+        layer=None,
+        forward_batch=None,
+        save_kv_cache: bool = True,
+        mixed_qkv: torch.Tensor | None = None,
+        a: torch.Tensor | None = None,
+        b: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        if mixed_qkv is not None:
+            return self.gdn_backend.forward_decode(
+                q=q,
+                k=k,
+                v=v,
+                layer=layer,
+                forward_batch=forward_batch,
+                save_kv_cache=save_kv_cache,
+                mixed_qkv=mixed_qkv,
+                a=a,
+                b=b,
+                **kwargs,
+            )
+        if q is None or k is None or v is None:
+            raise ValueError("q/k/v are required for full attention decode path.")
+        return self.full_backend.forward(
+            q=q,
+            k=k,
+            v=v,
+            layer=layer,
+            forward_batch=forward_batch,
+            save_kv_cache=save_kv_cache,
+            **kwargs,
+        )
+
+    def forward_extend(
+        self,
+        q: torch.Tensor | None = None,
+        k: torch.Tensor | None = None,
+        v: torch.Tensor | None = None,
+        layer=None,
+        forward_batch=None,
+        save_kv_cache: bool = True,
+        mixed_qkv: torch.Tensor | None = None,
+        a: torch.Tensor | None = None,
+        b: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        if mixed_qkv is not None:
+            return self.gdn_backend.forward_extend(
+                q=q,
+                k=k,
+                v=v,
+                layer=layer,
+                forward_batch=forward_batch,
+                save_kv_cache=save_kv_cache,
+                mixed_qkv=mixed_qkv,
+                a=a,
+                b=b,
+                **kwargs,
+            )
+        if q is None or k is None or v is None:
+            raise ValueError("q/k/v are required for full attention extend path.")
+        return self.full_backend.forward(
+            q=q,
+            k=k,
+            v=v,
+            layer=layer,
+            forward_batch=forward_batch,
+            save_kv_cache=save_kv_cache,
+            **kwargs,
+        )
+
+    def prepare_metadata(self, batch) -> None:
+        return self.full_backend.prepare_metadata(batch)
+
+    def init_capture_graph(self, max_seq_len: int, bs_list: List[int]) -> None:
+        self.gdn_backend.init_capture_graph(bs_list)
+        return self.full_backend.init_capture_graph(max_seq_len, bs_list)
+
+    def prepare_for_capture(self, batch) -> None:
+        self.gdn_backend.prepare_for_capture(batch)
+        return self.full_backend.prepare_for_capture(batch)
+
+    def prepare_for_replay(self, batch) -> None:
+        self.gdn_backend.prepare_for_replay(batch)
+        return self.full_backend.prepare_for_replay(batch)
+
+
+__all__ = ["GDNAttnBackend", "HybridLinearBackend"]

--- a/python/minisgl/attention/trtllm.py
+++ b/python/minisgl/attention/trtllm.py
@@ -47,15 +47,29 @@ class TensorRTLLMBackend(BaseAttnBackend):
         )
 
     def forward(
-        self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, layer_id: int, batch: Batch
+        self,
+        q: torch.Tensor | None = None,
+        k: torch.Tensor | None = None,
+        v: torch.Tensor | None = None,
+        layer=None,
+        forward_batch=None,
+        save_kv_cache: bool = True,
+        **kwargs,
     ) -> torch.Tensor:
+        if q is None or k is None or v is None or layer is None or forward_batch is None:
+            raise ValueError("q/k/v/layer/forward_batch are required for TensorRTLLMBackend.")
+        batch = forward_batch.batch
         from flashinfer.decode import trtllm_batch_decode_with_kv_cache
         from flashinfer.prefill import trtllm_batch_context_with_kv_cache
 
         metadata = batch.attn_metadata
         assert isinstance(metadata, TRTLLMMetadata)
-        self.kvcache.store_kv(k, v, batch.out_loc, layer_id)
-        kv_cache = (self.kvcache.k_cache(layer_id), self.kvcache.v_cache(layer_id))
+        if save_kv_cache:
+            self.kvcache.store_kv(k, v, batch.out_loc, layer.layer_id)
+        kv_cache = (
+            self.kvcache.k_cache(layer.layer_id),
+            self.kvcache.v_cache(layer.layer_id),
+        )
 
         if batch.is_prefill:
             return trtllm_batch_context_with_kv_cache(

--- a/python/minisgl/compilation/__init__.py
+++ b/python/minisgl/compilation/__init__.py
@@ -1,0 +1,10 @@
+from .compilation_config import register_split_op
+from .piecewise_context_manager import ForwardContext, get_forward_context, set_forward_context
+
+__all__ = [
+    "register_split_op",
+    "ForwardContext",
+    "get_forward_context",
+    "set_forward_context",
+]
+

--- a/python/minisgl/compilation/compilation_config.py
+++ b/python/minisgl/compilation/compilation_config.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Any, Callable, TypeVar
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def register_split_op() -> Callable[[F], F]:
+    """Compatibility decorator (no-op in minisgl)."""
+
+    def decorator(func: F) -> F:
+        setattr(func, "__minisgl_split_op__", True)
+        return func
+
+    return decorator
+

--- a/python/minisgl/compilation/piecewise_context_manager.py
+++ b/python/minisgl/compilation/piecewise_context_manager.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any, Iterator
+
+
+@dataclass
+class ForwardContext:
+    forward_batch: Any
+    attention_layers: list[Any]
+
+
+_FORWARD_CONTEXT: ContextVar[ForwardContext | None] = ContextVar(
+    "minisgl_forward_context", default=None
+)
+
+
+def get_forward_context() -> ForwardContext | None:
+    return _FORWARD_CONTEXT.get()
+
+
+@contextmanager
+def set_forward_context(
+    *,
+    forward_batch: Any,
+    attention_layers: list[Any],
+) -> Iterator[None]:
+    token = _FORWARD_CONTEXT.set(
+        ForwardContext(
+            forward_batch=forward_batch,
+            attention_layers=attention_layers,
+        )
+    )
+    try:
+        yield
+    finally:
+        _FORWARD_CONTEXT.reset(token)

--- a/python/minisgl/core.py
+++ b/python/minisgl/core.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, List, Literal
+from typing import TYPE_CHECKING, Any, Dict, List, Literal
 
 import torch
 
@@ -19,6 +19,9 @@ class SamplingParams:
     top_p: float = 1.0
     ignore_eos: bool = False
     max_tokens: int = 1024
+    stream: bool = True
+    reasoning_effort: str | None = None
+    chat_template_kwargs: Dict[str, Any] | None = None
 
     @property
     def is_greedy(self) -> bool:

--- a/python/minisgl/engine/engine.py
+++ b/python/minisgl/engine/engine.py
@@ -5,10 +5,12 @@ from typing import Any, Dict, NamedTuple, Tuple
 
 import torch
 from minisgl.attention import create_attention_backend
+from minisgl.compilation import set_forward_context
 from minisgl.core import Batch, Context, Req, set_global_ctx
 from minisgl.distributed import destroy_distributed, enable_pynccl_distributed, set_tp_info
 from minisgl.kvcache import create_kvcache_pool
 from minisgl.layers import set_rope_device
+from minisgl.model_executor import ForwardBatch
 from minisgl.models import create_model, load_weight
 from minisgl.moe import create_moe_backend
 from minisgl.utils import div_even, init_logger, is_sm90_supported, is_sm100_supported, torch_dtype
@@ -50,6 +52,7 @@ class Engine:
         with torch.device("meta"), torch_dtype(config.dtype):
             self.model = create_model(config.model_config)
         self.model.load_state_dict(self._load_weight_state_dict(config))
+        self.attention_layers = _collect_attention_layers(self.model)
 
         # ======================= KV cache initialization ========================
         self.num_pages = self._determine_num_pages(init_free_memory, config)
@@ -107,6 +110,7 @@ class Engine:
             max_seq_len=aligned_max_seq_len,
             vocab_size=config.model_config.vocab_size,
             dummy_req=self.dummy_req,
+            attention_layers=self.attention_layers,
         )
 
     def _init_communication(self, config: EngineConfig) -> torch.distributed.ProcessGroup:
@@ -191,10 +195,17 @@ class Engine:
     def forward_batch(self, batch: Batch, args: BatchSamplingArgs) -> ForwardOutput:
         assert torch.cuda.current_stream() == self.stream
         with self.ctx.forward_batch(batch):
+            forward_batch = ForwardBatch.from_batch(batch, attn_backend=self.attn_backend)
+            forward_ctx = set_forward_context(
+                forward_batch=forward_batch,
+                attention_layers=self.attention_layers,
+            )
             if self.graph_runner.can_use_cuda_graph(batch):
-                logits = self.graph_runner.replay(batch)
+                with forward_ctx:
+                    logits = self.graph_runner.replay(batch)
             else:
-                logits = self.model.forward()
+                with forward_ctx:
+                    logits = self.model.forward()
 
         for req in batch.reqs:
             req.complete_one()
@@ -231,3 +242,21 @@ def _adjust_config(config: EngineConfig):
     if config.model_config.is_moe and config.moe_backend == "auto":
         override("moe_backend", "fused")
         logger.info_rank0(f"Auto-selected MoE backend: {config.moe_backend}")
+
+def _collect_attention_layers(model: Any) -> list[Any]:
+    layers: list[Any] = []
+    root = getattr(model, "model", None)
+    op_list = getattr(getattr(root, "layers", None), "op_list", None)
+    if not isinstance(op_list, list):
+        return layers
+
+    for layer in op_list:
+        if hasattr(layer, "self_attn"):
+            layers.append(layer.self_attn)
+        elif hasattr(layer, "linear_attn") and hasattr(layer.linear_attn, "attn"):
+            layers.append(layer.linear_attn.attn)
+        elif hasattr(layer, "linear_attn"):
+            layers.append(layer.linear_attn)
+        else:
+            layers.append(None)
+    return layers

--- a/python/minisgl/engine/graph.py
+++ b/python/minisgl/engine/graph.py
@@ -5,8 +5,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List
 
 import torch
+from minisgl.compilation import set_forward_context
 from minisgl.core import Batch, Req, get_global_ctx
 from minisgl.distributed import get_tp_info
+from minisgl.model_executor import ForwardBatch
 from minisgl.utils import init_logger
 from tqdm import tqdm
 
@@ -88,6 +90,7 @@ class GraphRunner:
         max_seq_len: int,
         vocab_size: int,
         dummy_req: Req,
+        attention_layers: list[object],
     ) -> None:
         cuda_graph_bs = _determine_cuda_graph_bs(
             cuda_graph_bs=cuda_graph_bs,
@@ -100,6 +103,7 @@ class GraphRunner:
         self.dummy_req = dummy_req
         self.stream = stream
         self.device = device
+        self.attention_layers = attention_layers
         self._capture_graphs(max_seq_len, vocab_size, model)
 
     def _capture_graphs(self, max_seq_len: int, vocab_size: int, model: BaseLLMModel):
@@ -136,9 +140,13 @@ class GraphRunner:
             self.attn_backend.prepare_for_capture(batch)
             self.buffer.set_batch(batch)
             with get_global_ctx().forward_batch(batch):
-                self.buffer.logits[:bs] = model.forward()
-                with torch.cuda.graph(graph, pool=pool, stream=self.stream):
+                with set_forward_context(
+                    forward_batch=ForwardBatch.from_batch(batch, attn_backend=self.attn_backend),
+                    attention_layers=self.attention_layers,
+                ):
                     self.buffer.logits[:bs] = model.forward()
+                    with torch.cuda.graph(graph, pool=pool, stream=self.stream):
+                        self.buffer.logits[:bs] = model.forward()
             if pool is None:
                 pool = graph.pool()  # reuse cuda graph handle to reduce memory
             self.graph_map[bs] = graph

--- a/python/minisgl/kernel/triton/causal_conv1d.py
+++ b/python/minisgl/kernel/triton/causal_conv1d.py
@@ -1,0 +1,528 @@
+from __future__ import annotations
+
+# SPDX-License-Identifier: Apache-2.0
+# Adapted from sglang/vllm causal conv1d Triton implementation.
+
+from typing import Optional, Union
+
+import torch
+import triton
+import triton.language as tl
+
+PAD_SLOT_ID = -1
+
+
+@triton.jit()
+def _causal_conv1d_update_kernel(
+    x_ptr,
+    w_ptr,
+    bias_ptr,
+    conv_state_ptr,
+    cache_seqlens_ptr,
+    conv_state_indices_ptr,
+    num_accept_tokens_ptr,
+    intermediate_conv_window_ptr,
+    intermediate_state_indices_ptr,
+    retrieve_next_token_ptr,
+    retrieve_next_sibling_ptr,
+    retrieve_parent_token_ptr,
+    o_ptr,
+    batch: int,
+    dim: tl.constexpr,
+    seqlen: tl.constexpr,
+    state_len: tl.constexpr,
+    num_cache_lines: tl.constexpr,
+    stride_x_seq: tl.constexpr,
+    stride_x_dim: tl.constexpr,
+    stride_x_token: tl.constexpr,
+    stride_w_dim: tl.constexpr,
+    stride_w_width: tl.constexpr,
+    stride_conv_state_seq: tl.constexpr,
+    stride_conv_state_dim: tl.constexpr,
+    stride_conv_state_tok: tl.constexpr,
+    stride_state_indices: tl.constexpr,
+    stride_inter_seq: tl.constexpr,
+    stride_inter_step: tl.constexpr,
+    stride_inter_dim: tl.constexpr,
+    stride_inter_win: tl.constexpr,
+    stride_intermediate_state_indices: tl.constexpr,
+    stride_retrieve_next_token_seq: tl.constexpr,
+    stride_retrieve_next_token_token: tl.constexpr,
+    stride_retrieve_next_sibling_seq: tl.constexpr,
+    stride_retrieve_next_sibling_token: tl.constexpr,
+    stride_retrieve_parent_token_seq: tl.constexpr,
+    stride_retrieve_parent_token_token: tl.constexpr,
+    stride_o_seq: tl.constexpr,
+    stride_o_dim: tl.constexpr,
+    stride_o_token: tl.constexpr,
+    pad_slot_id: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    KERNEL_WIDTH: tl.constexpr,
+    SILU_ACTIVATION: tl.constexpr,
+    IS_CONTINUOUS_BATCHING: tl.constexpr,
+    IS_SPEC_DECODING: tl.constexpr,
+    NP2_STATELEN: tl.constexpr,
+    NP2_SEQLEN: tl.constexpr,
+    USE_PAD_SLOT: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    SAVE_INTERMEDIATE: tl.constexpr,
+    HAS_EAGLE_TREE_CUSTOM_ATTN_MASK: tl.constexpr,
+):
+    idx_seq = tl.program_id(0)
+    if idx_seq >= batch:
+        return
+
+    idx_feats = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    if IS_CONTINUOUS_BATCHING:
+        conv_state_batch_coord = tl.load(
+            conv_state_indices_ptr + idx_seq * stride_state_indices
+        ).to(tl.int64)
+        if SAVE_INTERMEDIATE:
+            intermediate_state_batch_coord = tl.load(
+                intermediate_state_indices_ptr + idx_seq * stride_intermediate_state_indices
+            ).to(tl.int64)
+    else:
+        conv_state_batch_coord = idx_seq
+
+    if USE_PAD_SLOT:
+        if conv_state_batch_coord == pad_slot_id:
+            return
+
+    if IS_SPEC_DECODING:
+        conv_state_token_offset = tl.load(num_accept_tokens_ptr + idx_seq) - 1
+    else:
+        conv_state_token_offset = 0
+
+    conv_states_base = (
+        conv_state_ptr
+        + (conv_state_batch_coord * stride_conv_state_seq)
+        + (idx_feats * stride_conv_state_dim)
+    )
+    mask_w = idx_feats < dim
+
+    prior_tokens = conv_states_base + conv_state_token_offset * stride_conv_state_tok
+    if KERNEL_WIDTH >= 2:
+        conv_states_ptrs = prior_tokens
+        col0 = tl.load(conv_states_ptrs, mask_w, 0.0)
+    if KERNEL_WIDTH >= 3:
+        conv_states_ptrs = prior_tokens + 1 * stride_conv_state_tok
+        col1 = tl.load(conv_states_ptrs, mask_w, 0.0)
+    if KERNEL_WIDTH >= 4:
+        conv_states_ptrs = prior_tokens + 2 * stride_conv_state_tok
+        col2 = tl.load(conv_states_ptrs, mask_w, 0.0)
+    if KERNEL_WIDTH == 5:
+        conv_states_ptrs = prior_tokens + 3 * stride_conv_state_tok
+        col3 = tl.load(conv_states_ptrs, mask_w, 0.0)
+
+    idx_tokens = tl.arange(0, NP2_STATELEN)
+
+    conv_state_ptrs_source = (
+        conv_state_ptr
+        + (conv_state_batch_coord * stride_conv_state_seq)
+        + conv_state_token_offset * stride_conv_state_tok
+        + (idx_feats * stride_conv_state_dim)[None, :]
+        + ((idx_tokens + (1 if IS_SPEC_DECODING else seqlen)) * stride_conv_state_tok)[:, None]
+    )
+    mask = (
+        (conv_state_batch_coord < num_cache_lines)
+        & ((idx_tokens + seqlen) < state_len)[:, None]
+        & (idx_feats < dim)[None, :]
+    )
+    conv_state = tl.load(conv_state_ptrs_source, mask, other=0.0)
+
+    val = state_len - seqlen
+    x_base = x_ptr + (idx_seq * stride_x_seq) + (idx_feats * stride_x_dim)
+    x_ptrs = x_base[None, :] + ((idx_tokens - val) * stride_x_token)[:, None]
+    mask_x = (
+        (idx_tokens - val >= 0)[:, None]
+        & (idx_tokens - val < seqlen)[:, None]
+        & (idx_feats < dim)[None, :]
+    )
+    loaded_x = tl.load(x_ptrs, mask_x, 0.0)
+    tl.debug_barrier()
+
+    new_conv_state = tl.where(mask, conv_state, loaded_x)
+
+    conv_state_base = (
+        conv_state_ptr
+        + (conv_state_batch_coord * stride_conv_state_seq)
+        + (idx_feats * stride_conv_state_dim)
+    )
+    conv_state_ptrs_target = conv_state_base + (idx_tokens * stride_conv_state_tok)[:, None]
+    mask = (idx_tokens < state_len)[:, None] & (idx_feats < dim)[None, :]
+    tl.store(conv_state_ptrs_target, new_conv_state, mask)
+
+    if HAS_BIAS:
+        bias = bias_ptr + idx_feats
+        mask_bias = idx_feats < dim
+        acc_preload = tl.load(bias, mask=mask_bias, other=0.0).to(tl.float32)
+    else:
+        acc_preload = tl.zeros((BLOCK_N,), dtype=tl.float32)
+
+    if HAS_EAGLE_TREE_CUSTOM_ATTN_MASK:
+        idx_tokens = tl.arange(0, NP2_SEQLEN)
+        mask_retrieve = idx_tokens < seqlen
+        retrieve_next_token_base = (
+            retrieve_next_token_ptr
+            + (idx_seq * stride_retrieve_next_token_seq)
+            + idx_tokens * stride_retrieve_next_token_token
+        )
+        retrieve_next_tokens = tl.load(retrieve_next_token_base, mask_retrieve)
+        retrieve_next_sibling_base = (
+            retrieve_next_sibling_ptr
+            + (idx_seq * stride_retrieve_next_sibling_seq)
+            + idx_tokens * stride_retrieve_next_sibling_token
+        )
+        retrieve_next_siblings = tl.load(retrieve_next_sibling_base, mask_retrieve)
+        parent_idx_tokens = tl.zeros((NP2_SEQLEN,), dtype=tl.int32)
+
+    w_base = w_ptr + (idx_feats * stride_w_dim)
+    mask_w = idx_feats < dim
+    if KERNEL_WIDTH >= 2:
+        w_ptrs = w_base + (0 * stride_w_width)
+        w_col0 = tl.load(w_ptrs, mask_w, other=0.0)
+        w_ptrs = w_base + (1 * stride_w_width)
+        w_col1 = tl.load(w_ptrs, mask_w, other=0.0)
+    if KERNEL_WIDTH >= 3:
+        w_ptrs = w_base + (2 * stride_w_width)
+        w_col2 = tl.load(w_ptrs, mask_w, other=0.0)
+    if KERNEL_WIDTH >= 4:
+        w_ptrs = w_base + (3 * stride_w_width)
+        w_col3 = tl.load(w_ptrs, mask_w, other=0.0)
+
+    x_base_1d = x_base
+    mask_x_1d = idx_feats < dim
+
+    for idx_token in tl.static_range(seqlen):
+        acc = acc_preload
+
+        if HAS_EAGLE_TREE_CUSTOM_ATTN_MASK:
+            retrieve_next_token_idx = tl.sum(
+                tl.where(idx_tokens == idx_token, retrieve_next_tokens, 0)
+            )
+            if retrieve_next_token_idx != -1:
+                parent_idx_tokens = tl.where(
+                    idx_tokens == retrieve_next_token_idx,
+                    idx_token,
+                    parent_idx_tokens,
+                )
+            retrieve_sibling_token_idx = tl.sum(
+                tl.where(idx_tokens == idx_token, retrieve_next_siblings, 0)
+            )
+            if retrieve_sibling_token_idx != -1:
+                parent_idx_token = tl.sum(
+                    tl.where(idx_tokens == idx_token, parent_idx_tokens, 0)
+                )
+                parent_idx_tokens = tl.where(
+                    idx_tokens == retrieve_sibling_token_idx,
+                    parent_idx_token,
+                    parent_idx_tokens,
+                )
+
+            _idx_token = idx_token
+            x_ptrs_1d = x_base_1d + _idx_token * stride_x_token
+            matrix_x = tl.load(x_ptrs_1d, mask=mask_x_1d)
+            for j in tl.static_range(KERNEL_WIDTH):
+                if KERNEL_WIDTH == 2:
+                    if j == 0:
+                        matrix_w = w_col1
+                    else:
+                        matrix_w = w_col0
+                elif KERNEL_WIDTH == 3:
+                    if j == 0:
+                        matrix_w = w_col2
+                    elif j == 1:
+                        matrix_w = w_col1
+                    else:
+                        matrix_w = w_col0
+                elif KERNEL_WIDTH == 4:
+                    if j == 0:
+                        matrix_w = w_col3
+                    elif j == 1:
+                        matrix_w = w_col2
+                    elif j == 2:
+                        matrix_w = w_col1
+                    else:
+                        matrix_w = w_col0
+
+                if SAVE_INTERMEDIATE:
+                    base_ptr = (
+                        intermediate_conv_window_ptr
+                        + intermediate_state_batch_coord * stride_inter_seq
+                        + idx_token * stride_inter_step
+                        + idx_feats * stride_inter_dim
+                    )
+                    if KERNEL_WIDTH - j - 2 >= 0:
+                        tl.store(
+                            base_ptr + (KERNEL_WIDTH - j - 2) * stride_inter_win,
+                            matrix_x,
+                            mask=mask_w,
+                        )
+
+                acc += matrix_x * matrix_w
+
+                if _idx_token > 0:
+                    _idx_token = tl.sum(
+                        tl.where(idx_tokens == _idx_token, parent_idx_tokens, 0)
+                    )
+                    x_ptrs_1d = x_base_1d + _idx_token * stride_x_token
+                    matrix_x = tl.load(x_ptrs_1d, mask=mask_x_1d)
+                else:
+                    if KERNEL_WIDTH == 2:
+                        if _idx_token == 0:
+                            matrix_x = col0
+                    elif KERNEL_WIDTH == 3:
+                        if _idx_token == 0:
+                            matrix_x = col1
+                        else:
+                            matrix_x = col0
+                    elif KERNEL_WIDTH == 4:
+                        if _idx_token == 0:
+                            matrix_x = col2
+                        elif _idx_token == -1:
+                            matrix_x = col1
+                        else:
+                            matrix_x = col0
+                    _idx_token = _idx_token - 1
+        else:
+            matrix_w = w_col0
+            matrix_x = col0
+
+            for j in tl.static_range(KERNEL_WIDTH):
+                if KERNEL_WIDTH == 2:
+                    if j == 1:
+                        matrix_w = w_col1
+                        x_ptrs_1d = x_base_1d + idx_token * stride_x_token
+                        matrix_x = tl.load(x_ptrs_1d, mask=mask_x_1d)
+                elif KERNEL_WIDTH == 3:
+                    if j == 1:
+                        matrix_w = w_col1
+                        matrix_x = col1
+                    elif j == 2:
+                        matrix_w = w_col2
+                        x_ptrs_1d = x_base_1d + idx_token * stride_x_token
+                        matrix_x = tl.load(x_ptrs_1d, mask=mask_x_1d)
+                elif KERNEL_WIDTH == 4:
+                    if j == 1:
+                        matrix_w = w_col1
+                        matrix_x = col1
+                    elif j == 2:
+                        matrix_w = w_col2
+                        matrix_x = col2
+                    elif j == 3:
+                        matrix_w = w_col3
+                        x_ptrs_1d = x_base_1d + idx_token * stride_x_token
+                        matrix_x = tl.load(x_ptrs_1d, mask=mask_x_1d)
+
+                acc += matrix_x * matrix_w
+
+            if KERNEL_WIDTH == 2:
+                col0 = matrix_x
+            elif KERNEL_WIDTH == 3:
+                col0 = col1
+                col1 = matrix_x
+            elif KERNEL_WIDTH == 4:
+                col0 = col1
+                col1 = col2
+                col2 = matrix_x
+
+            if SAVE_INTERMEDIATE:
+                base_ptr = (
+                    intermediate_conv_window_ptr
+                    + intermediate_state_batch_coord * stride_inter_seq
+                    + idx_token * stride_inter_step
+                    + idx_feats * stride_inter_dim
+                )
+                if KERNEL_WIDTH >= 2:
+                    tl.store(base_ptr + 0 * stride_inter_win, col0, mask=mask_w)
+                if KERNEL_WIDTH >= 3:
+                    tl.store(base_ptr + 1 * stride_inter_win, col1, mask=mask_w)
+                if KERNEL_WIDTH >= 4:
+                    tl.store(base_ptr + 2 * stride_inter_win, col2, mask=mask_w)
+
+        if SILU_ACTIVATION:
+            acc = acc / (1 + tl.exp(-acc))
+        mask_1d = (idx_token < seqlen) & (idx_feats < dim)
+        o_ptrs = (
+            o_ptr
+            + (idx_seq) * stride_o_seq
+            + idx_token * stride_o_token
+            + (idx_feats * stride_o_dim)
+        )
+        tl.store(o_ptrs, acc, mask=mask_1d)
+
+        if HAS_EAGLE_TREE_CUSTOM_ATTN_MASK:
+            tl.store(
+                retrieve_parent_token_ptr
+                + idx_seq * stride_retrieve_parent_token_seq
+                + idx_tokens * stride_retrieve_parent_token_token,
+                parent_idx_tokens,
+                mask=mask_retrieve,
+            )
+
+
+def causal_conv1d_update(
+    x: torch.Tensor,
+    conv_state: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    activation: Union[bool, str, None] = None,
+    cache_seqlens: Optional[torch.Tensor] = None,
+    conv_state_indices: Optional[torch.Tensor] = None,
+    num_accept_tokens: Optional[torch.Tensor] = None,
+    intermediate_conv_window: Optional[torch.Tensor] = None,
+    intermediate_state_indices: Optional[torch.Tensor] = None,
+    retrieve_next_token: Optional[torch.Tensor] = None,
+    retrieve_next_sibling: Optional[torch.Tensor] = None,
+    retrieve_parent_token: Optional[torch.Tensor] = None,
+    pad_slot_id: int = PAD_SLOT_ID,
+    validate_data: bool = False,
+):
+    if isinstance(activation, bool):
+        activation = "silu" if activation is True else None
+    elif activation is not None:
+        assert activation in ["silu", "swish"]
+
+    unsqueeze = x.dim() == 2
+    if unsqueeze:
+        x = x.unsqueeze(-1)
+
+    batch, dim, seqlen = x.shape
+    _, width = weight.shape
+    num_cache_lines, _, state_len = conv_state.size()
+
+    if validate_data:
+        assert dim == weight.size(0)
+        assert state_len >= width - 1
+        assert dim == conv_state.size(1)
+        if conv_state_indices is None:
+            assert conv_state.size(0) >= batch
+        else:
+            assert (batch,) == conv_state_indices.shape
+            assert intermediate_state_indices is not None
+            assert (batch,) == intermediate_state_indices.shape
+        assert num_cache_lines >= batch
+        assert weight.stride(1) == 1
+        assert cache_seqlens is None
+
+    out = torch.empty_like(x)
+    stride_w_dim, stride_w_width = weight.stride()
+    stride_x_seq, stride_x_dim, stride_x_token = x.stride()
+    stride_o_seq, stride_o_dim, stride_o_token = out.stride()
+    stride_istate_seq, stride_istate_dim, stride_istate_token = conv_state.stride()
+    stride_state_indices = (
+        conv_state_indices.stride(0) if conv_state_indices is not None else 0
+    )
+    stride_intermediate_state_indices = (
+        intermediate_state_indices.stride(0) if intermediate_state_indices is not None else 0
+    )
+    if num_accept_tokens is not None:
+        state_len = width - 1 + (seqlen - 1)
+    else:
+        state_len = width - 1
+    np2_statelen = triton.next_power_of_2(state_len)
+    np2_seqlen = triton.next_power_of_2(seqlen)
+
+    def grid(meta):
+        return (
+            batch,
+            triton.cdiv(dim, meta["BLOCK_N"]),
+        )
+
+    if intermediate_conv_window is not None:
+        stride_inter_seq, stride_inter_step, stride_inter_dim, stride_inter_win = (
+            intermediate_conv_window.stride(0),
+            intermediate_conv_window.stride(1),
+            intermediate_conv_window.stride(2),
+            intermediate_conv_window.stride(3),
+        )
+    else:
+        stride_inter_seq = stride_inter_step = stride_inter_dim = stride_inter_win = 0
+
+    if retrieve_next_token is not None:
+        stride_retrieve_next_token_seq, stride_retrieve_next_token_token = (
+            retrieve_next_token.stride(0),
+            retrieve_next_token.stride(1),
+        )
+    else:
+        stride_retrieve_next_token_seq = stride_retrieve_next_token_token = 0
+
+    if retrieve_next_sibling is not None:
+        stride_retrieve_next_sibling_seq, stride_retrieve_next_sibling_token = (
+            retrieve_next_sibling.stride(0),
+            retrieve_next_sibling.stride(1),
+        )
+    else:
+        stride_retrieve_next_sibling_seq = stride_retrieve_next_sibling_token = 0
+
+    if retrieve_parent_token is not None:
+        stride_retrieve_parent_token_seq, stride_retrieve_parent_token_token = (
+            retrieve_parent_token.stride(0),
+            retrieve_parent_token.stride(1),
+        )
+    else:
+        stride_retrieve_parent_token_seq = stride_retrieve_parent_token_token = 0
+
+    _causal_conv1d_update_kernel[grid](
+        x,
+        weight,
+        bias,
+        conv_state,
+        cache_seqlens,
+        conv_state_indices,
+        num_accept_tokens,
+        intermediate_conv_window if intermediate_conv_window is not None else x,
+        intermediate_state_indices,
+        retrieve_next_token,
+        retrieve_next_sibling,
+        retrieve_parent_token,
+        out,
+        batch,
+        dim,
+        seqlen,
+        state_len,
+        num_cache_lines,
+        stride_x_seq,
+        stride_x_dim,
+        stride_x_token,
+        stride_w_dim,
+        stride_w_width,
+        stride_istate_seq,
+        stride_istate_dim,
+        stride_istate_token,
+        stride_state_indices,
+        stride_inter_seq,
+        stride_inter_step,
+        stride_inter_dim,
+        stride_inter_win,
+        stride_intermediate_state_indices,
+        stride_retrieve_next_token_seq,
+        stride_retrieve_next_token_token,
+        stride_retrieve_next_sibling_seq,
+        stride_retrieve_next_sibling_token,
+        stride_retrieve_parent_token_seq,
+        stride_retrieve_parent_token_token,
+        stride_o_seq,
+        stride_o_dim,
+        stride_o_token,
+        pad_slot_id,
+        HAS_BIAS=bias is not None,
+        KERNEL_WIDTH=width,
+        SILU_ACTIVATION=activation in ["silu", "swish"],
+        IS_CONTINUOUS_BATCHING=conv_state_indices is not None,
+        IS_SPEC_DECODING=num_accept_tokens is not None,
+        NP2_STATELEN=np2_statelen,
+        NP2_SEQLEN=np2_seqlen,
+        USE_PAD_SLOT=pad_slot_id is not None,
+        BLOCK_N=256,
+        SAVE_INTERMEDIATE=intermediate_conv_window is not None,
+        HAS_EAGLE_TREE_CUSTOM_ATTN_MASK=retrieve_next_token is not None,
+    )
+
+    if unsqueeze:
+        out = out.squeeze(-1)
+    return out
+
+
+__all__ = ["causal_conv1d_update", "PAD_SLOT_ID"]

--- a/python/minisgl/kernel/triton/gdn_decode.py
+++ b/python/minisgl/kernel/triton/gdn_decode.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _packed_decode_kernel(
+    mixed_qkv,
+    a,
+    b,
+    A_log,
+    dt_bias,
+    out,
+    state,
+    state_indices,
+    scale,
+    stride_mixed_tok: tl.constexpr,
+    stride_a_tok: tl.constexpr,
+    stride_b_tok: tl.constexpr,
+    stride_state_slot: tl.constexpr,
+    stride_indices: tl.constexpr,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    SOFTPLUS_THRESHOLD: tl.constexpr,
+):
+    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+    i_n, i_hv = i_nh // HV, i_nh % HV
+    i_h = i_hv // (HV // H)
+
+    o_k = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    mask_k = o_k < K
+    mask_v = o_v < V
+    mask_h = mask_v[:, None] & mask_k[None, :]
+
+    slot = tl.load(state_indices + i_n * stride_indices).to(tl.int64)
+
+    p_o = out + (i_n * HV + i_hv) * V + o_v
+    if slot < 0:
+        zero = tl.zeros([BV], dtype=tl.float32).to(p_o.dtype.element_ty)
+        tl.store(p_o, zero, mask=mask_v)
+        return
+
+    p_state = state + slot * stride_state_slot
+    p_state = p_state + i_hv * V * K + o_v[:, None] * K + o_k[None, :]
+    h = tl.load(p_state, mask=mask_h, other=0).to(tl.float32)
+
+    p_mixed = mixed_qkv + i_n * stride_mixed_tok
+    q_off = i_h * K + o_k
+    k_off = (H * K) + i_h * K + o_k
+    v_off = (2 * H * K) + i_hv * V + o_v
+
+    q = tl.load(p_mixed + q_off, mask=mask_k, other=0).to(tl.float32)
+    k = tl.load(p_mixed + k_off, mask=mask_k, other=0).to(tl.float32)
+    v = tl.load(p_mixed + v_off, mask=mask_v, other=0).to(tl.float32)
+
+    q = q / tl.sqrt(tl.sum(q * q) + 1e-6)
+    k = k / tl.sqrt(tl.sum(k * k) + 1e-6)
+    q = q * scale
+
+    a_val = tl.load(a + i_n * stride_a_tok + i_hv).to(tl.float32)
+    b_val = tl.load(b + i_n * stride_b_tok + i_hv).to(tl.float32)
+    A_val = tl.load(A_log + i_hv).to(tl.float32)
+    dt_val = tl.load(dt_bias + i_hv).to(tl.float32)
+
+    x = a_val + dt_val
+    softplus_x = tl.where(x <= SOFTPLUS_THRESHOLD, tl.log(1.0 + tl.exp(x)), x)
+    g = -tl.exp(A_val) * softplus_x
+    beta = tl.sigmoid(b_val)
+
+    h = h * tl.exp(g)
+    v = v - tl.sum(h * k[None, :], axis=1)
+    v = v * beta
+    h = h + v[:, None] * k[None, :]
+    o = tl.sum(h * q[None, :], axis=1)
+
+    tl.store(p_o, o.to(p_o.dtype.element_ty), mask=mask_v)
+    tl.store(p_state, h.to(p_state.dtype.element_ty), mask=mask_h)
+
+
+def packed_decode(
+    mixed_qkv: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state: torch.Tensor,
+    state_indices: torch.Tensor,
+    num_q_heads: int,
+    num_v_heads: int,
+    head_k_dim: int,
+    head_v_dim: int,
+    scale: float,
+) -> torch.Tensor:
+    if mixed_qkv.ndim != 2 or a.ndim != 2 or b.ndim != 2:
+        raise ValueError("packed_decode expects [B, D] mixed_qkv and [B, HV] a/b.")
+    if state.ndim != 4:
+        raise ValueError("state must be [num_slots, HV, V, K].")
+    if state_indices.ndim != 1:
+        raise ValueError("state_indices must be [B].")
+    if num_q_heads <= 0 or num_v_heads <= 0:
+        raise ValueError("num_q_heads and num_v_heads must be positive.")
+
+    B = mixed_qkv.shape[0]
+    H = num_q_heads
+    HV = num_v_heads
+    K = head_k_dim
+    V = head_v_dim
+    BK = triton.next_power_of_2(K)
+    BV = min(triton.next_power_of_2(V), 32)
+
+    out = torch.empty((B, 1, HV, V), dtype=mixed_qkv.dtype, device=mixed_qkv.device)
+    grid = (triton.cdiv(V, BV), B * HV)
+    _packed_decode_kernel[grid](
+        mixed_qkv=mixed_qkv,
+        a=a,
+        b=b,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        out=out,
+        state=state,
+        state_indices=state_indices,
+        scale=scale,
+        stride_mixed_tok=mixed_qkv.stride(0),
+        stride_a_tok=a.stride(0),
+        stride_b_tok=b.stride(0),
+        stride_state_slot=state.stride(0),
+        stride_indices=state_indices.stride(0),
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        BK=BK,
+        BV=BV,
+        SOFTPLUS_THRESHOLD=20.0,
+        num_warps=1,
+        num_stages=3,
+    )
+    return out[:, 0]
+
+
+__all__ = ["packed_decode"]

--- a/python/minisgl/kernel/triton/gdn_fused_proj.py
+++ b/python/minisgl/kernel/triton/gdn_fused_proj.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def fused_qkvzba_split_reshape_cat_contiguous_kernel(
+    mixed_qkv,
+    z,
+    b,
+    a,
+    mixed_qkvz,
+    mixed_ba,
+    NUM_HEADS_QK: tl.constexpr,
+    NUM_HEADS_V: tl.constexpr,
+    HEAD_QK: tl.constexpr,
+    HEAD_V: tl.constexpr,
+):
+    i_bs, i_qk = tl.program_id(0), tl.program_id(1)
+
+    v_per_group: tl.constexpr = NUM_HEADS_V // NUM_HEADS_QK
+
+    total_q: tl.constexpr = NUM_HEADS_QK * HEAD_QK
+    total_k: tl.constexpr = NUM_HEADS_QK * HEAD_QK
+    total_v: tl.constexpr = NUM_HEADS_V * HEAD_V
+    total_qkvz: tl.constexpr = total_q + total_k + total_v + total_v
+    total_ba: tl.constexpr = NUM_HEADS_V * 2
+
+    qkv_dim_t: tl.constexpr = total_q + total_k + total_v
+
+    blk_q_ptr = mixed_qkvz + i_bs * total_qkvz + i_qk * HEAD_QK + tl.arange(0, HEAD_QK)
+    blk_k_ptr = (
+        mixed_qkvz
+        + i_bs * total_qkvz
+        + total_q
+        + i_qk * HEAD_QK
+        + tl.arange(0, HEAD_QK)
+    )
+    blk_v_ptr = (
+        mixed_qkvz
+        + i_bs * total_qkvz
+        + total_q
+        + total_k
+        + i_qk * v_per_group * HEAD_V
+        + tl.arange(0, v_per_group * HEAD_V)
+    )
+    blk_z_ptr = (
+        mixed_qkvz
+        + i_bs * total_qkvz
+        + total_q
+        + total_k
+        + total_v
+        + i_qk * v_per_group * HEAD_V
+        + tl.arange(0, v_per_group * HEAD_V)
+    )
+
+    blk_q_st_ptr = mixed_qkv + i_bs * qkv_dim_t + i_qk * HEAD_QK + tl.arange(0, HEAD_QK)
+    blk_k_st_ptr = (
+        mixed_qkv
+        + i_bs * qkv_dim_t
+        + NUM_HEADS_QK * HEAD_QK
+        + i_qk * HEAD_QK
+        + tl.arange(0, HEAD_QK)
+    )
+    blk_v_st_ptr = (
+        mixed_qkv
+        + i_bs * qkv_dim_t
+        + NUM_HEADS_QK * HEAD_QK * 2
+        + i_qk * v_per_group * HEAD_V
+        + tl.arange(0, v_per_group * HEAD_V)
+    )
+    blk_z_st_ptr = (
+        z
+        + i_bs * NUM_HEADS_V * HEAD_V
+        + i_qk * v_per_group * HEAD_V
+        + tl.arange(0, v_per_group * HEAD_V)
+    )
+
+    tl.store(blk_q_st_ptr, tl.load(blk_q_ptr))
+    tl.store(blk_k_st_ptr, tl.load(blk_k_ptr))
+    tl.store(blk_v_st_ptr, tl.load(blk_v_ptr))
+    tl.store(blk_z_st_ptr, tl.load(blk_z_ptr))
+
+    for i in tl.static_range(v_per_group):
+        blk_b_ptr = mixed_ba + i_bs * total_ba + i_qk * v_per_group + i
+        blk_b_st_ptr = b + i_bs * NUM_HEADS_V + i_qk * v_per_group + i
+        tl.store(blk_b_st_ptr, tl.load(blk_b_ptr))
+
+    for i in tl.static_range(v_per_group):
+        blk_a_ptr = mixed_ba + i_bs * total_ba + NUM_HEADS_V + i_qk * v_per_group + i
+        blk_a_st_ptr = a + i_bs * NUM_HEADS_V + i_qk * v_per_group + i
+        tl.store(blk_a_st_ptr, tl.load(blk_a_ptr))
+
+
+def fused_qkvzba_split_reshape_cat_contiguous(
+    mixed_qkvz: torch.Tensor,
+    mixed_ba: torch.Tensor,
+    num_heads_qk: int,
+    num_heads_v: int,
+    head_qk: int,
+    head_v: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    batch = mixed_qkvz.shape[0]
+    qkv_dim_t = num_heads_qk * head_qk * 2 + num_heads_v * head_v
+    mixed_qkv = torch.empty(
+        (batch, qkv_dim_t),
+        dtype=mixed_qkvz.dtype,
+        device=mixed_qkvz.device,
+    )
+    z = torch.empty(
+        (batch, num_heads_v, head_v),
+        dtype=mixed_qkvz.dtype,
+        device=mixed_qkvz.device,
+    )
+    b = torch.empty(
+        (batch, num_heads_v),
+        dtype=mixed_ba.dtype,
+        device=mixed_ba.device,
+    )
+    a = torch.empty_like(b)
+    grid = (batch, num_heads_qk)
+    fused_qkvzba_split_reshape_cat_contiguous_kernel[grid](
+        mixed_qkv,
+        z,
+        b,
+        a,
+        mixed_qkvz,
+        mixed_ba,
+        num_heads_qk,
+        num_heads_v,
+        head_qk,
+        head_v,
+        num_warps=1,
+        num_stages=3,
+    )
+    return mixed_qkv, z, b, a
+
+
+__all__ = ["fused_qkvzba_split_reshape_cat_contiguous"]

--- a/python/minisgl/layers/__init__.py
+++ b/python/minisgl/layers/__init__.py
@@ -10,7 +10,8 @@ from .linear import (
     LinearRowParallel,
 )
 from .moe import MoELayer
-from .norm import RMSNorm, RMSNormFused
+from .norm import GemmaRMSNorm, GemmaRMSNormFused, RMSNorm, RMSNormFused
+from .radix_linear_attention import RadixLinearAttention
 from .rotary import get_rope, set_rope_device
 
 __all__ = [
@@ -28,6 +29,9 @@ __all__ = [
     "LinearQKVMerged",
     "RMSNorm",
     "RMSNormFused",
+    "GemmaRMSNorm",
+    "GemmaRMSNormFused",
+    "RadixLinearAttention",
     "get_rope",
     "set_rope_device",
     "LinearReplicated",

--- a/python/minisgl/layers/attention.py
+++ b/python/minisgl/layers/attention.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
+from minisgl.compilation import get_forward_context
 from minisgl.core import get_global_ctx
 from minisgl.distributed import get_tp_info
 from minisgl.utils import div_even
@@ -13,6 +14,14 @@ from .rotary import get_rope
 if TYPE_CHECKING:
     from minisgl.layers import RMSNorm
     from minisgl.models import RotaryConfig
+
+
+def _to_hashable(obj):
+    if isinstance(obj, dict):
+        return tuple((k, _to_hashable(v)) for k, v in sorted(obj.items()))
+    if isinstance(obj, list):
+        return tuple(_to_hashable(v) for v in obj)
+    return obj
 
 
 class AttentionLayer(StateLessOP):
@@ -32,6 +41,8 @@ class AttentionLayer(StateLessOP):
         tp_size = get_tp_info().size
         self.num_qo_heads = div_even(num_qo_heads, tp_size)
         self.num_kv_heads = div_even(num_kv_heads, tp_size, allow_replicate=True)
+        self.tp_q_head_num = self.num_qo_heads
+        self.v_head_dim = self.head_dim
         self.qo_attn_dim = self.num_qo_heads * head_dim
         self.kv_attn_dim = self.num_kv_heads * head_dim
         self.rotary = get_rope(
@@ -39,7 +50,7 @@ class AttentionLayer(StateLessOP):
             rotary_dim=rotary_config.rotary_dim,
             max_position=rotary_config.max_position,
             base=rotary_config.base,
-            rope_scaling=tuple(rotary_config.scaling.items()) if rotary_config.scaling else None,
+            rope_scaling=_to_hashable(rotary_config.scaling) if rotary_config.scaling else None,
         )
         self.q_norm = q_norm
         self.k_norm = k_norm
@@ -53,5 +64,14 @@ class AttentionLayer(StateLessOP):
             self.k_norm.forward_inplace(k.view(-1, self.num_kv_heads, self.head_dim))
         q, k = self.rotary.forward(ctx.batch.positions, q, k)
         q = q.view(-1, self.num_qo_heads, self.head_dim)
-        o = ctx.attn_backend.forward(q, k, v, self.layer_id, ctx.batch)
+        forward_ctx = get_forward_context()
+        if forward_ctx is None:
+            raise RuntimeError("No active forward context when running attention layer.")
+        o = ctx.attn_backend.forward(
+            q=q,
+            k=k,
+            v=v,
+            layer=self,
+            forward_batch=forward_ctx.forward_batch,
+        )
         return o.view(-1, self.qo_attn_dim)

--- a/python/minisgl/layers/linear.py
+++ b/python/minisgl/layers/linear.py
@@ -76,13 +76,16 @@ class LinearQKVMerged(_LinearTPImpl):
         num_qo_heads: int,
         num_kv_heads: int,
         has_bias: bool,
+        q_multiplier: int = 1,
     ):
+        if q_multiplier < 1:
+            raise ValueError(f"q_multiplier must be >= 1, got {q_multiplier}")
         tp_info = get_tp_info()
 
-        local_num_qo = div_even(num_qo_heads, tp_info.size)
+        local_num_qo = div_even(num_qo_heads, tp_info.size) * q_multiplier
         local_num_kv = div_even(num_kv_heads, tp_info.size, allow_replicate=True)
         full_isize = hidden_size
-        full_osize = (num_qo_heads + 2 * num_kv_heads) * head_dim
+        full_osize = (num_qo_heads * q_multiplier + 2 * num_kv_heads) * head_dim
         local_isize = hidden_size
         local_osize = (local_num_qo + 2 * local_num_kv) * head_dim
         super().__init__(full_isize, full_osize, local_isize, local_osize, has_bias)

--- a/python/minisgl/layers/norm.py
+++ b/python/minisgl/layers/norm.py
@@ -36,3 +36,36 @@ class RMSNormFused(BaseOP):
             return self.rmsnorm(x, self.weight, self.eps), x
         self.fused_add_rmsnorm(x, residual, self.weight, self.eps)
         return x, residual
+
+
+class GemmaRMSNorm(BaseOP):
+    def __init__(self, size: int, eps: float) -> None:
+        from flashinfer import gemma_rmsnorm
+
+        self.eps = eps
+        self.weight = torch.empty(size)
+        self.gemma_rmsnorm = gemma_rmsnorm
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.gemma_rmsnorm(x, self.weight, self.eps)
+
+    def forward_inplace(self, x: torch.Tensor) -> None:
+        self.gemma_rmsnorm(x, self.weight, self.eps, out=x)
+
+
+class GemmaRMSNormFused(BaseOP):
+    def __init__(self, size: int, eps: float) -> None:
+        from flashinfer import gemma_fused_add_rmsnorm, gemma_rmsnorm
+
+        self.eps = eps
+        self.weight = torch.empty(size)
+        self.gemma_rmsnorm = gemma_rmsnorm
+        self.gemma_fused_add_rmsnorm = gemma_fused_add_rmsnorm
+
+    def forward(
+        self, x: torch.Tensor, residual: torch.Tensor | None = None
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            return self.gemma_rmsnorm(x, self.weight, self.eps), x
+        self.gemma_fused_add_rmsnorm(x, residual, self.weight, self.eps)
+        return x, residual

--- a/python/minisgl/layers/radix_linear_attention.py
+++ b/python/minisgl/layers/radix_linear_attention.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Tuple, Union
+
+import torch
+from minisgl.compilation import get_forward_context, register_split_op
+from minisgl.utils import register_custom_op
+
+from .base import BaseOP
+
+if TYPE_CHECKING:
+    from minisgl.model_executor.forward_batch_info import ForwardBatch
+
+
+class RadixLinearAttention(BaseOP):
+    """
+    The Linear Attention Layer Implementation.
+    """
+
+    def __init__(
+        self,
+        layer_id: int,
+        num_q_heads: int,
+        num_k_heads: int,
+        num_v_heads: int,
+        head_q_dim: int,
+        head_k_dim: int,
+        head_v_dim: int,
+        # GDN KDA Shared Weights
+        conv_weights: Optional[Union[torch.Tensor, Tuple[torch.Tensor, ...]]] = None,
+        bias: Optional[Union[torch.Tensor, Tuple[torch.Tensor, ...]]] = None,
+        activation: str = "silu",
+        A_log: Optional[torch.Tensor] = None,
+        dt_bias: Optional[torch.Tensor] = None,
+    ):
+        self.layer_id = layer_id
+        self.num_q_heads = num_q_heads
+        self.num_k_heads = num_k_heads
+        self.num_v_heads = num_v_heads
+        self.head_q_dim = head_q_dim
+        self.head_k_dim = head_k_dim
+        self.head_v_dim = head_v_dim
+        self.q_dim = num_q_heads * head_q_dim
+        self.k_dim = num_k_heads * head_k_dim
+        self.v_dim = num_v_heads * head_v_dim
+
+        self.conv_weights = conv_weights
+        self.bias = bias
+        self.activation = activation
+
+        self.A_log = A_log
+        self.dt_bias = dt_bias
+
+    def forward(
+        self,
+        forward_batch: ForwardBatch,
+        mixed_qkv: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+    ) -> torch.Tensor:
+        if forward_batch.forward_mode.is_extend() and get_forward_context() is not None:
+            # Output shape from linear attention: (1, seq_len, num_v_heads, head_v_dim)
+            seq_len = mixed_qkv.shape[0]
+            output = torch.empty(
+                (1, seq_len, self.num_v_heads, self.head_v_dim),
+                dtype=mixed_qkv.dtype,
+                device=mixed_qkv.device,
+            )
+            unified_linear_attention_with_output(
+                mixed_qkv,
+                a,
+                b,
+                output,
+                self.layer_id,
+            )
+            return output
+        else:
+            return forward_batch.attn_backend.forward(
+                layer=self,
+                forward_batch=forward_batch,
+                mixed_qkv=mixed_qkv,
+                a=a,
+                b=b,
+            )
+
+
+@register_custom_op(mutates_args=["output"])
+@register_split_op()
+def unified_linear_attention_with_output(
+    mixed_qkv: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    output: torch.Tensor,
+    layer_id: int,
+) -> None:
+    """
+    Custom op wrapper for linear attention computation only.
+    """
+    context = get_forward_context()
+    if context is None:
+        raise RuntimeError("No active forward context for unified_linear_attention_with_output.")
+
+    forward_batch = context.forward_batch
+    attention_layers = context.attention_layers
+    attention_layer = attention_layers[layer_id]
+    if attention_layer is None:
+        raise RuntimeError(f"Attention layer {layer_id} is not available in forward context.")
+    real_num_tokens = forward_batch.num_token_non_padded_cpu
+
+    ret = forward_batch.attn_backend.forward(
+        layer=attention_layer,
+        forward_batch=forward_batch,
+        mixed_qkv=mixed_qkv[:real_num_tokens],
+        a=a[:real_num_tokens],
+        b=b[:real_num_tokens],
+    )
+
+    if ret.ndim == 4:
+        output[:, :real_num_tokens].copy_(ret[:, :real_num_tokens])
+    elif ret.ndim == 3:
+        output[:, :real_num_tokens].copy_(ret.unsqueeze(0))
+    else:
+        raise RuntimeError(f"Expected ret.ndim in (3, 4), got {ret.ndim}.")
+    return

--- a/python/minisgl/layers/rotary.py
+++ b/python/minisgl/layers/rotary.py
@@ -20,7 +20,8 @@ class RotaryEmbedding(StateLessOP):
     ) -> None:
         super().__init__()
         self.head_size = head_size
-        assert rotary_dim == head_size
+        assert 0 < rotary_dim <= head_size
+        assert rotary_dim % 2 == 0
         inv_freq = 1.0 / (base ** (torch.arange(0, rotary_dim, 2, dtype=torch.float) / rotary_dim))
         if post_process is not None:
             inv_freq = post_process(inv_freq)
@@ -97,7 +98,8 @@ def _get_rope(
             orig_max_pos: int = rope_scaling["original_max_position_embeddings"]
 
             def _find_correction_dim(num_rotations: float) -> float:
-                return rotary_dim * math.log(orig_max_pos / (num_rotations * 2 * math.pi)) / (2 * math.log(base))
+                numerator = rotary_dim * math.log(orig_max_pos / (num_rotations * 2 * math.pi))
+                return numerator / (2 * math.log(base))
 
             low = max(math.floor(_find_correction_dim(beta_fast)), 0)
             high = min(math.ceil(_find_correction_dim(beta_slow)), rotary_dim // 2 - 1)

--- a/python/minisgl/message/tokenizer.py
+++ b/python/minisgl/message/tokenizer.py
@@ -29,6 +29,9 @@ class DetokenizeMsg(BaseTokenizerMsg):
     uid: int
     next_token: int
     finished: bool
+    finish_reason: str = ""
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
 
 
 @dataclass

--- a/python/minisgl/model_executor/__init__.py
+++ b/python/minisgl/model_executor/__init__.py
@@ -1,0 +1,4 @@
+from .forward_batch_info import ForwardBatch, ForwardMode
+
+__all__ = ["ForwardMode", "ForwardBatch"]
+

--- a/python/minisgl/model_executor/forward_batch_info.py
+++ b/python/minisgl/model_executor/forward_batch_info.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import torch
+    from minisgl.core import Batch
+
+
+class ForwardMode(str, Enum):
+    PREFILL = "prefill"
+    DECODE = "decode"
+    IDLE = "idle"
+
+    def is_prefill(self) -> bool:
+        return self is ForwardMode.PREFILL
+
+    def is_decode(self) -> bool:
+        return self is ForwardMode.DECODE
+
+    def is_extend(self) -> bool:
+        # Keep naming aligned with sglang: both prefill/decode are extend-like.
+        return self in (ForwardMode.PREFILL, ForwardMode.DECODE)
+
+    def is_idle(self) -> bool:
+        return self is ForwardMode.IDLE
+
+
+@dataclass
+class ForwardBatch:
+    forward_mode: ForwardMode
+    batch: "Batch"
+    reqs: list[Any]
+    padded_reqs: list[Any]
+    out_cache_loc: "torch.Tensor"
+    num_token_non_padded_cpu: int
+    attn_backend: Any
+    out_cache_loc_swa: "torch.Tensor | None" = None
+
+    @classmethod
+    def from_batch(cls, batch: "Batch", *, attn_backend: Any) -> "ForwardBatch":
+        return cls(
+            forward_mode=ForwardMode(batch.phase),
+            batch=batch,
+            reqs=batch.reqs,
+            padded_reqs=batch.padded_reqs,
+            out_cache_loc=batch.out_loc,
+            num_token_non_padded_cpu=sum(req.extend_len for req in batch.reqs),
+            attn_backend=attn_backend,
+            out_cache_loc_swa=None,
+        )

--- a/python/minisgl/models/config.py
+++ b/python/minisgl/models/config.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Any, Dict
+
 from transformers import PretrainedConfig
 
 
@@ -32,22 +34,44 @@ class ModelConfig:
     norm_topk_prob: bool
     model_type: str
     architectures: list[str]
+    attn_output_gate: bool
+    layer_types: list[str] | None
+    full_attention_interval: int | None
+    linear_conv_kernel_dim: int
+    linear_key_head_dim: int
+    linear_value_head_dim: int
+    linear_num_key_heads: int
+    linear_num_value_heads: int
 
     @property
     def is_moe(self) -> bool:
         return "moe" in self.model_type
 
+    @property
+    def has_linear_layers(self) -> bool:
+        return self.layer_types is not None and any(t == "linear_attention" for t in self.layer_types)
+
     @classmethod
-    def from_hf(cls, config: PretrainedConfig) -> ModelConfig:
-        if hasattr(config, "text_config") and config.text_config is not None:
-            top = config
-            config = config.text_config
-            for attr in ("architectures", "rope_theta", "rope_scaling"):
-                if not getattr(config, attr, None) and getattr(top, attr, None):
-                    setattr(config, attr, getattr(top, attr))
+    def from_hf(cls, config: PretrainedConfig | dict) -> ModelConfig:
+        def _get_attr(obj, attr: str):
+            if isinstance(obj, dict):
+                return obj.get(attr)
+            return getattr(obj, attr, None)
+
+        top = config
+        text_config = _get_attr(config, "text_config")
+        if text_config is not None:
+            config = text_config
+        if isinstance(config, dict):
+            config = PretrainedConfig.from_dict(config)
+        for attr in ("architectures", "rope_theta", "rope_scaling", "rope_parameters"):
+            if not getattr(config, attr, None) and (top_attr := _get_attr(top, attr)):
+                setattr(config, attr, top_attr)
 
         num_kv_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
-        head_dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+        head_dim = getattr(config, "head_dim", None) or (
+            config.hidden_size // config.num_attention_heads
+        )
         tie_word_embeddings = getattr(config, "tie_word_embeddings", False)
         model_type = getattr(config, "model_type", "llama")
         num_experts = getattr(config, "num_local_experts", getattr(config, "num_experts", 0))
@@ -55,10 +79,48 @@ class ModelConfig:
         moe_intermediate_size = getattr(config, "moe_intermediate_size", 0)
         norm_topk_prob = getattr(config, "norm_topk_prob", False)
         architectures = getattr(config, "architectures", ["LlamaForCausalLM"])
+        attn_output_gate = bool(getattr(config, "attn_output_gate", False))
+        full_attention_interval = getattr(config, "full_attention_interval", None)
+        layer_types = getattr(config, "layer_types", None)
+        if layer_types is not None:
+            layer_types = list(layer_types)
+        elif full_attention_interval:
+            layer_types = [
+                "attention" if (idx + 1) % full_attention_interval == 0 else "linear_attention"
+                for idx in range(config.num_hidden_layers)
+            ]
 
-        # Llama/Qwen: rope_theta is a direct attr; Mistral: it's inside rope_scaling dict
+        rope_parameters = getattr(config, "rope_parameters", None)
         rope_scaling = getattr(config, "rope_scaling", None)
-        rope_theta = getattr(config, "rope_theta", None) or rope_scaling["rope_theta"]
+        if rope_parameters is not None:
+            rope_scaling = rope_parameters
+
+        rope_theta = getattr(config, "rope_theta", None)
+        if rope_theta is None and isinstance(rope_parameters, dict):
+            rope_theta = rope_parameters.get("rope_theta")
+        if rope_theta is None and isinstance(rope_scaling, dict):
+            rope_theta = rope_scaling.get("rope_theta")
+        if rope_theta is None:
+            rope_theta = 10000.0
+
+        partial_rotary_factor = getattr(config, "partial_rotary_factor", None)
+        if partial_rotary_factor is None and isinstance(rope_parameters, dict):
+            partial_rotary_factor = rope_parameters.get("partial_rotary_factor")
+        if partial_rotary_factor is None and isinstance(rope_scaling, dict):
+            partial_rotary_factor = rope_scaling.get("partial_rotary_factor")
+        if partial_rotary_factor is None:
+            partial_rotary_factor = 1.0
+
+        rotary_dim = int(head_dim * float(partial_rotary_factor))
+        rotary_dim = max(2, min(rotary_dim, head_dim))
+        if rotary_dim % 2 != 0:
+            rotary_dim -= 1
+
+        linear_conv_kernel_dim = int(getattr(config, "linear_conv_kernel_dim", 4))
+        linear_key_head_dim = int(getattr(config, "linear_key_head_dim", head_dim))
+        linear_value_head_dim = int(getattr(config, "linear_value_head_dim", head_dim))
+        linear_num_key_heads = int(getattr(config, "linear_num_key_heads", 0))
+        linear_num_value_heads = int(getattr(config, "linear_num_value_heads", 0))
 
         return cls(
             num_layers=config.num_hidden_layers,
@@ -73,7 +135,7 @@ class ModelConfig:
             tie_word_embeddings=tie_word_embeddings,
             rotary_config=RotaryConfig(
                 head_dim=head_dim,
-                rotary_dim=head_dim,
+                rotary_dim=rotary_dim,
                 max_position=config.max_position_embeddings,
                 base=rope_theta,
                 scaling=rope_scaling,
@@ -84,4 +146,12 @@ class ModelConfig:
             norm_topk_prob=norm_topk_prob,
             model_type=model_type,
             architectures=architectures,
+            attn_output_gate=attn_output_gate,
+            layer_types=layer_types,
+            full_attention_interval=full_attention_interval,
+            linear_conv_kernel_dim=linear_conv_kernel_dim,
+            linear_key_head_dim=linear_key_head_dim,
+            linear_value_head_dim=linear_value_head_dim,
+            linear_num_key_heads=linear_num_key_heads,
+            linear_num_value_heads=linear_num_value_heads,
         )

--- a/python/minisgl/models/qwen3_5.py
+++ b/python/minisgl/models/qwen3_5.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Tuple
+
+import torch
+import torch.nn.functional as F
+from minisgl.compilation import get_forward_context
+from minisgl.core import get_global_ctx
+from minisgl.distributed import get_tp_info
+from minisgl.layers import (
+    BaseOP,
+    GemmaRMSNormFused,
+    LinearColParallelMerged,
+    LinearRowParallel,
+    OPList,
+    ParallelLMHead,
+    RMSNorm,
+    RadixLinearAttention,
+    VocabParallelEmbedding,
+)
+from minisgl.kernel.triton.gdn_fused_proj import (
+    fused_qkvzba_split_reshape_cat_contiguous,
+)
+from minisgl.utils import div_even, nvtx_annotate
+
+from .base import BaseLLMModel
+from .utils import GatedMLP as Qwen3_5MLP
+from .utils import RopeAttn as Qwen3_5Attn
+
+if TYPE_CHECKING:
+    from .config import ModelConfig
+
+
+def _get_layer_type(config: "ModelConfig", layer_id: int) -> str:
+    if not config.layer_types:
+        return "attention"
+    layer_type = config.layer_types[layer_id]
+    if layer_type == "full_attention":
+        return "attention"
+    return layer_type
+
+
+class _DepthwiseConv1D(BaseOP):
+    def __init__(self, channels: int, kernel_size: int):
+        self.weight = torch.empty(channels, 1, kernel_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+
+class Qwen3_5GatedDeltaNet(BaseOP):
+    def __init__(self, config: "ModelConfig", layer_id: int):
+        if config.linear_num_key_heads <= 0 or config.linear_num_value_heads <= 0:
+            raise ValueError("Invalid qwen3.5 linear attention config.")
+
+        tp_size = get_tp_info().size
+        self.layer_id = layer_id
+        self.head_k_dim = config.linear_key_head_dim
+        self.head_v_dim = config.linear_value_head_dim
+        self.num_q_heads = div_even(config.linear_num_key_heads, tp_size, allow_replicate=True)
+        self.num_v_heads = div_even(config.linear_num_value_heads, tp_size, allow_replicate=True)
+        if self.num_v_heads % self.num_q_heads != 0:
+            raise ValueError("num_v_heads must be divisible by num_q_heads for GDN.")
+
+        key_dim = config.linear_num_key_heads * self.head_k_dim
+        value_dim = config.linear_num_value_heads * self.head_v_dim
+        self.hidden_act = config.hidden_act
+
+        self.in_proj_qkvz = self.create_qkvz_proj(
+            hidden_size=config.hidden_size,
+            key_dim=key_dim,
+            value_dim=value_dim,
+        )
+        self.in_proj_ba = self.create_ba_proj(
+            hidden_size=config.hidden_size,
+            num_v_heads=config.linear_num_value_heads,
+        )
+
+        self.local_qk_dim = self.num_q_heads * self.head_k_dim
+        self.local_v_dim = self.num_v_heads * self.head_v_dim
+        self.local_conv_dim = 2 * self.local_qk_dim + self.local_v_dim
+
+        self.conv1d = _DepthwiseConv1D(self.local_conv_dim, config.linear_conv_kernel_dim)
+        self.A_log = torch.empty(self.num_v_heads)
+        self.dt_bias = torch.empty(self.num_v_heads)
+        self.attn = RadixLinearAttention(
+            layer_id=layer_id,
+            num_q_heads=self.num_q_heads,
+            num_k_heads=self.num_q_heads,
+            num_v_heads=self.num_v_heads,
+            head_q_dim=self.head_k_dim,
+            head_k_dim=self.head_k_dim,
+            head_v_dim=self.head_v_dim,
+            # Keep these as non-Tensor at init time to avoid state_dict loading
+            # expecting duplicated keys under linear_attn.attn.*.
+            conv_weights=None,
+            bias=None,
+            activation=self.hidden_act,
+            A_log=None,
+            dt_bias=None,
+        )
+
+        self.norm = RMSNorm(self.head_v_dim, eps=config.rms_norm_eps)
+        self.out_proj = LinearRowParallel(
+            value_dim,
+            config.hidden_size,
+            has_bias=False,
+        )
+
+    def create_qkvz_proj(
+        self,
+        hidden_size: int,
+        key_dim: int,
+        value_dim: int,
+    ) -> LinearColParallelMerged:
+        return LinearColParallelMerged(
+            hidden_size,
+            [key_dim, key_dim, value_dim, value_dim],
+            has_bias=False,
+        )
+
+    def create_ba_proj(
+        self,
+        hidden_size: int,
+        num_v_heads: int,
+    ) -> LinearColParallelMerged:
+        return LinearColParallelMerged(
+            hidden_size,
+            [num_v_heads, num_v_heads],
+            has_bias=False,
+        )
+
+    def fix_query_key_value_ordering(
+        self,
+        mixed_qkvz: torch.Tensor,
+        mixed_ba: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        query, key, value, z = mixed_qkvz.split(
+            [self.local_qk_dim, self.local_qk_dim, self.local_v_dim, self.local_v_dim], dim=-1
+        )
+        b, a = mixed_ba.split([self.num_v_heads, self.num_v_heads], dim=-1)
+        value = value.view(value.shape[0], self.num_v_heads, self.head_v_dim)
+        z = z.view(z.shape[0], self.num_v_heads, self.head_v_dim)
+        return query, key, value, z, b, a
+
+    def _forward_input_proj(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        projected_states_qkvz = self.in_proj_qkvz.forward(x)
+        projected_states_ba = self.in_proj_ba.forward(x)
+        return projected_states_qkvz, projected_states_ba
+
+    def _fused_input_reorder(
+        self,
+        projected_states_qkvz: torch.Tensor,
+        projected_states_ba: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor] | None:
+        if not projected_states_qkvz.is_cuda:
+            return None
+        if self.num_v_heads % self.num_q_heads != 0:
+            return None
+        if (self.num_v_heads // self.num_q_heads) not in (1, 2, 4):
+            return None
+        try:
+            return fused_qkvzba_split_reshape_cat_contiguous(
+                projected_states_qkvz,
+                projected_states_ba,
+                self.num_q_heads,
+                self.num_v_heads,
+                self.head_k_dim,
+                self.head_v_dim,
+            )
+        except Exception:
+            return None
+
+    @nvtx_annotate("GatedDeltaNet")
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        forward_ctx = get_forward_context()
+        forward_batch = forward_ctx.forward_batch if forward_ctx is not None else None
+
+        projected_states_qkvz, projected_states_ba = self._forward_input_proj(x)
+        fused_out = self._fused_input_reorder(projected_states_qkvz, projected_states_ba)
+        if fused_out is None:
+            query, key, value, z, b, a = self.fix_query_key_value_ordering(
+                projected_states_qkvz, projected_states_ba
+            )
+            mixed_qkv = torch.cat((query, key, value.reshape(value.shape[0], -1)), dim=-1)
+        else:
+            mixed_qkv, z, b, a = fused_out
+        b = b.contiguous()
+        a = a.contiguous()
+
+        # Keep RadixLinearAttention references aligned after state_dict loading.
+        self.attn.conv_weights = self.conv1d.weight
+        self.attn.A_log = self.A_log
+        self.attn.dt_bias = self.dt_bias
+        core = self.attn.forward(
+            forward_batch=forward_batch,
+            mixed_qkv=mixed_qkv,
+            a=a,
+            b=b,
+        ).to(dtype=z.dtype)
+
+        core = core.reshape(-1, core.shape[-1])
+        z = z.reshape(-1, z.shape[-1])
+        core = self.norm.forward(core)
+        core = core * F.silu(z)
+        core = core.reshape(x.shape[0], -1)
+        return self.out_proj.forward(core)
+
+
+class _Qwen3_5BaseDecoderLayer(BaseOP):
+    def __init__(self, config: "ModelConfig", layer_id: int):
+        self.mlp = Qwen3_5MLP(config)
+        self.input_layernorm = GemmaRMSNormFused(
+            size=config.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+        self.post_attention_layernorm = GemmaRMSNormFused(
+            size=config.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+        self._layer_id = layer_id
+
+    def _run_attention(self, x: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    @nvtx_annotate("Layer_{}", layer_id_field="_layer_id")
+    def forward(
+        self,
+        x: torch.Tensor,
+        residual: torch.Tensor | None = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        x, residual = self.input_layernorm.forward(x, residual)
+        x = self._run_attention(x)
+        x, residual = self.post_attention_layernorm.forward(x, residual)
+        x = self.mlp.forward(x)
+        return x, residual
+
+
+class Qwen3_5LinearDecoderLayer(_Qwen3_5BaseDecoderLayer):
+    """Qwen3.5 Decoder Layer with Linear Attention (GatedDeltaNet)."""
+
+    def __init__(self, config: "ModelConfig", layer_id: int):
+        self.linear_attn = Qwen3_5GatedDeltaNet(config, layer_id)
+        super().__init__(config, layer_id)
+
+    def _run_attention(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear_attn.forward(x)
+
+
+class Qwen3_5AttentionDecoderLayer(_Qwen3_5BaseDecoderLayer):
+    """Qwen3.5 Decoder Layer with Full Attention."""
+
+    def __init__(self, config: "ModelConfig", layer_id: int):
+        self.self_attn = Qwen3_5Attn(
+            config,
+            layer_id,
+            has_qk_norm=True,
+            has_attn_output_gate=config.attn_output_gate,
+            use_gemma_norm=True,
+        )
+        super().__init__(config, layer_id)
+
+    def _run_attention(self, x: torch.Tensor) -> torch.Tensor:
+        return self.self_attn.forward(x)
+
+
+_DECODER_LAYER_REGISTRY = {
+    "linear_attention": Qwen3_5LinearDecoderLayer,
+    "attention": Qwen3_5AttentionDecoderLayer,
+}
+
+
+class Qwen3_5Model(BaseOP):
+    def __init__(self, config: "ModelConfig"):
+        self.embed_tokens = VocabParallelEmbedding(
+            num_embeddings=config.vocab_size,
+            embedding_dim=config.hidden_size,
+        )
+        layers: list[BaseOP] = []
+        for layer_id in range(config.num_layers):
+            layer_type = _get_layer_type(config, layer_id)
+            layer_cls = _DECODER_LAYER_REGISTRY.get(layer_type)
+            if layer_cls is None:
+                raise ValueError(f"Unsupported qwen3.5 layer type: {layer_type}")
+            layers.append(layer_cls(config, layer_id))
+        self.layers = OPList(layers)
+        self.norm = GemmaRMSNormFused(
+            size=config.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        x = self.embed_tokens.forward(input_ids)
+        residual: torch.Tensor | None = None
+        for layer in self.layers.op_list:
+            x, residual = layer.forward(x, residual)
+        return self.norm.forward(x, residual)[0]
+
+
+class Qwen3_5ForCausalLM(BaseLLMModel):
+    def __init__(self, config: "ModelConfig"):
+        self.model = Qwen3_5Model(config)
+        self.lm_head = ParallelLMHead(
+            num_embeddings=config.vocab_size,
+            embedding_dim=config.hidden_size,
+            tie_word_embeddings=config.tie_word_embeddings,
+            tied_embedding=self.model.embed_tokens if config.tie_word_embeddings else None,
+        )
+        super().__init__()
+
+    def forward(self) -> torch.Tensor:
+        output = self.model.forward(get_global_ctx().batch.input_ids)
+        logits = self.lm_head.forward(output)
+        return logits
+
+
+__all__ = ["Qwen3_5GatedDeltaNet", "Qwen3_5ForCausalLM"]

--- a/python/minisgl/models/register.py
+++ b/python/minisgl/models/register.py
@@ -7,6 +7,9 @@ _MODEL_REGISTRY = {
     "Qwen2ForCausalLM": (".qwen2", "Qwen2ForCausalLM"),
     "Qwen3ForCausalLM": (".qwen3", "Qwen3ForCausalLM"),
     "Qwen3MoeForCausalLM": (".qwen3_moe", "Qwen3MoeForCausalLM"),
+    "Qwen3_5ForCausalLM": (".qwen3_5", "Qwen3_5ForCausalLM"),
+    "Qwen3_5ForConditionalGeneration": (".qwen3_5", "Qwen3_5ForCausalLM"),
+    "Qwen3_5MoeForConditionalGeneration": (".qwen3_5", "Qwen3_5ForCausalLM"),
     "MistralForCausalLM": (".mistral", "MistralForCausalLM"),
     "Mistral3ForConditionalGeneration": (".mistral", "MistralForCausalLM"),
 }

--- a/python/minisgl/models/utils.py
+++ b/python/minisgl/models/utils.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
+import torch
 from minisgl.layers import (
     AttentionLayer,
     BaseOP,
+    GemmaRMSNorm,
     LinearColParallelMerged,
     LinearOProj,
     LinearQKVMerged,
@@ -17,10 +17,6 @@ from minisgl.layers import (
 )
 from minisgl.models import ModelConfig
 from minisgl.utils import nvtx_annotate
-
-if TYPE_CHECKING:
-    import torch
-
 
 class GatedMLP(BaseOP):
     def __init__(self, config: ModelConfig):
@@ -84,19 +80,25 @@ class RopeAttn(BaseOP):
         *,
         has_attn_bias: bool = False,
         has_qk_norm: bool = False,
+        has_attn_output_gate: bool = False,
+        use_gemma_norm: bool = False,
     ):
         head_dim = config.head_dim
+        q_multiplier = 2 if has_attn_output_gate else 1
         self.qkv_proj = LinearQKVMerged(
             hidden_size=config.hidden_size,
             head_dim=config.head_dim,
             num_qo_heads=config.num_qo_heads,
             num_kv_heads=config.num_kv_heads,
             has_bias=has_attn_bias,
+            q_multiplier=q_multiplier,
         )
         self.has_qk_norm = has_qk_norm
+        self.has_attn_output_gate = has_attn_output_gate
         if has_qk_norm:
-            self.q_norm = RMSNorm(head_dim, eps=config.rms_norm_eps)
-            self.k_norm = RMSNorm(head_dim, eps=config.rms_norm_eps)
+            norm_cls = GemmaRMSNorm if use_gemma_norm else RMSNorm
+            self.q_norm = norm_cls(head_dim, eps=config.rms_norm_eps)
+            self.k_norm = norm_cls(head_dim, eps=config.rms_norm_eps)
         else:
             self.q_norm = None
             self.k_norm = None
@@ -119,7 +121,19 @@ class RopeAttn(BaseOP):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         qkv = self.qkv_proj.forward(x)
         del x
-        o = self.attn.forward(qkv)
+        if self.has_attn_output_gate:
+            q_dim = self.attn.qo_attn_dim
+            kv_dim = self.attn.kv_attn_dim
+            qg, k, v = qkv.split([2 * q_dim, kv_dim, kv_dim], dim=-1)
+            orig_shape = qg.shape[:-1]
+            qg = qg.view(*orig_shape, self.attn.num_qo_heads, -1)
+            q, gate = torch.chunk(qg, 2, dim=-1)
+            q = q.reshape(*orig_shape, -1)
+            gate = gate.reshape(*orig_shape, -1)
+            o = self.attn.forward(torch.cat([q, k, v], dim=-1))
+            o = o * torch.sigmoid(gate)
+        else:
+            o = self.attn.forward(qkv)
         return self.o_proj.forward(o)
 
 

--- a/python/minisgl/models/weight.py
+++ b/python/minisgl/models/weight.py
@@ -7,11 +7,26 @@ from typing import Dict, Iterator, Tuple
 import safetensors
 import torch
 from minisgl.distributed import get_tp_info
-from minisgl.utils import cached_load_hf_config, div_ceil, download_hf_weight
+from minisgl.utils import cached_load_hf_config, div_ceil, div_even, download_hf_weight
 from tqdm import tqdm
 
-_SPLIT_DIM_0 = [".q_proj", ".k_proj", ".v_proj", ".gate_proj", ".up_proj"]
-_SPLIT_DIM_1 = [".o_proj", ".down_proj"]
+_SPLIT_DIM_0 = [
+    ".q_proj",
+    ".k_proj",
+    ".v_proj",
+    ".gate_proj",
+    ".up_proj",
+    ".in_proj_qkv",
+    ".in_proj_z",
+    ".in_proj_qkvz",
+    ".in_proj_a",
+    ".in_proj_b",
+    ".in_proj_ba",
+    ".conv1d",
+    ".A_log",
+    ".dt_bias",
+]
+_SPLIT_DIM_1 = [".o_proj", ".down_proj", ".out_proj"]
 
 # Merge groups: individual projections -> fused projection
 _MERGE_GROUPS = {
@@ -20,6 +35,10 @@ _MERGE_GROUPS = {
     ".v_proj": (".qkv_proj", ("q", "k", "v")),
     ".gate_proj": (".gate_up_proj", ("gate", "up")),
     ".up_proj": (".gate_up_proj", ("gate", "up")),
+    ".in_proj_qkv": (".in_proj_qkvz", ("qkv", "z")),
+    ".in_proj_z": (".in_proj_qkvz", ("qkv", "z")),
+    ".in_proj_b": (".in_proj_ba", ("b", "a")),
+    ".in_proj_a": (".in_proj_ba", ("b", "a")),
 }
 _SLOT_NAMES = {
     ".q_proj": "q",
@@ -27,17 +46,75 @@ _SLOT_NAMES = {
     ".v_proj": "v",
     ".gate_proj": "gate",
     ".up_proj": "up",
+    ".in_proj_qkv": "qkv",
+    ".in_proj_z": "z",
+    ".in_proj_b": "b",
+    ".in_proj_a": "a",
 }
 _EXPERT_PATTERN = re.compile(r"^(?P<prefix>.+\.experts)\.(?P<idx>\d+)\.(?P<name>.+)$")
 
 
-def _shard_tensor(key: str, value: torch.Tensor, r: int, n: int, num_kv_heads: int):
+def _normalize_weight_name(name: str) -> str:
+    # Qwen3.5 conditional-generation checkpoints wrap text weights with `model.language_model.*`.
+    if name.startswith("model.language_model."):
+        return "model." + name.removeprefix("model.language_model.")
+    if name.startswith("language_model.model."):
+        return name.removeprefix("language_model.")
+    if name.startswith("language_model."):
+        return name.removeprefix("language_model.")
+    return name
+
+
+def _shard_linear_qkv_tensor(
+    value: torch.Tensor,
+    r: int,
+    n: int,
+    *,
+    num_key_heads: int,
+    key_head_dim: int,
+    num_value_heads: int,
+    value_head_dim: int,
+) -> torch.Tensor:
+    key_dim = num_key_heads * key_head_dim
+    value_dim = num_value_heads * value_head_dim
+    total_dim = 2 * key_dim + value_dim
+    if value.shape[0] != total_dim:
+        raise ValueError(
+            f"Unexpected linear QKV tensor shape: {value.shape}, expected first dim {total_dim}."
+        )
+
+    local_num_key_heads = div_even(num_key_heads, n, allow_replicate=True)
+    local_num_value_heads = div_even(num_value_heads, n, allow_replicate=True)
+    local_key_dim = local_num_key_heads * key_head_dim
+    local_value_dim = local_num_value_heads * value_head_dim
+
+    q_start = r * local_key_dim
+    k_start = key_dim + r * local_key_dim
+    v_start = 2 * key_dim + r * local_value_dim
+
+    q = value[q_start : q_start + local_key_dim]
+    k = value[k_start : k_start + local_key_dim]
+    v = value[v_start : v_start + local_value_dim]
+    return torch.cat([q, k, v], dim=0).clone()
+
+
+def _shard_tensor(key: str, value: torch.Tensor, r: int, n: int, config):
     """Extract rank r's shard from a single tensor. Returns a contiguous copy."""
+    if key.endswith(".in_proj_qkv.weight") or key.endswith(".conv1d.weight"):
+        return _shard_linear_qkv_tensor(
+            value,
+            r,
+            n,
+            num_key_heads=config.linear_num_key_heads,
+            key_head_dim=config.linear_key_head_dim,
+            num_value_heads=config.linear_num_value_heads,
+            value_head_dim=config.linear_value_head_dim,
+        )
     if any(key.count(sub) for sub in _SPLIT_DIM_0):
         is_kv_proj = any(key.count(sub) for sub in (".k_proj", ".v_proj"))
-        if is_kv_proj and num_kv_heads is not None and num_kv_heads < n:
-            head_dim = value.shape[0] // num_kv_heads
-            head_idx = r * num_kv_heads // n
+        if is_kv_proj and config.num_kv_heads is not None and config.num_kv_heads < n:
+            head_dim = value.shape[0] // config.num_kv_heads
+            head_idx = r * config.num_kv_heads // n
             return value[head_idx * head_dim : (head_idx + 1) * head_dim].clone()
         return value.chunk(n, dim=0)[r].clone()
     elif any(key.count(sub) for sub in _SPLIT_DIM_1):
@@ -55,8 +132,8 @@ def _shard_tensor(key: str, value: torch.Tensor, r: int, n: int, num_kv_heads: i
 def _get_merge_info(key: str):
     """If key belongs to a merge group, return (merged_key, slot, all_slots). Else None."""
     for suffix, (fused_suffix, slots) in _MERGE_GROUPS.items():
-        if key.count(suffix):
-            return key.replace(suffix, fused_suffix), _SLOT_NAMES[suffix], slots
+        if f"{suffix}." in key:
+            return key.replace(suffix, fused_suffix, 1), _SLOT_NAMES[suffix], slots
     return None
 
 
@@ -90,11 +167,18 @@ def load_weight(model_path: str, device: torch.device) -> Iterator[Tuple[str, to
         with safetensors.safe_open(file, framework="pt", device=str(device)) as f:
             for name in f.keys():
                 # Strip multimodal wrapper prefix, skip vision/projector weights
-                if name.startswith(("vision_tower.", "multi_modal_projector.")):
+                if name.startswith(
+                    (
+                        "vision_tower.",
+                        "multi_modal_projector.",
+                        "model.visual.",
+                        "mtp.",
+                    )
+                ):
                     continue
                 raw = f.get_tensor(name)
-                name = name.removeprefix("language_model.")
-                tensor = _shard_tensor(name, raw, tp_info.rank, tp_info.size, config.num_kv_heads)
+                name = _normalize_weight_name(name)
+                tensor = _shard_tensor(name, raw, tp_info.rank, tp_info.size, config)
                 del raw
 
                 if (info := _get_merge_info(name)) is None:

--- a/python/minisgl/scheduler/cache.py
+++ b/python/minisgl/scheduler/cache.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, List, Tuple
+from typing import TYPE_CHECKING, Callable, List, Tuple
 
 import torch
 from minisgl.core import Req
@@ -13,30 +13,66 @@ if TYPE_CHECKING:
 
 
 class CacheManager:
-    def __init__(self, num_pages: int, page_size: int, page_table: torch.Tensor, type: str):
+    def __init__(
+        self,
+        num_pages: int,
+        page_size: int,
+        page_table: torch.Tensor,
+        type: str,
+        disable_prefix_cache: bool = False,
+        on_prefix_cache_store: Callable[[Req, BaseCacheHandle], None] | None = None,
+        on_prefix_cache_match: Callable[[BaseCacheHandle, int], None] | None = None,
+        prefix_state_checker: Callable[[BaseCacheHandle], bool] | None = None,
+    ):
         # The `_free_slots` follows a page-aligned manner. For example, if page_size = 2,
         # the `_free_slots` may look like [0, 2, 4, 6, ...], and each slot represents a page.
         device = page_table.device
         self.free_slots = torch.arange(num_pages, dtype=torch.int32, device=device) * page_size
         self.prefix_cache = create_prefix_cache(device=device, type=type)
+        self.disable_prefix_cache = disable_prefix_cache
+        self._empty_prefix_ids = torch.empty(0, dtype=torch.int32, device=device)
+        self._on_prefix_cache_store = on_prefix_cache_store
+        self._on_prefix_cache_match = on_prefix_cache_match
+        self._prefix_state_checker = prefix_state_checker
         self.device = device
         self.num_pages = num_pages
         self.page_table = page_table
         self.page_size = page_size
 
     def match_req(self, req: PendingReq) -> MatchResult:
+        if self.disable_prefix_cache:
+            return self.prefix_cache.match_prefix(self._empty_prefix_ids)
         input_len = req.input_len
         assert input_len > 0, "Input length must be greater than 0."
-        return self.prefix_cache.match_prefix(req.input_ids[: input_len - 1])
+        result = self.prefix_cache.match_prefix(req.input_ids[: input_len - 1])
+        if (
+            self._prefix_state_checker is not None
+            and result.cuda_handle.cached_len > 0
+            and not self._prefix_state_checker(result.cuda_handle)
+        ):
+            # If linear states are missing for this cache handle, force a cache miss.
+            return self.prefix_cache.match_prefix(self._empty_prefix_ids)
+        return result
+
+    def restore_req_state(self, handle: BaseCacheHandle, table_idx: int) -> None:
+        if self._on_prefix_cache_match is None or handle.cached_len == 0:
+            return
+        self._on_prefix_cache_match(handle, table_idx)
 
     @property
     def available_size(self) -> int:
+        if self.disable_prefix_cache:
+            return len(self.free_slots) * self.page_size
         return self.prefix_cache.size_info.evictable_size + len(self.free_slots) * self.page_size
 
     def lock(self, handle: BaseCacheHandle) -> None:
+        if self.disable_prefix_cache:
+            return
         self.prefix_cache.lock_handle(handle, unlock=False)
 
     def unlock(self, handle: BaseCacheHandle) -> None:
+        if self.disable_prefix_cache:
+            return
         self.prefix_cache.lock_handle(handle, unlock=True)
 
     def allocate_paged(self, reqs: List[Req]) -> None:
@@ -53,6 +89,12 @@ class CacheManager:
             _write_page_table(self.page_table, allocated, allocation_info, self.page_size)
 
     def cache_req(self, req: Req, *, finished: bool) -> None:
+        if self.disable_prefix_cache:
+            if finished:
+                page_indices = self.page_table[req.table_idx, : req.cached_len]
+                self._free(page_indices)
+            return
+
         # ==================================== valid cache region ====================================
         # [0, req.cached_len)                       This part is valid for attention kernel read/write.
         # [0, old_handle.cached_len)                This part is in the prefix cache before prefill.
@@ -68,6 +110,8 @@ class CacheManager:
         page_indices = self.page_table[req.table_idx, : req.cached_len]
         old_handle = req.cache_handle
         cached_len, new_handle = self.prefix_cache.insert_prefix(insert_ids, page_indices)
+        if not finished and self._on_prefix_cache_store is not None and new_handle.cached_len > 0:
+            self._on_prefix_cache_store(req, new_handle)
         # unlock until all operations on handle is done
         self.unlock(old_handle)
         # this part is already in the prefix cache, free it
@@ -79,8 +123,11 @@ class CacheManager:
             self.lock(new_handle)
 
     def check_integrity(self) -> None:
-        self.prefix_cache.check_integrity()
-        cache_pages = self.prefix_cache.size_info.total_size // self.page_size
+        if self.disable_prefix_cache:
+            cache_pages = 0
+        else:
+            self.prefix_cache.check_integrity()
+            cache_pages = self.prefix_cache.size_info.total_size // self.page_size
         if len(self.free_slots) + cache_pages != self.num_pages:
             raise RuntimeError(
                 "CacheManager integrity check failed:"

--- a/python/minisgl/scheduler/prefill.py
+++ b/python/minisgl/scheduler/prefill.py
@@ -59,6 +59,7 @@ class PrefillAdder:
             page_entry = self.table_manager.page_table[table_idx][:cached_len]
             device_ids.copy_(req.input_ids[:cached_len].pin_memory(), non_blocking=True)
             page_entry.copy_(handle.get_matched_indices())
+            self.cache_manager.restore_req_state(handle, table_idx)
 
         return handle, table_idx
 

--- a/python/minisgl/scheduler/scheduler.py
+++ b/python/minisgl/scheduler/scheduler.py
@@ -55,9 +55,45 @@ class Scheduler(SchedulerIOMixin):
         torch.cuda.set_stream(self.stream)
 
         # initialize other managers
-        self.table_manager = TableManager(config.max_running_req, self.engine.page_table)
+        self.table_manager = TableManager(
+            config.max_running_req,
+            self.engine.page_table,
+            on_slot_allocated=self.engine.attn_backend.on_table_slot_allocated,
+        )
+        on_prefix_cache_store = _resolve_optional_callback(
+            self.engine.attn_backend, "on_prefix_cache_store"
+        )
+        on_prefix_cache_match = _resolve_optional_callback(
+            self.engine.attn_backend, "on_prefix_cache_match"
+        )
+        prefix_state_checker = _resolve_optional_callback(
+            self.engine.attn_backend, "has_prefix_cache_state"
+        )
+        linear_prefix_state_supported = (
+            on_prefix_cache_store is not None
+            and on_prefix_cache_match is not None
+            and prefix_state_checker is not None
+        )
+        disable_prefix_cache = (
+            config.cache_type == "radix"
+            and config.model_config.has_linear_layers
+            and not linear_prefix_state_supported
+        )
+        logger.info_rank0(
+            f"Prefix cache setup: cache_type={config.cache_type}, "
+            f"has_linear_layers={config.model_config.has_linear_layers}, "
+            f"linear_prefix_state_supported={linear_prefix_state_supported}, "
+            f"disable_prefix_cache={disable_prefix_cache}"
+        )
         self.cache_manager = CacheManager(
-            self.engine.num_pages, config.page_size, self.engine.page_table, config.cache_type
+            self.engine.num_pages,
+            config.page_size,
+            self.engine.page_table,
+            config.cache_type,
+            disable_prefix_cache=disable_prefix_cache,
+            on_prefix_cache_store=on_prefix_cache_store,
+            on_prefix_cache_match=on_prefix_cache_match,
+            prefix_state_checker=prefix_state_checker,
         )
         self.decode_manager = DecodeManager(config.page_size)
         self.prefill_manager = PrefillManager(
@@ -265,3 +301,8 @@ def _make_write_tuple(batch: Batch, device: torch.device) -> Indice2D:
     write_list = [(req.device_len if req.can_decode else -1) for req in batch.reqs]
     write_host = torch.tensor(write_list, dtype=torch.int64, pin_memory=True)
     return mapping_host.to(device, non_blocking=True), write_host.to(device, non_blocking=True)
+
+
+def _resolve_optional_callback(obj: object, name: str):
+    cb = getattr(obj, name, None)
+    return cb if callable(cb) else None

--- a/python/minisgl/scheduler/table.py
+++ b/python/minisgl/scheduler/table.py
@@ -1,11 +1,19 @@
+from typing import Callable
+
 import torch
 
 
 class TableManager:
-    def __init__(self, max_running_reqs: int, page_table: torch.Tensor) -> None:
+    def __init__(
+        self,
+        max_running_reqs: int,
+        page_table: torch.Tensor,
+        on_slot_allocated: Callable[[int], None] | None = None,
+    ) -> None:
         self._max_running_reqs = max_running_reqs
         self._free_slots = list(range(max_running_reqs))
         self.page_table = page_table
+        self._on_slot_allocated = on_slot_allocated
         # NOTE: dummy request also use this pool to get the input ids, so we need to
         # make sure the token pool is initialized with valid values (token_id = 0).
         self.token_pool = torch.zeros_like(page_table, dtype=torch.int32)
@@ -15,7 +23,10 @@ class TableManager:
         return len(self._free_slots)
 
     def allocate(self) -> int:
-        return self._free_slots.pop()
+        slot = self._free_slots.pop()
+        if self._on_slot_allocated is not None:
+            self._on_slot_allocated(slot)
+        return slot
 
     def free(self, slot: int) -> None:
         self._free_slots.append(slot)

--- a/python/minisgl/utils/__init__.py
+++ b/python/minisgl/utils/__init__.py
@@ -11,6 +11,7 @@ from .mp import (
     ZmqSubQueue,
 )
 from .registry import Registry
+from .custom_op import register_custom_op
 from .torch_utils import nvtx_annotate, torch_dtype
 
 __all__ = [
@@ -31,6 +32,7 @@ __all__ = [
     "torch_dtype",
     "nvtx_annotate",
     "Registry",
+    "register_custom_op",
     "ZmqPushQueue",
     "ZmqPullQueue",
     "ZmqPubQueue",

--- a/python/minisgl/utils/custom_op.py
+++ b/python/minisgl/utils/custom_op.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, TypeVar
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def register_custom_op(
+    *,
+    mutates_args: Iterable[str] | None = None,
+) -> Callable[[F], F]:
+    """Compatibility decorator for custom ops (no-op in minisgl)."""
+
+    def decorator(func: F) -> F:
+        setattr(func, "__minisgl_custom_op__", True)
+        setattr(func, "__minisgl_mutates_args__", tuple(mutates_args or ()))
+        return func
+
+    return decorator
+

--- a/python/minisgl/utils/hf.py
+++ b/python/minisgl/utils/hf.py
@@ -29,12 +29,17 @@ def load_tokenizer(model_path: str) -> PreTrainedTokenizerBase:
 
 @functools.cache
 def _load_hf_config(model_path: str) -> Any:
-    return AutoConfig.from_pretrained(model_path)
+    try:
+        return AutoConfig.from_pretrained(model_path)
+    except Exception:
+        # Fallback for new model types not yet registered in installed transformers.
+        config_dict, _ = PretrainedConfig.get_config_dict(model_path)
+        return PretrainedConfig.from_dict(config_dict)
 
 
 def cached_load_hf_config(model_path: str) -> PretrainedConfig:
     config = _load_hf_config(model_path)
-    return type(config)(**config.to_dict())
+    return type(config).from_dict(config.to_dict())
 
 
 def download_hf_weight(model_path: str) -> str:


### PR DESCRIPTION
## Background
This PR adds **Qwen3.5 text-only** model support to mini-sglang, while keeping the serving path aligned with existing mini-sglang/sglang runtime patterns.

## What Changed
1. Added `Qwen3.5` model implementation and model registration.
2. Added the required GDN/Radix linear-attention path for Qwen3.5 prefill/decode.
3. Introduced minimal runtime infrastructure needed by this path:
- forward-batch context wiring
- custom op registration helpers
- model-executor helpers
- compilation context utilities
4. Updated related attention/layer/scheduler/tokenizer/model-config wiring so `/v1/chat/completions` works end-to-end.

## Scope
- In scope: **text inference path only** for Qwen3.5 family.
- Out of scope: multimodal support, broader refactors unrelated to Qwen3.5.

## Validation
`python -m minisgl --model /root/models/Qwen3.6-27B --tp 8 --port 30000 --dtype bfloat16 --attn fi`

## Notes for Reviewers
- This PR touches multiple subsystems because Qwen3.5 depends on both model-side and attention backend/kernel-side support.
- Interfaces were kept as close as practical to upstream sglang patterns to reduce future sync cost.
