### PR TITLE
Gate 2: request lifecycle safety (multistep + batching + cancel protocol)

### DIFF
--- a/docs/ascend_port/gate1_verdict.md
+++ b/docs/ascend_port/gate1_verdict.md
@@ -1,0 +1,278 @@
+# Gate 1 Verdict — Single-Request Eager Inference on Ascend NPU
+
+**Gate ID:** 1 (single-request eager on Ascend 910B1)
+**Verdict:** PASS
+**Frozen at commit:** `0206c54398c4c7ab567aa9b0ef11cd1683ed69b2`
+**Branch:** `gate1-engine-bootstrap`
+**Tag:** `gate1-single-request-eager`
+**Date:** 2026-07-05
+
+Gate 1 covers the minimum viable path: one user request, greedy sampling,
+eager (non-graph) forward, tensor parallel size 1, single Ascend NPU. All
+Gate 1 invariants below were verified end-to-end on real hardware.
+
+---
+
+## 1. Hardware and software versions
+
+| Component | Version |
+| --- | --- |
+| Accelerator | Ascend 910B1 (64 GiB HBM per die, 8 dies available) |
+| Dies used by Gate 1 | 1 (`npu:0`) |
+| Host OS | Ubuntu 22.04.5 LTS (jammy) |
+| Python | 3.11.14 |
+| PyTorch | 2.9.0+cpu (CUDA build not present) |
+| torch_npu | 2.9.0.post1+gitee7ba04 |
+| CANN | 8.5.1 (from `/usr/local/Ascend/cann-8.5.1`) |
+| Model under test | Qwen3-0.6B, 28 transformer layers, `float16` |
+| Attention backend | `npu_fia` (Ascend Fused Infer Attention Score) |
+| Cache type | `radix` |
+| Page size | 16 |
+
+Full path locations, container IDs, and workstation credentials are recorded
+outside the repository (private ops notes) and are deliberately omitted from
+this document.
+
+---
+
+## 2. Supported scope
+
+Gate 1 signs off on the following combinations only.
+
+**In scope:**
+
+* Single accelerator, `tp_info.size == 1`.
+* Eager mode only (`cuda_graph_bs=[]`, `cuda_graph_max_bs=0`).
+* One user request per invocation, batch size 1.
+* Greedy sampling (`temperature=0.0`).
+* Attention backend: `npu_fia`.
+* KV cache layout: Ascend-native paged layout.
+* `offline_mode=True` scheduler driver (no ZMQ tokenizer / detokenizer).
+* Distributed runtime is initialized only when `tp_info.size > 1`. For
+  Gate 1 (TP=1) no `torch.distributed` backend is brought up on any device.
+
+**Out of scope — explicitly not covered by Gate 1:**
+
+* TP > 1 collective execution on NPU (HCCL smoke test only asserts init;
+  no forward/decode across ranks).
+* Continuous batching / concurrent requests.
+* CUDA-graph or ACL-graph capture on NPU.
+* Non-greedy samplers (top-k / top-p / temperature).
+* Cross-request radix prefix reuse.
+* Long-context correctness beyond the `max_seq_len_override=1024` used in
+  the smoke probes.
+* Speculative decoding, chunked prefill across multiple physical batches,
+  MoE routing on NPU.
+* CPU-only inference correctness (only dispatch surfaces are tested).
+
+---
+
+## 3. Key commits (chronological, oldest first)
+
+Portable device / distributed runtime foundations:
+
+* `806ee1b` docs: audit Ascend port dependencies
+* `5c61c7c` feat: add portable device detection
+* `fd63d66` feat: add distributed backend selection
+* `9171ae2` feat: add portable distributed runtime initialization
+* `949a7e9` refactor: make bootstrap package imports lazy
+* `f7b4578` build: make CUDA dependencies optional
+* `4d9a3ad` test: add Ascend HCCL smoke test
+* `b7a613a` refactor: use shared device binding in engine
+* `afb315d` feat: add portable device stream runtime
+* `d6f826e` refactor: use portable stream runtime in engine
+* `ca5b68f` feat: add portable device event runtime
+* `32eb41e` refactor: use portable events in engine forward
+* `e33d9fc` feat: add portable device memory maintenance
+* `51455c7` refactor: use portable memory runtime in engine
+* `aaf7f15` feat: add portable free memory query
+* `9024a41` refactor: use portable free memory query in engine
+* `395608c` refactor: use portable memory runtime in graph runner
+
+Ascend-native KV layout and FIA attention:
+
+* `ba49c56` feat: add Ascend-native paged KV layout
+* `d15a0ab` feat: register Ascend FIA attention backend
+* `998d0b9` feat: add single-request FIA attention metadata
+* `2133c38` feat: implement single-request FIA attention forward
+
+Ascend-native model layers and dispatch:
+
+* `4ff3f1b` feat: add Ascend RMSNorm runtime dispatch
+* `f717828` feat: add Ascend rotary embedding dispatch
+* `75dbda8` fix: make NVTX annotations safe on non-CUDA devices
+* `bf3724a` feat: add native embedding dispatch for NPU and CPU
+* `73797c7` feat: add NPU and CPU SwiGLU dispatch
+* `35aeab4` fix: reshape attention QKV before normalization and RoPE
+* `61a2b4e` fix: key RoPE cache by explicit device
+
+Gate 1.11 fixes (bring the smoke probe green):
+
+* `0c66e5d` fix: skip distributed init for NPU single-rank engine
+* `df11e1d` fix: drop CUDA-only NVTX context inside Sampler.sample
+* `40bc57d` fix: route Scheduler stream lifecycle through device_runtime
+* `0206c54` scheduler: guard sync_all_ranks against a missing CPU process group
+
+---
+
+## 4. Prefill / decode invariants
+
+Verified with a single-request scheduler-driven probe (Scheduler +
+Engine + attention backend, `offline_mode=True`, driven through the same
+`normal_loop` branch that `run_forever` executes).
+
+**Input:** `input_ids = [3, 7, 11, 15]`, `SamplingParams(temperature=0.0, max_tokens=2)`
+**Model:** Qwen3-0.6B, dtype `float16`.
+
+**Two-token output (greedy):**
+
+| Step | Batch phase | Batch size | Positions | `out_loc` | Next token | Finished |
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| 0 | prefill | 1 | `[0, 1, 2, 3]` | `[0, 1, 2, 3]` | `15087` | False |
+| 1 | decode | 1 | `[4]` | `[4]` | `11` | True |
+
+Post-run request state on the tracked request:
+
+* `req.cached_len = 5`, `req.device_len = 6`
+* `req.input_ids = [3, 7, 11, 15, 15087, 11]`
+* `req.can_decode = False` (max_tokens reached)
+* `token_pool[table_idx, :16] = [3, 7, 11, 15, 15087, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]`
+
+Reference tokens `[15087, 11]` are the frozen Gate 1 fixture. Any future
+change that shifts these values must be treated as a regression.
+
+---
+
+## 5. KV cache and FIA contracts
+
+**KV write contract (Ascend-native paged layout, `page_size=16`,
+28 transformer layers):**
+
+* Baseline: `_k_buffer[:, 0, :, :16, :]` and `_v_buffer[:, 0, :, :16, :]`
+  are zero before the request enters the scheduler.
+* After the two-step run, per-slot layer-hit counts (out of 28 layers):
+
+  ```
+  K per-slot layer hits: [28, 28, 28, 28, 28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+  V per-slot layer hits: [28, 28, 28, 28, 28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+  ```
+
+  Slots 0..4 receive writes from every layer for both K and V (4 prefill
+  tokens plus 1 decode token = 5 slots). Slots 5..15 remain untouched.
+
+**FIA call contract:**
+
+* `torch_npu.npu_fused_infer_attention_score` is invoked exactly
+  `layers × batches = 28 × 2 = 56` times per single-request two-token run.
+* `store_kv` is invoked the same 56 times — one KV write per FIA call.
+* `attn_backend.prepare_metadata` is invoked exactly `batches = 2` times.
+* `FIAMetadata.get_last_indices` is not exercised on the Gate 1 path
+  (single-request prefill uses `out_loc` directly).
+
+**Scheduler / engine call contract per run:**
+
+* `model.forward` × 2, `sampler.sample` × 2.
+* `torch.distributed.init_process_group`, `all_reduce`, and
+  `destroy_process_group` — each called **0 times**. Distributed is never
+  brought up for TP=1 NPU.
+* `Scheduler.shutdown()` returns cleanly (`synchronize_device("npu")`,
+  no-op `sync_all_ranks`, `engine.shutdown()`).
+
+---
+
+## 6. Regression evidence (local, container `998ce5ba6e5e`)
+
+Each test target run standalone at HEAD `0206c54` with the repo `python/`
+on `PYTHONPATH` to avoid the pre-existing cross-file test-order
+contamination (`test_device_runtime.py` installs stub package objects for
+its own isolation; `test_ascend_fia_backend.py` prepends `python/` as a
+side-effect other tests rely on).
+
+| Test module | Result |
+| --- | --- |
+| `tests/misc/test_device_runtime.py` | **59 passed** |
+| `tests/misc/test_engine_tp1_nodist.py` | **7 passed** |
+| `tests/misc/test_sampler_no_cuda_nvtx.py` | **4 passed** |
+| `tests/misc/test_scheduler_device_backend.py` | **5 passed** |
+| `tests/misc/test_scheduler_sync_all_ranks.py` | **4 passed** |
+| **Total** | **79 passed / 79** |
+
+## 7. 910B1 hardware evidence
+
+Minimum two-token smoke rerun at HEAD `0206c54`:
+
+* `PROBE_RESULT=PASS`
+* `iter_count=2`, wall clock about 1.15 s (excluding one-time weight load).
+* `reply_log[0].next_token = 15087`, `reply_log[0].finished = False`
+* `reply_log[1].next_token = 11`,   `reply_log[1].finished = True`
+* `dist_initialized (after run) = False`
+* `shutdown_ok = True`
+* Counters:
+  * `model_forward = 2`
+  * `sampler_sample = 2`
+  * `prepare_metadata = 2`
+  * `store_kv = 56`
+  * `fia = 56`
+  * `init_process_group = 0`
+  * `all_reduce = 0`
+  * `destroy_process_group = 0`
+
+The probe script itself is a private ops artifact and is intentionally
+not committed to the repository. Its inputs, expected outputs, and the
+observed counters are reproduced above verbatim so this document is
+self-contained evidence.
+
+---
+
+## 8. Known gaps not covered by Gate 1
+
+The following remain open and should be addressed by later gates.
+
+* **TP > 1 execution on NPU.** HCCL init is exercised by
+  `test_ascend_fia_backend`'s smoke and by `test_distributed_runtime`, but
+  no forward or decode has been run across ranks.
+* **Continuous batching.** Only a single request is exercised. Overlap
+  scheduling (`Scheduler.overlap_loop`) is untested on NPU.
+* **Graph capture on NPU.** `graph_runner.pad_batch` is called on the eager
+  path only; no ACL-graph capture verified.
+* **Non-greedy samplers.** `Sampler.sample` has been shown to work on
+  greedy on NPU; top-k / top-p / temperature paths are not verified.
+* **Long context and radix reuse.** `max_seq_len_override=1024` and a
+  fresh request per run — no cross-request prefix cache hit tested.
+* **Cross-file test isolation.** `test_device_runtime.py` and
+  `test_sampler_no_cuda_nvtx.py` fail when run in the same pytest process
+  as tests that legitimately import `torch_npu` or the real `minisgl`
+  package. This is a test-harness ordering issue, not a runtime bug; each
+  file passes standalone. Fixing it is a documentation / harness task,
+  not a runtime task.
+* **Detokenizer / API server path on NPU.** Only the offline scheduler is
+  driven; the ZMQ tokenizer / detokenizer processes are untested here.
+
+---
+
+## 9. Reproduction outline
+
+The evidence in this document can be reproduced from HEAD
+`0206c54398c4c7ab567aa9b0ef11cd1683ed69b2` on tag
+`gate1-single-request-eager` by, on an Ascend 910B1 host with CANN 8.5.1
+and `torch_npu 2.9.0.post1`:
+
+1. Check out the tag; ensure `python/` is on `PYTHONPATH`.
+2. Load a Qwen3-0.6B checkpoint in `float16`.
+3. Build a `SchedulerConfig` with the parameters listed in section 1
+   (attention backend `npu_fia`, page size 16, TP=1, `offline_mode=True`,
+   cuda-graph disabled).
+4. Feed `input_ids=[3, 7, 11, 15]` through a `UserMsg` with
+   `SamplingParams(temperature=0.0, max_tokens=2)`.
+5. Drive `Scheduler.normal_loop()` inside `scheduler.engine_stream_ctx`
+   until two `DetokenizeMsg` replies land.
+6. Expect the invariants in sections 4 and 5 to hold exactly.
+
+---
+
+## Sign-off
+
+All Gate 1 invariants verified at HEAD `0206c54`. Gate 1 is frozen at
+this commit and this document. No merge into `ascend-port` is performed
+by this gate — the tag `gate1-single-request-eager` is the load-bearing
+reference for downstream gates.

--- a/docs/ascend_port/gate2_1_multistep_verdict.md
+++ b/docs/ascend_port/gate2_1_multistep_verdict.md
@@ -1,0 +1,249 @@
+# Gate 2.1 Verdict — Single-Request Multi-Step Scheduler on Ascend NPU
+
+**Gate ID:** 2.1 (single-request multi-step scheduler on Ascend 910B1)
+**Verdict:** PASS
+**Frozen at commit:** `846c16f9bc8c9b6b09815546f03a2960f64b230c`
+**Branch:** `gate2-multistep-scheduler`
+**Tag:** `gate2-single-request-multistep`
+**Date:** 2026-07-05
+
+Gate 2.1 extends Gate 1 (single-request eager forward) with the full
+scheduler-driven multi-step generation loop on a single Ascend 910B1 die. All
+invariants below were verified on real hardware. Host paths, container IDs,
+and credentials are recorded in private ops notes and are deliberately omitted
+from this document.
+
+---
+
+## 1. Software and hardware
+
+| Component | Version |
+| --- | --- |
+| Accelerator | Ascend 910B1 (64 GiB HBM per die) |
+| Dies used | 1 (`npu:0`) |
+| Python | 3.11.14 |
+| PyTorch | 2.9.x |
+| torch_npu | 2.9.0.post1+gitee7ba04 |
+| apache-tvm-ffi | 0.1.4+ (declared floor; wheel `0.1.12` verified on clean install) |
+| Model | Qwen3-0.6B, 28 layers, `float16` |
+| Attention backend | `npu_fia` (Ascend Fused Infer Attention Score) |
+| Cache type | `radix` |
+| Page size | 16 tokens |
+| Tensor parallel size | 1 |
+| CUDA graph | disabled |
+
+---
+
+## 2. Supported scope
+
+Gate 2.1 signs off on the following combinations only:
+
+- Single-request path, greedy sampling only (`temperature=0.0`).
+- Prefill + decode driven by `Scheduler.normal_loop` in `offline_mode=True`.
+- Radix prefix cache with page size 16 and `ignore_eos={True,False}`.
+- Per-request `max_tokens` termination and per-request `stop_token_ids`
+  termination (immutable tuple, membership check happens after
+  `req.append_host` so the stop token itself is retained in the output).
+- Cross-page continuous generation (KV writes crossing a page boundary in
+  the same request).
+- Retained-prefix reuse via the Radix tree, and eviction back into the
+  free-slot pool via the production `_allocate` chain.
+
+---
+
+## 3. Out of scope (explicitly deferred)
+
+- Multi-request batching (concurrent prefill/decode across requests). See
+  §10 for the identified follow-up gate.
+- Tensor parallel size > 1 and any multi-die setup.
+- Non-greedy sampling (top-k, top-p, temperature != 0).
+- CUDA-graph capture on Ascend.
+- Continuous-batching admission / preemption policies.
+- Speculative or draft-model decoding.
+- Any performance / latency target — Gate 2.1 is a correctness gate.
+
+---
+
+## 4. Multi-step generation evidence
+
+Prompt `[3, 7, 11, 15]`, `max_tokens=8`, `temperature=0.0`,
+`ignore_eos=True`, page size 16:
+
+- Emitted tokens: `[15087, 11, 400, 4080, 16, 11, 15, 15087]`
+- Finished pattern: exactly the last step, no earlier flag.
+- One prefill batch (`positions=[0,1,2,3]`) followed by seven decode batches
+  (`positions=[4]` … `[10]`).
+- Distributed init counter `= 0`, `all_reduce` counter `= 0`.
+- `Scheduler.shutdown()` returns cleanly; CacheManager `available_size`
+  returns to its baseline.
+
+---
+
+## 5. Stop-token semantics
+
+`SamplingParams.stop_token_ids: tuple[int, ...] = ()`. The tuple default is
+immutable and shared across instances; a non-empty tuple activates a
+membership check in `Scheduler._process_last_data` **after**
+`req.append_host` runs, so the stop token itself remains in the output
+sequence.
+
+Prompt `[3, 7, 11, 15]`, `max_tokens=8`, `ignore_eos=True`,
+`stop_token_ids=(11,)`:
+
+- Emitted tokens: `[15087, 11]`
+- Finished pattern: `[False, True]`
+- The stop-token check is independent of `ignore_eos`. `ignore_eos` only
+  silences the tokenizer EOS; it does not disable user-declared stop
+  tokens. An empty tuple restores pre-Gate-2.1c behaviour verbatim.
+- No third batch is produced; distributed counters remain zero and the
+  allocator is fully restored on shutdown.
+
+Test coverage: `tests/misc/test_sampling_params_stop_tokens.py` (7 rows)
+plus `tests/misc/test_scheduler_stop_tokens.py` (10 rows) lock the field
+contract and the scheduler behaviour rows.
+
+---
+
+## 6. Cross-page KV contract
+
+Prompt `[3, 7, 11, 15]`, `max_tokens=20`, `ignore_eos=True`, page size 16
+crosses one page boundary in the same request:
+
+- Prefill fills physical page 0 slots `0..3`.
+- Decode steps `1..15` fill page 0 slots `4..15` (all 28 attention layers).
+- Step 16 opens page 1 slot 0 (`out_loc=16`, `positions=[16]`); the page
+  table row extends from `[page0, page1, …]`.
+- After step 19 the request holds `cached_len=23`, `device_len=24` on
+  logical page slots `0..6` of page 1; slots `7..15` remain zero (`K=0,
+  V=0` across all layers) and page 2 is untouched.
+- KV writes on page 0 are frozen once the page is full — subsequent
+  reuse must not rewrite the retained content (see §7).
+
+---
+
+## 7. Radix reuse and eviction contract
+
+Two consecutive requests share a 16-token prefix:
+
+**Phase A — build the retained page.** Same prompt as §6; after the
+request finishes the radix root has one child with `page_id=0`,
+`length=16`, `ref_count=0`, and `evictable_size=16`.
+
+**Phase B — reuse.** Submit `prefix16 + [123]` with `max_tokens=1`. The
+scheduler produces exactly one prefill batch with `cached_len=16`,
+`device_len=17`, `positions=[16]`, and 28 FIA calls / 28 `store_kv` calls
+for the single new token. The retained physical page 0 is bit-equal
+before and after Phase B (`torch.equal` on both K and V buffers). The
+retained node's `page_id=0` still points into the radix root, the new
+token lands in a fresh physical slot (page 2 slot 0 in the observed run),
+and `available_size` is unchanged.
+
+**Phase C — production eviction round-trip.** Force the eviction branch
+by calling `CacheManager._allocate(free_pages + evictable_pages)`. This
+invokes `RadixPrefixCache.evict` and concatenates the evicted pages into
+`free_slots`, then `_free` returns them. Observed transitions:
+
+- `free_pages`: baseline → baseline-1 (retained) → 0 (post `_allocate`) → baseline (restored)
+- `evictable_size`: `0 → 16 → 0` (post-eviction)
+- Radix root children: `[{page_id: 0, len: 16, ref: 0}] → []` after evict.
+- `available_size` returns to the pre-Gate-2.1 baseline.
+
+Probe verdict: `PROBE_RESULT=PASS`. Distributed remains uninitialised;
+`shutdown()` clean.
+
+---
+
+## 8. Dependency requirement — `apache-tvm-ffi`
+
+`RadixPrefixCache._tree_walk → get_match_len → fast_compare_key` (loaded
+via `tvm_ffi.cpp.load` inside `minisgl.kernel.utils.load_aot`) runs on
+every prefix match on every supported device (CUDA, Ascend NPU, CPU).
+Before Gate 2.1g, `apache-tvm-ffi>=0.1.4` was declared only in the
+`[project.optional-dependencies].cuda` extra, and the project's install
+command (both `README.md` and the container `Dockerfile`) is
+`pip install -e .` without any extra. Clean Ascend installs therefore
+missed the wheel and crashed with
+`ModuleNotFoundError: No module named 'tvm_ffi'` on the first prefix
+scheduling call.
+
+Gate 2.1g moved the pin into base `[project].dependencies` (no
+duplication with the `cuda` extra) and added three structural tests
+under `tests/misc/test_pyproject_config.py`:
+
+- `test_cross_device_required_dep_is_in_base_dependencies` — must be a
+  base dep.
+- `test_cross_device_required_dep_not_only_in_cuda_extra` — must not be
+  duplicated in the `cuda` extra.
+- `test_apache_tvm_ffi_pin_preserved` — pin string
+  `apache-tvm-ffi>=0.1.4` is exact.
+
+Clean-venv smoke: `pip install -e .` in a fresh Python 3.11 venv
+auto-installs `apache-tvm-ffi==0.1.12`; `import tvm_ffi`,
+`from tvm_ffi.cpp import load`, and the three-state `fast_compare_key`
+smoke (identical → 5, diff-at-3 → 3, disjoint → 0) all pass.
+
+---
+
+## 9. Common invariants (all evidence runs)
+
+Every smoke, probe, and test run recorded above satisfies:
+
+- `torch.distributed.is_initialized() == False` at teardown.
+- `Scheduler.shutdown()` returns without raising.
+- `CacheManager.available_size` post-shutdown equals its baseline.
+- No CUDA-only surface (`torch.cuda.nvtx`, `torch.cuda.stream`, etc.)
+  is invoked on the NPU code path (locked by `test_sampler_no_cuda_nvtx`
+  and `test_device_runtime` isolation-mode passes).
+
+---
+
+## 10. Known follow-up gap — multi-request batching
+
+Gate 2.1 verifies a single in-flight request end-to-end. The next Gate
+(2.2, to be scoped) must cover:
+
+- Concurrent prefill of two or more requests in the same batch.
+- Mixed prefill+decode batches (chunked prefill continuation).
+- Prefix-cache reuse across two requests submitted in the same
+  scheduler tick.
+- Correct account of KV pages, `free_slots`, and `evictable_size` when
+  requests finish in a different order from the order they were
+  submitted.
+- Correct interaction between per-request `stop_token_ids` and batched
+  decode (the current membership check runs per request in
+  `_process_last_data`; batched cases must not conflate flags).
+
+No runtime code should need to change for Gate 2.1's single-request
+scope, but the batch scheduler and cache manager will exercise code
+paths not covered by this verdict.
+
+---
+
+## 11. Evidence trail (commit summary)
+
+- `ff0549e` `scheduler: honour per-request stop_token_ids (Gate 2.1c)`
+- `846c16f` `deps: move apache-tvm-ffi to base dependencies (Gate 2.1g)`
+
+Intermediate probe scripts (single-page decode, cross-page decode,
+retained prefix reuse, eviction round-trip, dependency smoke) are not
+committed to the repository per policy — their outputs are summarised
+above.
+
+---
+
+## 12. Test surface locked at this gate
+
+- `tests/misc/test_sampling_params_stop_tokens.py` — 7 rows
+- `tests/misc/test_scheduler_stop_tokens.py` — 10 rows
+- `tests/misc/test_pyproject_config.py` — 14 rows (adds `apache-tvm-ffi`
+  cross-device placement)
+- `tests/misc/test_scheduler_device_backend.py` — 5 rows
+- `tests/misc/test_scheduler_sync_all_ranks.py` — 4 rows
+- `tests/misc/test_device.py` — 8 rows
+- `tests/misc/test_device_runtime.py` — 59 rows (passing under module
+  isolation; per-module `sys.modules` state is a pre-existing test
+  concern, not a Gate 2.1 regression)
+- `tests/misc/test_sampler_no_cuda_nvtx.py` — 4 rows
+
+Total: **111 rows pass** under isolated invocation on the target
+platform.

--- a/docs/ascend_port/gate2_2_multirequest_verdict.md
+++ b/docs/ascend_port/gate2_2_multirequest_verdict.md
@@ -1,0 +1,365 @@
+# Gate 2.2 Verdict — Multi-Request Batching on Ascend NPU
+
+**Gate ID:** 2.2 (multi-request batching on Ascend 910B1)
+**Verdict:** PASS
+**Frozen at commit:** `3d6b3edf1aae971082ec6cebec8e88f481e68193`
+**Branch:** `gate2-multirequest-batching`
+**Tag:** `gate2-multirequest-batching`
+**Date:** 2026-07-05
+
+Gate 2.2 lifts the Ascend FIA backend and the scheduler from the
+single-in-flight-request scope frozen at Gate 2.1 to concurrent
+multi-request batching under `Scheduler.normal_loop` in `offline_mode=True`.
+All invariants below were verified on a single Ascend 910B1 die on real
+hardware. Host paths, container IDs, and credentials are recorded in
+private ops notes and are deliberately omitted from this document.
+
+---
+
+## 1. Software and hardware
+
+Inherits Gate 2.1's platform (see `gate2_1_multistep_verdict.md` §1):
+
+| Component | Value |
+| --- | --- |
+| Accelerator | Ascend 910B1 (64 GiB HBM per die) |
+| Dies used | 1 (`npu:0`) |
+| Model | Qwen3-0.6B, 28 layers, `float16` |
+| Attention backend | `npu_fia` (Ascend Fused Infer Attention Score) |
+| Cache type | `radix` |
+| Page size | 16 tokens |
+| Tensor parallel size | 1 |
+| CUDA graph | disabled |
+
+---
+
+## 2. Supported scope
+
+Gate 2.2 signs off on the following combinations, in addition to the
+Gate 2.1 single-request scope:
+
+- **Equal-length prefill (`B >= 1`).** Every request in the prefill
+  batch shares `extend_len`, `device_len`, and `cached_len`. Query is
+  reshaped `[B, S, Hq, D]` BSND, `actual_seq_lengths = [S]*B`,
+  `actual_seq_lengths_kv = [S+cached]*B`.
+- **Ragged prefill with no cached prefix (`B >= 1`).** Every request
+  has `cached_len == 0`; individual `extend_len == device_len` values
+  may differ. Query is right-padded to `max_query_len` along the S axis
+  and each request supplies its own `actual_seq_lengths[i]` /
+  `actual_seq_lengths_kv[i]`. Padding rows read `atten_mask=None`.
+- **Pure-decode batches with mixed `cached_len` (`B >= 1`).** Every
+  request has `extend_len == 1`; `cached_len` (equivalently `device_len`)
+  may differ per request. `query_seq_lens = [1]*B`,
+  `actual_seq_lengths_kv[i]` records each request's KV length, and
+  `max_query_len == 1` so the FIA `atten_mask` argument is `None`.
+- **Dynamic admission during decode.** A new request that arrives while
+  one or more requests are running is prefilled in the very next tick as
+  a single-request prefill batch, then joins the running set for joint
+  decode on the subsequent tick. Existing requests' KV pages, page-table
+  rows, and radix-cache state are bit-equal across the admission event.
+- **Batch grow/shrink over a request's lifetime.** The batch size seen
+  by the attention backend follows the observed admission/completion
+  order, e.g. `[prefill1, prefill1, decode2, prefill1, decode3, decode2,
+  decode1]`. Requests finish in `max_tokens` order, and each completion
+  releases its page-table row and KV slots back to the pool.
+- **Per-request `max_tokens` and `stop_token_ids` under batching.** The
+  membership check runs per request inside `_process_last_data` after
+  each request's own `append_host`; a stop for one request does not
+  alter any other request's flag.
+- **Cross-request KV isolation.** All observed multi-request runs have
+  pair-wise-disjoint `table_idx` sets and pair-wise-disjoint physical
+  page id sets across requests active in the same batch.
+
+---
+
+## 3. Out of scope (explicitly deferred)
+
+Deferred to a later gate; the FIA backend raises `NotImplementedError`
+today when asked for these shapes:
+
+- **Ragged prefill with a cached prefix in the same batch.** Any batch
+  where some request has `cached_len > 0` *and* some request has
+  `extend_len > 1` while the batch is not entirely equal-length is
+  refused. The FIA operator supports the shape in principle, but the
+  wrapper does not yet emit the split-KV layout and the scheduler does
+  not currently produce this shape (prefill-first admission below).
+- **Chunked prefill continuation** (splitting a single request's prefill
+  across two ticks).
+- **Non-greedy sampling** (`temperature > 0`, top-k, top-p).
+- **Preemption / re-scheduling of an in-flight request.** The scheduler
+  currently admits new prefill work only when free page-table slots
+  exist; it does not evict a running request to make room.
+- **Cancellation and mid-request error recovery.** A raised exception
+  inside the engine is not proven to leave the allocator, page table,
+  and radix tree in their pre-batch state under partial completion.
+- **Server / IPC path.** All Gate 2.2 evidence runs go through
+  `offline_mode=True` with an in-process driver replacing
+  `offline_receive_msg` / `offline_send_result`. The ZMQ / socket
+  transport is not exercised.
+- **Stress / soak testing.** No large-batch or long-duration runs.
+- **Tensor parallel size > 1**, multi-die setups, and CUDA-graph capture
+  on Ascend all remain out of scope, per Gate 2.1.
+- **Performance / latency targets.** Gate 2.2 is a correctness gate.
+
+---
+
+## 4. Equal-length batching contract (Gate 2.2c)
+
+`AscendFIABackend.prepare_metadata` classifies every batch by walking
+`batch.reqs` once. When every request shares `extend_len`, `device_len`,
+and `cached_len` with the head request, the batch takes the
+**equal-length** path:
+
+- `FIAMetadata.query_seq_len = extend_len` (shared) and
+  `kv_seq_len = device_len` (shared).
+- `query_seq_lens = [extend_len]*B`,
+  `kv_seq_lens = [device_len]*B`.
+- `actual_seq_lengths = [extend_len]*B`,
+  `actual_seq_lengths_kv = [device_len]*B`.
+- `max_query_len = extend_len`; the FIA `atten_mask` is a causal mask
+  built once when `max_query_len > 1` and passed as `None` when
+  `max_query_len == 1` (decode).
+- `block_table` is a `[B, max_pages]` `int32` tensor sliced from
+  `engine.page_table`; per-batch max page count comes from the shared
+  `device_len`.
+- KV writes use the flat `batch.out_loc` produced by the scheduler,
+  concatenating per-request slots in request order.
+
+Evidence (`gate22i_smoke1_equal.py`): two requests of length 4 with
+`max_tokens=2` produce one prefill batch (`size=2`, `query_seq_len=4`)
+followed by one decode batch (`size=2`, `query_seq_len=1`,
+`kv_seq_len=5`). Pages `{0}` and `{1}` are disjoint; the allocator and
+page-table free list return to their baselines.
+
+---
+
+## 5. Ragged prefill contract (Gate 2.2f)
+
+When at least one request in a prefill batch differs from the head in
+`extend_len` and every request has `cached_len == 0`, the batch takes
+the **ragged-prefill** path:
+
+- Query is right-padded to `max_query_len = max(extend_len)` along the
+  S axis so the operator sees `[B, max_query_len, Hq, D]` BSND.
+- `actual_seq_lengths[i] = extend_len[i]` and
+  `actual_seq_lengths_kv[i] = device_len[i] == extend_len[i]`. The
+  operator uses these lengths to short-circuit padded rows.
+- `atten_mask` is the same causal mask used by equal-length prefill,
+  sized to `max_query_len`.
+- KV writes use the flat `batch.out_loc`, sized to
+  `sum(extend_len)` — padded rows do **not** contribute to KV writes.
+
+Evidence (`gate22f_paired.py`, and the ragged tests in
+`tests/misc/test_ascend_fia_backend.py`): a `B=2` prefill with
+`extend_len=[4, 2]` and `cached_len=[0, 0]` runs one FIA call per
+layer with `query_seq_lens=[4,2]`, `kv_seq_lens=[4,2]`, and produces
+disjoint per-request KV pages. Output shape matches the flat
+`sum(extend_len)`-row layout that the scheduler expects.
+
+---
+
+## 6. Pure-decode mixed-cached-length contract (Gate 2.2f extension)
+
+When every request has `extend_len == 1` but individual `cached_len`
+(equivalently `device_len`) values differ, the batch takes the
+**pure-decode** path:
+
+- `query_seq_lens = [1]*B`, `max_query_len = 1`, so `atten_mask` is
+  passed as `None` to FIA (decode has no future to mask).
+- `actual_seq_lengths = [1]*B`,
+  `actual_seq_lengths_kv[i] = device_len[i]` — each request answers its
+  own KV length.
+- `block_table` is `[B, max_pages]` where `max_pages =
+  ceil(max(device_len) / page_size)`; rows are independently sliced per
+  request from `engine.page_table[req.table_idx]` and the unused
+  columns of shorter requests carry the page-table's default `0` padding.
+- Query and output remain flat `[B, Hq, D]` at the wrapper boundary,
+  reshaped to `[B, 1, Hq, D]` BSND only inside `forward`.
+
+Evidence (four `test_gate22f_*` rows in
+`tests/misc/test_ascend_fia_backend.py`): a `B=2` decode with
+`cached_len=[4, 2]`, `device_len=[5, 3]` produces
+`actual_seq_lengths_kv=[5, 3]`, `atten_mask=None`, and `store_kv`
+receives the batch-wide `out_loc` unchanged.
+
+---
+
+## 7. Rejected shape today — ragged prefill with cached prefix
+
+Batches where *some* request has `cached_len > 0` and *some* request has
+`extend_len > 1`, and the batch is not entirely equal-length, raise
+`NotImplementedError` inside `prepare_metadata`. The wrapper's
+`raise` is the enforcement point; the classification loop reports the
+first offender (uid, `cached_len`, `extend_len`, `device_len`).
+
+The scheduler as of this gate does not currently emit this shape:
+
+- New requests are admitted only when there is a free page-table slot.
+- `_schedule_next_batch` picks any pending prefill work before any
+  decode work each tick, so a newly-arrived request always gets its own
+  single-request prefill tick before joining the running decode batch.
+- The only ragged-prefill batches produced by the scheduler have
+  `cached_len == 0` for every request in that batch (radix hits reuse
+  the retained pages via a separate code path that shares the same
+  `cached_len` across the batch — verified by the equal-length
+  contract).
+
+The consequence is that Gate 2.2 does not need a mixed-cached-prefix
+ragged prefill path to be correct today, but adopting chunked prefill,
+speculative decoding, or continuous batching in a later gate will
+require lifting this rejection.
+
+---
+
+## 8. Dynamic admission strategy (Gate 2.2g)
+
+`Scheduler.normal_loop` ingests messages via `offline_receive_msg` at
+the top of every tick before it calls `_schedule_next_batch`. The
+observed policy under Gate 2.2:
+
+- **Prefill-before-decode priority.** If `PrefillManager.pending_list`
+  is non-empty and there is a free page-table slot, `_schedule_next_batch`
+  returns a prefill batch. The still-running decode set is queued for
+  the next tick.
+- **Single-request admission tick.** A newly-arrived request is
+  prefilled by itself on the first tick after it arrives, then joins
+  the joint decode batch on the following tick.
+- **Bit-equal isolation.** For every observed admission event, the
+  running requests' K-cache slices over `[0 .. device_len-1]` (i.e. the
+  KV that had already been written to HBM) are `torch.equal`-bit-equal
+  before and after the newcomer's prefill runs. The newcomer's KV lands
+  in a disjoint set of pages and its page-table row is a fresh slot.
+- **No preemption.** No running request is displaced or truncated by the
+  admission of a new request. The active count is bounded above by
+  `max_running_req` and by page-table capacity; today the admission
+  order is FIFO on `pending_list`.
+
+Evidence (`gate22g_dynamic.py`): submit A alone, tick prefill; while A
+is running, push B; next tick prefills B alone; next tick runs an
+`A+B` joint decode. Verified: A's tokens match its single-request
+baseline `[15087, 11, 400, 4080]`; B's tokens match its single-request
+baseline `[315, 279, 7042, 304]`; A's KV over its written prefix is
+bit-equal across the admission event; page-table and page sets are
+disjoint; the allocator returns to baseline on shutdown.
+
+---
+
+## 9. Batch grow/shrink timeline (Gate 2.2h)
+
+Three requests A (`max_tokens=5`), B (`max_tokens=4`), C (`max_tokens=2`)
+were admitted at three different scheduler ticks. The scheduler produced
+the following batch-size timeline through the backend:
+
+| Step | Phase | Size | uids |
+| :--: | :--: | :--: | :--: |
+| 0 | prefill | 1 | `{A}` |
+| 1 | prefill | 1 | `{B}` |
+| 2 | decode  | 2 | `{A,B}` |
+| 3 | prefill | 1 | `{C}` |
+| 4 | decode  | 3 | `{A,B,C}` |
+| 5 | decode  | 2 | `{A,B}` (C finished) |
+| 6 | decode  | 1 | `{A}` (B finished) |
+
+At the size-3 decode step (step 4), `query_seq_lens = [1,1,1]`,
+`max_query_len = 1` (so the FIA `atten_mask` is `None`), and
+`actual_seq_lengths_kv` records each request's individual KV length.
+The `table_idx` sets and physical page sets are pair-wise disjoint
+across all three requests over the entire timeline. Every per-request
+output matches its single-request baseline verbatim.
+
+Shrink evidence: after C completes at step 5, the batch shrinks to
+`{A, B}`; after B completes at step 6, only A remains. On the final
+`shutdown()`, `CacheManager.available_size`, `free_slots`, and
+`TableManager._free_slots` all match their pre-run baselines and
+`torch.distributed.is_initialized() == False`.
+
+---
+
+## 10. KV and table isolation and reclamation
+
+The following invariants hold across every Gate 2.2 smoke and probe:
+
+- `TableManager._free_slots` is restored to its pre-batch state after
+  every request completes.
+- `CacheManager.available_size` and `len(CacheManager.free_slots)` are
+  restored to their pre-batch baselines after `Scheduler.shutdown()`.
+- Physical page id sets are pair-wise disjoint across requests active in
+  the same batch (observed on every multi-request smoke).
+- `table_idx` sets are pair-wise disjoint across requests active in the
+  same batch.
+- The layer-0 K-cache slice over each request's written prefix is
+  `torch.equal`-bit-equal before and after any concurrent request's
+  prefill or decode step.
+- `torch.distributed.is_initialized() == False` at teardown.
+  `init_process_group` and `all_reduce` counters remain zero.
+
+---
+
+## 11. Common invariants (all evidence runs)
+
+Every Gate 2.2 smoke and probe additionally satisfies the Gate 2.1
+invariants:
+
+- `Scheduler.shutdown()` returns without raising.
+- No CUDA-only surface (`torch.cuda.nvtx`, `torch.cuda.stream`, etc.)
+  is invoked on the NPU code path.
+- Greedy sampling, `page_size = 16`, `tp_size = 1`, `cache_type = radix`,
+  `attention_backend = npu_fia`.
+
+---
+
+## 12. Test surface locked at this gate
+
+Locked test files (all pass on the target platform under the standard
+pytest invocation; row counts recorded at gate freeze):
+
+- `tests/misc/test_ascend_fia_backend.py` — 65 rows (equal-length,
+  ragged-prefill, and pure-decode mixed-cached-length contracts).
+- `tests/misc/test_scheduler_device_backend.py` — 5 rows.
+- `tests/misc/test_scheduler_sync_all_ranks.py` — 4 rows.
+- `tests/misc/test_scheduler_stop_tokens.py` — 10 rows (inherited from
+  Gate 2.1c; still valid under batching because the check is
+  per-request).
+- `tests/misc/test_sampling_params_stop_tokens.py` — 7 rows.
+- `tests/misc/test_pyproject_config.py` — 14 rows.
+
+Total: **105 rows pass** under the standard invocation on the target
+platform.
+
+---
+
+## 13. Evidence trail (commit summary)
+
+- `3f8146c` `attention/ascend_fia: support equal-length B>=1 batches (Gate 2.2c)`
+- `3d6b3ed` `attention/ascend_fia: ragged prefill + pure-decode mixed cached (Gate 2.2f)`
+
+Intermediate probe scripts (equal-length paired, ragged-prompt paired,
+dynamic admission, three-request grow/shrink) are not committed to the
+repository per policy — their outputs are summarised above.
+
+---
+
+## 14. Next-phase gaps
+
+The following are the identified follow-ups for the gate after 2.2.
+They are not regressions of Gate 2.2; they are shapes that Gate 2.2's
+scope deliberately excludes:
+
+- **Ragged prefill with cached prefix.** Lift the `NotImplementedError`
+  in `prepare_metadata` once the scheduler emits this shape (chunked
+  prefill or speculative decoding).
+- **Cancellation and exception paths.** Prove that a mid-batch raise
+  (allocator failure, model failure, driver disconnect) restores
+  `CacheManager`, `TableManager`, and radix state to their pre-batch
+  baselines.
+- **Server / IPC transport.** Reproduce every Gate 2.2 smoke through
+  the real ZMQ / socket path, not the in-process offline driver.
+- **Preemption / re-scheduling.** Admit new prefill work by evicting a
+  running request when the running set is at capacity.
+- **Stress / soak.** Long-duration multi-request runs (hundreds of
+  concurrent requests, thousands of ticks) with allocator and radix
+  accounting checked on a rolling basis.
+- **Batched `stop_token_ids` audit.** The per-request check works today;
+  a dedicated batched-stop test row should be added when the scheduler
+  supports per-tick multi-request stop concurrency beyond what
+  `test_scheduler_stop_tokens.py` covers.

--- a/docs/ascend_port/gate2_3_request_lifecycle_verdict.md
+++ b/docs/ascend_port/gate2_3_request_lifecycle_verdict.md
@@ -1,0 +1,490 @@
+# Gate 2.3 Verdict — Request Lifecycle and Cancel Protocol on Ascend NPU
+
+**Gate ID:** 2.3 (request lifecycle and cancel protocol on Ascend 910B1)
+**Verdict:** PASS
+**Branch:** `gate2-request-lifecycle`
+**Runtime frozen at commit:** `ac1bb8e58de7987c581a71806bf1cde3122e1be0`
+**Tag:** `gate2-request-lifecycle` (points to the verdict-freeze commit)
+**Date:** 2026-07-05
+
+Gate 2.3 hardens the request lifecycle in the Ascend 910B1 port along the
+axes that Gate 2.2 deliberately excluded (see
+`gate2_2_multirequest_verdict.md` §14 "Cancellation and exception paths"):
+transactional page allocation, sampler commit atomicity, shutdown drain,
+overlap-loop abort fence, and end-to-end abort acknowledgement between
+the frontend, tokenizer, and scheduler. All invariants below were
+verified on a single Ascend 910B1 die on real hardware or through
+hermetic tests committed to this branch. Host paths, container IDs, and
+credentials are recorded in private ops notes and are deliberately
+omitted from this document.
+
+---
+
+## 1. Software and hardware
+
+Inherits Gate 2.2's platform (see `gate2_2_multirequest_verdict.md` §1):
+
+| Component | Value |
+| --- | --- |
+| Accelerator | Ascend 910B1 (64 GiB HBM per die) |
+| Dies used | 1 (`npu:0`) |
+| Model | Qwen3-0.6B, 28 layers, `float16` |
+| Attention backend | `npu_fia` (Ascend Fused Infer Attention Score) |
+| Cache type | `radix` |
+| Page size | 16 tokens |
+| Tensor parallel size | 1 |
+| CUDA graph | disabled |
+| Scheduler mode | `offline_mode=True` for in-process probes; server
+  path unchanged |
+
+---
+
+## 2. Scope
+
+Gate 2.3 signs off on the following behaviours, in addition to the
+Gate 2.2 multi-request batching scope:
+
+- **Transactional page allocation in `_prepare_batch`.** A failure
+  raised anywhere between KV-page allocation and the sampler
+  commit boundary restores the allocator (`CacheManager.available_size`
+  and `CacheManager.free_slots` cardinality) and the `page_table` rows
+  of unrelated requests to the pre-batch snapshot.
+- **Atomic request-state commit past the sampler.** The scheduler
+  writes back `input_ids`, `device_len`, and `cached_len` only after
+  the sampler has returned a token successfully. A raise inside the
+  sampler leaves every request's logical length and host-token buffer
+  unchanged.
+- **Shutdown drain.** `Scheduler.shutdown` frees every pending and
+  running request before tearing down the engine, so the allocator,
+  page table, and radix cache return to their pre-run baseline
+  regardless of the state at shutdown time.
+- **Overlap-loop abort fence.** An `AbortBackendMsg` that arrives while
+  the target `uid` is inflight on device is deferred to
+  `deferred_abort_uids`. The uid is yanked from the schedulable set
+  immediately, its post-fence sampled token is suppressed, and its
+  resources are freed exactly once after `_process_last_data` has
+  drained the fence tail. Sibling requests in the same batch keep
+  their sampled tokens and stay running.
+- **End-to-end abort acknowledgement.** The scheduler emits an
+  `AbortAckMsg` on the tokenizer channel after — and only after —
+  `_free_req_resources` has run for the aborted uid. The tokenizer
+  forwards it as `AbortAckReply` to the frontend, and the frontend
+  drains its `abort_pending` state and unblocks any waiter. The
+  acknowledgement path is a first-class message channel, never a
+  cancel-stub `DetokenizeMsg(next_token=-1)`.
+- **Frontend abort-pending state machine.** Between
+  `abort_user(uid)` and receipt of `AbortAckReply(uid)`, the frontend
+  drops any late `UserReply(uid)` that races the ack, keeps the
+  request's ack-map and event-map entries alive, and cleans all four
+  buckets (`ack_map`, `event_map`, `abort_pending`,
+  `abort_pending_events`) idempotently on ack arrival.
+
+---
+
+## 3. Explicit non-scope
+
+Gate 2.3 does NOT attempt, and does NOT attest to, the following:
+
+- **In-process sampler recovery.** After a sampler failure, the
+  scheduler propagates the exception unchanged; there is no attempt to
+  restart the sampler on the same tick, re-sample from the same
+  hidden states, or resume the aborted forward. Gate 2.3c's assertion
+  is atomicity of the commit boundary, not recovery.
+- **`model.forward` / FIA in-process recovery.** A raise from inside
+  the attention or transformer stack terminates the tick. There is
+  no partial retry.
+- **CPU copy / event-record failures past the sampler.** Once the
+  sampler has committed a token and the scheduler has advanced the
+  request, a raise in the CPU-side detokenize-copy or the event-record
+  path is not covered — recovery would require reverting a
+  committed token, which is out of scope.
+- **Full HTTP + ZMQ cross-process cancel.** The abort acknowledgement
+  contract is proven with the in-process offline driver and hermetic
+  tests. Cross-process transport regressions are Gate 2.4 material.
+- **Server crash / restart lifecycle.** No client-side reconnect or
+  request-replay semantics are asserted.
+- **Tensor-parallel size > 1 lifecycle.** All evidence is single-die.
+- **Long soak.** No thousand-tick, hundreds-of-request stress run is
+  part of the gate.
+
+---
+
+## 4. Gate 2.3a — Pre-work audit
+
+Before touching runtime code, the pre-2.3 request lifecycle was audited
+against the crash / cancel / shutdown scenarios that Gate 2.2 identified
+as out-of-scope. The relevant findings:
+
+- `_prepare_batch` allocated KV pages incrementally without a rollback
+  path. A raise between KV-page allocation and the sampler committing
+  a token would leak pages back onto no free list, permanently
+  reducing `available_size`.
+- `Engine.forward_batch` wrote back `input_ids`, `device_len`,
+  `cached_len` before the sampler committed. A sampler failure
+  therefore left the request advanced by one token that was never
+  produced, breaking the invariant that host token counts match the
+  scheduler's view.
+- `Scheduler.shutdown` tore down the engine without walking the
+  pending or running sets. In-flight requests leaked their KV pages
+  and their table-manager slots, so a re-instantiated scheduler
+  observed non-baseline allocator state.
+- `overlap_loop` had no fence between "abort msg observed on host"
+  and "device forward for the target uid still in flight". A
+  well-timed abort could free a KV page while it was being read by a
+  running attention kernel.
+- `AbortBackendMsg` had no acknowledgement path. The frontend used a
+  timeout-based heuristic to declare the request cancelled, which
+  raced natural finishes.
+
+These findings drove the changes committed in Gate 2.3b through 2.3f.
+
+---
+
+## 5. Gate 2.3b — Transactional page allocation
+
+**Runtime commit:** `d520a71` — `scheduler: transactional page allocation rollback in _prepare_batch`
+
+Invariants asserted:
+
+- Every KV page allocated inside `_prepare_batch` is tracked. On any
+  raise between the first allocation and the successful return of the
+  method, `rollback_allocation` returns the allocated pages to the
+  cache manager.
+- The `cache_manager`'s `available_size` and the length of
+  `free_slots` after the rollback are bit-equal to the pre-batch
+  snapshot.
+- The `page_table` rows of requests unrelated to the failing batch
+  are not touched by the rollback.
+- Scratch attributes (`batch.positions`, `out_loc`, `padded_reqs`,
+  `attn_metadata`) written inside the failing method are cleared, so
+  no stale pointer to a freed page survives.
+- A fresh request pushed after the rollback completes normally and
+  the allocator returns to the same free-page cardinality once that
+  request retires.
+
+Explicitly out-of-scope for 2.3b: `table_manager.allocate` runs in the
+upstream `PrefillAdder` step, not inside `_prepare_batch`. The
+transaction covers only the KV-page allocations that `_prepare_batch`
+itself performs.
+
+Regression coverage: `tests/misc/test_scheduler_prepare_batch_txn.py`
+— 5 tests, PASS.
+
+Real-device evidence: fresh 910B1 probe run in this Gate 2.3g freeze.
+
+```
+pre_avail=271840   pre_free_pages=16990
+post_avail=271840  post_free_pages=16990   (rollback restored allocator)
+post_fu_avail=271856 post_fu_free_pages=16991 (followup req retired cleanly)
+prep_err='gate2.3g probe A synthetic rejection'
+first_prefix_row_pre  == first_prefix_row_post  (retained prefix untouched)
+VERDICT: PASS
+```
+
+---
+
+## 6. Gate 2.3c — Sampler commit atomicity
+
+**Runtime commit:** `f56ce2a` — `engine: atomic request-state commit past sampler in forward_batch`
+
+Invariants asserted:
+
+- `Engine.forward_batch` writes back `input_ids`, `device_len`, and
+  `cached_len` only after the sampler has returned. A raise inside
+  the sampler leaves every request's logical state unchanged.
+- The exception raised inside the sampler propagates unchanged; the
+  scheduler does NOT swallow, translate, or retry it.
+- The host CPU token buffer is not appended to on the failing tick.
+
+Regression coverage:
+`tests/misc/test_engine_forward_sampler_atomic.py` — 5 tests, PASS.
+
+Real-device evidence status:
+
+```
+Sampler atomicity evidence status:
+- Original Gate 2.3c 910B1 evidence: PASS
+- Evidence commit: f56ce2a
+- Gate 2.3g fresh re-attestation: NOT RUN
+- Reason: the freeze-only probe addressed the wrong model wrapper
+  (`Qwen3ForCausalLM.named_modules`), so it failed before fault
+  injection.
+- This is a probe-construction defect, not a runtime failure.
+- No runtime or probe code was modified during Gate 2.3g.
+```
+
+The Gate 2.3c capability itself is attested by the original 910B1
+evidence recorded at `f56ce2a` and by the 5-row hermetic regression
+that passes on the current branch.
+
+---
+
+## 7. Gate 2.3d — Shutdown drain
+
+**Runtime commit:** `4ef0c15` — `scheduler: shutdown-time drain of pending + running requests`
+
+Invariants asserted:
+
+- `Scheduler.shutdown` walks `prefill_manager.pending_list` and
+  `decode_manager.running_reqs` before the engine is torn down.
+- Every drained request has its table slot returned to
+  `TableManager._free_slots` and its KV pages returned via
+  `cache_manager.cache_req(finished=True)`.
+- After shutdown, the allocator (`available_size`, `free_slots`
+  cardinality) and the `TableManager._free_slots` multiset are
+  bit-equal to the pre-run baseline.
+- The drain runs even when both sets are non-empty.
+
+Regression coverage: `tests/misc/test_scheduler_shutdown_drain.py`
+— 8 tests, PASS.
+
+Real-device evidence: fresh 910B1 probe run in this Gate 2.3g freeze.
+
+```
+Pre-shutdown: running=1  pending=1  (uids A running, B pending)
+              table_free=[0,1,2,3,4,5,6]  avail=271856  free_pages=16991
+Post-shutdown: running=0  pending=0
+               table_free=[0,1,2,3,4,5,6,7]  avail=271872  free_pages=16992
+               (identical to baseline)
+VERDICT: PASS (shutdown drained pending+running to baseline)
+```
+
+---
+
+## 8. Gate 2.3e — Overlap-loop abort fence
+
+**Runtime commit:** `ada1688` — `scheduler: overlap-loop abort fence (Gate 2.3e)`
+
+Invariants asserted:
+
+- When `_process_one_msg` sees `AbortBackendMsg(uid)` while `uid` is
+  in `inflight_uids`, the uid is added to `deferred_abort_uids` and
+  removed from `decode_manager.running_reqs` immediately, without
+  freeing any resources yet.
+- `_process_last_data` emits no `DetokenizeMsg` for a deferred uid
+  and does not append to that uid's host token buffer.
+- `_apply_deferred_aborts` runs after `_process_last_data` completes
+  and frees each deferred req exactly once (`_free_req_resources`
+  called with the correct `Req` instance).
+- Sibling requests in the same batch keep their sampled tokens and
+  stay in `decode_manager.running_reqs`.
+- Two abort msgs for the same inflight uid are idempotent — the set
+  membership guarantees a single free.
+- `normal_loop` is unaffected: `inflight_uids` is never populated
+  under `normal_loop`, so aborts take the immediate-free branch.
+
+Regression coverage:
+`tests/misc/test_scheduler_overlap_abort_fence.py` — 7 tests, PASS.
+
+Real-device evidence status:
+
+```
+Overlap abort fence evidence status:
+- Original Gate 2.3e 910B1 evidence: PASS
+- Evidence commit: ada1688
+- Current regression:
+  test_scheduler_overlap_abort_fence.py — 7 tests PASS
+- Gate 2.3g fresh real-probe re-attestation: NOT COMPLETED
+- Reason:
+  the pre-Gate-2.3f probe assumed every scheduler reply was a
+  DetokenizeMsg. Gate 2.3f legitimately added AbortAckMsg to the
+  same reply channel, so the probe failed in post-run result parsing
+  when it accessed `next_token` on an AbortAckMsg.
+- The overlap fence itself reached and executed its intended runtime
+  path before the parser failure.
+- This is historical probe/schema drift, not an overlap-fence runtime
+  failure.
+- No runtime or probe code was modified during Gate 2.3g.
+```
+
+The Gate 2.3e capability itself is attested by the original 910B1
+evidence recorded at `ada1688` and by the 7-row hermetic regression
+that passes on the current branch. The current-session Gate 2.3f
+end-to-end abort ack probe (§9) also exercises the overlap fence code
+path under a deferred abort and independently confirms the fence
+behaviour on device.
+
+---
+
+## 9. Gate 2.3f — End-to-end abort acknowledgement
+
+**Runtime commit:** `ac1bb8e` — `scheduler+server: end-to-end abort acknowledgement (Gate 2.3f)`
+
+Invariants asserted:
+
+- New message types are added, both idempotent by design:
+  - `AbortAckMsg(uid)` on the tokenizer channel
+    (`BaseTokenizerMsg` subclass).
+  - `AbortAckReply(uid)` on the frontend channel
+    (`BaseFrontendMsg` subclass).
+- The scheduler appends the aborted uid to `_pending_abort_acks`
+  immediately after `_free_req_resources(req)` — never before. The
+  queue is drained by `_flush_pending_acks()` at the end of the tick.
+- `_flush_pending_acks()` is called at both `normal_loop` and
+  `overlap_loop` tails, so both scheduling loops emit the ack on the
+  same tick the free happened.
+- The tokenizer forwards a batched `AbortAckMsg` as an
+  `AbortAckReply` batch (unwrapped to a single message when there is
+  exactly one entry) on the frontend channel.
+- The frontend's `abort_pending` set is populated by
+  `abort_user(uid)` and cleared only by receipt of an
+  `AbortAckReply(uid)`. A late `UserReply(uid)` that arrives between
+  those two events is silently dropped by the listen dispatch.
+- Cleanup on ack is idempotent: pop from `ack_map`, `event_map`,
+  `abort_pending`, `abort_pending_events`; a duplicate ack is a
+  strict no-op.
+- Normal end-of-stream (EOS or stop_token) is undisturbed —
+  no abort machinery fires on natural finish.
+- Abort semantics by request state (all covered by hermetic tests):
+  - **Waiting** (in `pending_list`, not yet forwarded): request
+    removed from pending, KV resources freed, ack emitted.
+  - **Running** under `normal_loop` (no fence): immediate-free
+    branch, ack emitted the same tick.
+  - **Running** under `overlap_loop` with uid inflight: fence branch
+    defers the free to after `_process_last_data`, then acks.
+  - **Unknown uid** (never seen by the scheduler): the abort is a
+    no-op runtime-side; no ack is emitted. The frontend's
+    `abort_pending` entry, if any, waits until the frontend times
+    out or the caller resolves it out-of-band.
+  - **Duplicate abort for the same uid** while it is inflight:
+    idempotent via `deferred_abort_uids` set membership; a single
+    free, a single ack.
+
+Regression coverage: `tests/misc/test_scheduler_abort_ack.py` —
+8 tests, PASS. (Covers A: non-inflight ack after free; B: deferred
+inflight ack after apply; C: waiting-list abort ack; D: sibling
+survives partial abort; E: idempotent duplicate abort ack; F:
+frontend drops racing `UserReply`; G: natural finish emits no ack;
+H: tokenizer forwards `AbortAckMsg` to frontend as `AbortAckReply`.)
+
+Real-device evidence: fresh 910B1 probe run in this Gate 2.3g freeze,
+covering four flows on one scheduler instance:
+
+```
+flow1 (normal_loop immediate abort):
+  uid_in_running=False  uid_in_pending=False
+  acks=1  detoks=1 (the pre-abort prefill token, not a stale finish)
+
+flow2 (overlap_loop deferred abort):
+  acks=1  detoks=0
+  timeline: free_idx=0  ackq_idx=1   (free precedes ack, invariant holds)
+
+flow3 (frontend late-token drop + idempotent cleanup):
+  late_dropped=True  frontend_cleaned=True  dup_ok=True
+
+flow4 (follow-up on the SAME scheduler after both abort flows):
+  followup_ok=True
+
+Post-shutdown allocator: avail=271856/271856  pages=16991/16991
+VERDICT: PASS
+```
+
+---
+
+## 10. Evidence summary
+
+| Capability | Original evidence | Gate 2.3g re-attestation |
+| --- | --- | --- |
+| allocation rollback | prior 910B1 PASS | fresh real-probe PASS |
+| sampler state atomicity | Gate 2.3c PASS / `f56ce2a` | not rerun; probe targets wrong model wrapper |
+| shutdown drain | prior 910B1 PASS | fresh real-probe PASS |
+| overlap abort fence | Gate 2.3e PASS / `ada1688` | hermetic 7/7 PASS; old real probe incompatible with AbortAck schema |
+| abort acknowledgement | Gate 2.3f PASS / `ac1bb8e` | fresh message-flow PASS |
+
+Summary:
+
+```
+Fresh real probes: A, C, E PASS
+Inherited real evidence: B, D
+Current hermetic regressions for B and D: PASS
+```
+
+---
+
+## 11. Test surface locked at this gate
+
+Locked test files (all pass on the target platform under the standard
+pytest invocation; row counts recorded at gate freeze):
+
+- `tests/misc/test_scheduler_prepare_batch_txn.py` — 5 rows (Gate 2.3b).
+- `tests/misc/test_engine_forward_sampler_atomic.py` — 5 rows (Gate 2.3c).
+- `tests/misc/test_scheduler_shutdown_drain.py` — 8 rows (Gate 2.3d).
+- `tests/misc/test_scheduler_overlap_abort_fence.py` — 7 rows (Gate 2.3e).
+- `tests/misc/test_scheduler_abort_ack.py` — 8 rows (Gate 2.3f).
+
+Gate 2.3 total: **33 rows pass**.
+
+Inherited-and-still-passing baseline surface exercised in this freeze:
+
+- `tests/misc/test_ascend_fia_backend.py` — 72 rows.
+- `tests/misc/test_pyproject_config.py` — 11 rows.
+
+Inherited total: 83 rows pass. Combined this-gate + baseline pytest
+count exercised: 116 rows.
+
+---
+
+## 12. Evidence trail (commit summary)
+
+- `d520a71` `scheduler: transactional page allocation rollback in _prepare_batch (Gate 2.3b)`
+- `f56ce2a` `engine: atomic request-state commit past sampler in forward_batch (Gate 2.3c)`
+- `4ef0c15` `scheduler: shutdown-time drain of pending + running requests (Gate 2.3d)`
+- `ada1688` `scheduler: overlap-loop abort fence (Gate 2.3e)`
+- `ac1bb8e` `scheduler+server: end-to-end abort acknowledgement (Gate 2.3f)`
+
+Intermediate probe scripts (probe A `_prepare_batch` rollback, probe C
+shutdown drain, probe E abort message flow) are not committed to the
+repository per policy — their outputs are summarised in §5, §7, §9
+above.
+
+---
+
+## 13. Freeze integrity note
+
+```
+Gate 2.3g did not alter runtime or fault-injection code.
+A failed sampler re-attestation script was excluded because it did not
+reach the intended injection point. The verdict relies on the previously
+recorded 910B1 Gate 2.3c evidence and its committed regression tests.
+```
+
+```
+Two historical real-device re-attestation scripts were excluded from
+fresh PASS accounting because they failed before completing their
+intended assertions:
+1. Probe B targeted the wrong model wrapper before sampler injection.
+2. Probe D pre-dated AbortAckMsg and assumed a DetokenizeMsg-only
+   scheduler reply channel.
+Neither failure indicates a runtime regression. Gate 2.3g modified
+neither runtime nor fault-injection code and relies on the original
+committed 910B1 evidence plus current unchanged regression tests.
+```
+
+---
+
+## 14. Next-phase gaps
+
+These are follow-ups after Gate 2.3. They are not regressions of Gate 2.3;
+they are shapes Gate 2.3's scope deliberately excludes:
+
+- **In-process sampler / forward recovery.** Prove — or explicitly
+  decline to prove — that a raise inside the sampler or the
+  transformer stack can be recovered without tearing down the
+  scheduler. Today the exception unwinds the tick and requires an
+  external restart.
+- **CPU-side detokenize copy / event-record failure.** Once the
+  sampler has committed, a raise in the CPU copy or event-record
+  path is not covered; recovery would require rolling back a
+  committed token.
+- **Cross-process transport.** Reproduce the abort-ack contract
+  across the real ZMQ / HTTP path, not just the in-process offline
+  driver.
+- **Server crash / restart lifecycle.** Client-side reconnect and
+  request replay after a server restart are not covered.
+- **Tensor-parallel size > 1.** All lifecycle proofs here are single
+  die; the fence-and-ack contract on TP > 1 needs its own gate.
+- **Long soak.** Hundreds of concurrent requests, thousands of
+  ticks, rolling allocator and radix accounting.
+- **Abort-during-prefill on a chunked request.** Chunked prefill is
+  not enabled at this gate; when it lands, the abort contract needs
+  a re-audit against `ChunkedReq`'s partial-commit invariants.

--- a/docs/ascend_port/source_dependency_audit.md
+++ b/docs/ascend_port/source_dependency_audit.md
@@ -1,0 +1,315 @@
+# mini-sglang-ascend 源码依赖静态审计报告
+
+> 分支：`gate0-ascend-bootstrap`  ·  审计模式：**纯静态、源码级、不安装、不运行、不改动生产代码**
+> 平台：macOS 24.3.0（无 CUDA、无 NPU；仅做源码扫描与结构分析）
+> 生成物仅新增两个文件：
+> - `docs/ascend_port/source_dependency_audit.md`（本文件）
+> - `docs/ascend_port/source_dependency_inventory.csv`
+> 不修改 `pyproject.toml`、`uv.lock`、任何 `python/` 生产代码，不做 `cuda→npu` 盲替，不 `pip install`，不 `git commit`。
+> 审计工具：`rg`, `grep`, `find`, Python AST（离线阅读），无副作用。
+
+## 1. 执行摘要 (Executive Summary)
+
+- 项目主体是一个基于 PyTorch 的 LLM 推理引擎（Mini-SGLang 分支），控制平面/调度/模型/张量/KV 缓存代码基本 **device-agnostic**，可直接复用；对 CUDA/NCCL 的耦合集中在四条通道：
+  1. **设备原语**（`torch.cuda.*` Stream/Event/CUDAGraph/内存查询/nvtx）——由 `python/minisgl/engine/engine.py:31-209`、`python/minisgl/engine/graph.py:75-140`、`python/minisgl/scheduler/scheduler.py:53-134`、`python/minisgl/utils/arch.py:12-14`、`python/minisgl/utils/torch_utils.py:24` 统治。
+  2. **算子后端**（`flashinfer`、`sgl_kernel`、Triton MoE）——集中在 `python/minisgl/layers/{norm,rotary,activation}.py`、`python/minisgl/attention/{fi,fa,trtllm}.py`、`python/minisgl/moe/fused.py`、`python/minisgl/engine/sample.py:30`。
+  3. **自研 PyNCCL C++/CUDA 封装**——`python/minisgl/kernel/pynccl.py`、`python/minisgl/kernel/csrc/include/minisgl/nccl227.h`、`python/minisgl/kernel/csrc/src/pynccl.cu`，直接调用 NCCL 2.27 API。
+  4. **JIT 加载的 CUDA 小算子**——`python/minisgl/kernel/{index,store}.py` 借助 `apache-tvm-ffi` 编译 `.cu`。
+- **可直接复用比例**（按 Python 源文件数量粗估）：约 **70–75%** 的 `.py` 文件属于 `portable` 或 `thin-adaptation`；其中 `portable` 约 55%，`thin-adaptation` 约 20%；余下的 `backend-replacement`（≈20%）与 `major-rewrite`（<5%）集中在算子/通信实现层。
+- **重写必需模块**：`kernel/csrc/src/pynccl.cu` + `kernel/csrc/include/minisgl/nccl227.h` + `kernel/pynccl.py`（NCCL → HCCL），以及所有 `flashinfer.*`、`sgl_kernel.*`、Triton MoE、`kernel/*.cu` JIT 算子的 Ascend 替代实现——但**这些均不在 Gate 0 范围内**。
+- **Gate 0**（最小可运行 Ascend 引导）只需插入设备抽象层、令 `torch.distributed` 后端字符串在 Ascend 上走 `hccl`、把 PyNCCL/图捕获/`flashinfer`/`sgl_kernel`/Triton 相关导入改为**可选（延迟或有条件）**、把 `pyproject.toml` 里 CUDA 类依赖挪进可选 extra——**不引入任何 NPU 算子实现**。
+- License：`pyproject.toml:13` 声明 `MIT`；`LICENSE` 为 sgl-project 2026 MIT；仓库无 `NOTICE`。作为 fork 建议补充 `NOTICE`，但不属于代码合规性阻塞项，且**本次审计不修改**。
+- 备注：环境变量声称工作目录为 `/Users/dev/workspace-669590f9`，实际仓库位于 `/Users/lirui/PycharmProjects/mini-sglang-ascend`；已按实际代码结构完成审计。
+
+## 2. 仓库结构 (Repository Structure)
+
+顶层布局（见 `ls` 输出）：
+```
+Dockerfile
+LICENSE                             # MIT, sgl-project 2026
+NOTICE                              # 不存在
+README.md
+assets/
+benchmark/
+docs/
+  features.md
+  structures.md
+  ascend_port/                      # 本次新增目录
+pyproject.toml                      # setuptools+wheel, package-dir=python
+python/minisgl/                     # 主包
+tests/
+```
+
+`python/minisgl/` 关键子包一览：
+- `core.py`——不可变数据类 `Batch`/`Req`/`Context`/`SamplingParams`（100% portable）。
+- `env.py`——环境变量集中定义（含 `PYNCCL_MAX_BUFFER_SIZE`，`python/minisgl/env.py`）。
+- `engine/`——运行时控制平面：`engine.py`、`graph.py`、`sample.py`、`config.py`。
+- `scheduler/`——两流重叠调度：`scheduler.py`、`cache.py`、`prefill.py`、`io.py`、`config.py`。
+- `distributed/`——`impl.py`（Torch/PyNCCL 双实现）、`info.py`（rank/world 元数据）。
+- `attention/`——`base.py`、`utils.py`、`fi.py`、`fa.py`、`trtllm.py`、`__init__.py`（Registry）。
+- `kvcache/`——`base.py`、`naive_cache.py`、`radix_cache.py`、`mha_pool.py`、`__init__.py`（Registry）。
+- `layers/`——`attention.py`、`linear.py`、`norm.py`、`rotary.py`、`activation.py`、`embedding.py`、`moe.py`、`base.py`。
+- `models/`——`base.py`、`weight.py`、`llama.py`、`qwen3_moe.py`。
+- `moe/`——`fused.py`（`sgl_kernel` + Triton 驱动）。
+- `kernel/`——tvm-ffi 驱动的 JIT/AOT 层：`__init__.py`（**贪婪导入**）、`pynccl.py`、`index.py`、`store.py`、`tensor.py`、`radix.py`、`moe_impl.py`、`utils.py`、`triton/fused_moe.py`、`csrc/`。
+- `server/`——`args.py`、`launch.py`、`http.py`。
+- `utils/`——`arch.py`、`torch_utils.py`、`mp.py`、`hf.py`、`logger.py`、`registry.py`、`misc.py`。
+- `benchmark/perf.py`——开发工具，基于 `CUDAGraph`。
+
+## 3. 依赖清单 (Dependency Inventory)
+
+来源：`pyproject.toml:22-34`。
+
+| 依赖 | 用途 | Python 源引用 | 可移植性 | 建议动作 |
+| :-- | :-- | :-- | :-- | :-- |
+| `accelerate` (`pyproject.toml:22`) | 未使用 | 无 (`rg` 无 `import accelerate`) | portable（可删） | Ascend 依赖列表中删除；不动主 `pyproject.toml` |
+| `msgpack` | ZMQ 编码 | `python/minisgl/utils/mp.py:5` | portable | 保留 |
+| `modelscope` | 权重下载备选 | `python/minisgl/utils/hf.py` | portable | 保留 |
+| `torch<2.10.0` (`pyproject.toml:25`) | 全体核心 | 全仓库 | thin-adaptation | Ascend 需与 `torch_npu` 匹配版本；解耦 CUDA build |
+| `transformers>=4.56.0,<=4.57.3` | tokenizer/config | `python/minisgl/utils/hf.py` | portable | 保留 |
+| `flashinfer-python>=0.5.3` (`pyproject.toml:27`) | 注意力/RMSNorm/RoPE/Activation/采样 | `python/minisgl/layers/{norm,rotary,activation}.py`, `attention/{fi,trtllm}.py`, `engine/sample.py:30` | backend-replacement | 移入 `[cuda]` extra；Ascend 提供替代 |
+| `pyzmq`, `uvicorn`, `fastapi`, `prompt_toolkit`, `openai` | 服务层 | `python/minisgl/{server,utils/mp.py}` | portable | 保留 |
+| `apache-tvm-ffi>=0.1.4` (`pyproject.toml:32`) | JIT/AOT 加载器 | `python/minisgl/kernel/utils.py:63,99`；`python/minisgl/kernel/{pynccl,index,store,tensor,radix}.py` | thin-adaptation | CPU AOT 部分可保留；`cuda_files` 分支需要 device-gated |
+| `sgl_kernel>=0.3.17.post1` (`pyproject.toml:33`) | FlashAttention KVCache/MoE 辅助 | `python/minisgl/attention/fa.py:158`, `python/minisgl/moe/fused.py:16,71` | backend-replacement | 移入 `[cuda]` extra |
+| `quack-kernels` (`pyproject.toml:34`) | 未使用 | 无 | portable（可删） | 从 Ascend 依赖列表移除 |
+| `triton`（隐式，随 torch） | Fused MoE | `python/minisgl/kernel/moe_impl.py:20-21,66`, `python/minisgl/kernel/triton/fused_moe.py:1-2,5,50` | backend-replacement | 在 Ascend 上禁用；MoE 路径 Gate 0 关闭 |
+| dev extras (`pyproject.toml:41-52`) | pytest/ruff/mypy 等 | 开发工具 | portable | 保留 |
+
+**关键结论：`accelerate` 与 `quack-kernels` 是完全无源码引用的“死声明”，是当前 CUDA 依赖清单里最容易的清理项。**
+
+## 4. CUDA 专用 API 清单 (CUDA-Specific API Inventory)
+
+以下均通过 `rg 'torch\.cuda\.'` 及派生正则获得，仅列直接调用点：
+
+| 位置 | 调用 | 语义 | Ascend 替代 |
+| :-- | :-- | :-- | :-- |
+| `python/minisgl/utils/arch.py:12` | `torch.cuda.is_available()` | 判断 CUDA 是否可用 | 设备抽象；NPU 返回 `False` for `is_arch_supported` |
+| `python/minisgl/utils/arch.py:14` | `torch.cuda.get_device_capability()` | 架构探测 | 抽象层返回 `None` on NPU；上层 `is_sm90/sm100` 保持 `False` |
+| `python/minisgl/utils/torch_utils.py:24` | `import torch.cuda.nvtx as nvtx` | 装饰器打点 | 抽象为 no-op 或 `torch_npu` 打点 |
+| `python/minisgl/engine/engine.py:31` | `torch.cuda.is_initialized()` | 启动守卫 | 抽象层 |
+| `python/minisgl/engine/engine.py:35` | `f"cuda:{rank}"` | 设备字符串 | 抽象层 → `npu:{rank}` |
+| `python/minisgl/engine/engine.py:36` | `torch.cuda.set_device(...)` | 绑定设备 | `torch_npu.npu.set_device(...)` |
+| `python/minisgl/engine/engine.py:38-39` | `torch.cuda.Stream(...)` + `set_stream(...)` | 工作流 | `torch_npu.npu.Stream/set_stream` |
+| `python/minisgl/engine/engine.py:172-174` | `synchronize/empty_cache/reset_peak_memory_stats` | 显存管理 | `torch_npu.npu.*` |
+| `python/minisgl/engine/engine.py:192` | `torch.cuda.current_stream()` | 获取当前流 | `torch_npu.npu.current_stream()` |
+| `python/minisgl/engine/engine.py:204` | `torch.cuda.Event(...)` | 事件同步 | `torch_npu.npu.Event(...)`（NPU 支持） |
+| `python/minisgl/engine/graph.py:75` | `torch.cuda.mem_get_info(...)` | 剩余显存 | `torch_npu.npu.mem_get_info` |
+| `python/minisgl/engine/graph.py:112-114` | `synchronize/empty_cache/reset_peak_memory_stats` | 显存管理 | 同上 |
+| `python/minisgl/engine/graph.py:133` | `torch.cuda.CUDAGraph()` | 图捕获 | Gate 0 直接屏蔽；Gate 1 才评估 `aclgraph` |
+| `python/minisgl/engine/graph.py:140` | `torch.cuda.graph(pool=...)` | 图捕获上下文 | 同上 |
+| `python/minisgl/engine/sample.py:72` | `torch.cuda.nvtx.range("Sampler")` | 打点 | 抽象层 |
+| `python/minisgl/scheduler/scheduler.py:53-55` | `Stream / stream / set_stream` | 双流重叠 | 抽象层 |
+| `python/minisgl/scheduler/scheduler.py:128` | `torch.cuda.current_stream()` | 双流控制 | 抽象层 |
+| `python/minisgl/scheduler/scheduler.py:134` | `torch.cuda.synchronize()` | 同步 | 抽象层 |
+| `python/minisgl/attention/fi.py:120` | `torch.cuda.Event(...)` | FI 后端同步 | 后端选择时才触发；Gate 0 不启用 FI |
+
+`pin_memory` 出现在 `python/minisgl/engine/sample.py:21`、`python/minisgl/attention/fi.py:114,173,198`、`python/minisgl/attention/fa.py:76`、`python/minisgl/attention/trtllm.py:100`、`python/minisgl/scheduler/scheduler.py:238,253,264,266`、`python/minisgl/scheduler/cache.py:134-135`、`python/minisgl/scheduler/prefill.py:60,81`——`torch_npu` 通常兼容 `pin_memory=True`，需要实机验证；不合规时回退为普通张量即可，属 P2。
+
+**验证结果：`rg 'torch\.compile'` 无命中，`rg 'jit\.script'` 无命中——不需要图编译适配。**
+
+## 5. 算子依赖清单 (Kernel Dependency Inventory)
+
+| 类别 | 位置 | 依赖库/文件 | Ascend 替代 |
+| :-- | :-- | :-- | :-- |
+| Attention prefill/decode | `python/minisgl/attention/fi.py`、`python/minisgl/attention/trtllm.py:52-53` | `flashinfer.BatchPrefillWithPagedKVCacheWrapper`、`CUDAGraphBatchDecodeWithPagedKVCacheWrapper`、`trtllm_batch_decode_with_kv_cache`、`trtllm_batch_context_with_kv_cache` | Gate 1：`torch_npu.npu_incre_flash_attention` / `torch_npu.npu_prompt_flash_attention`；Gate 0 不注册 |
+| Attention（PagedKV） | `python/minisgl/attention/fa.py:158` | `sgl_kernel.flash_attn.flash_attn_with_kvcache` | Gate 1 编写 Ascend 后端类；Gate 0 用 Registry 空注册 |
+| RoPE | `python/minisgl/layers/rotary.py:35` | `flashinfer.apply_rope_with_cos_sin_cache_inplace` | 纯 torch 版或 `torch_npu.npu_rotary_mul` |
+| RMSNorm | `python/minisgl/layers/norm.py:10,25` | `flashinfer.rmsnorm`、`flashinfer.fused_add_rmsnorm` | `torch_npu.npu_rms_norm` / 纯 torch |
+| 激活 | `python/minisgl/layers/activation.py:10,16` | `flashinfer.silu_and_mul`、`flashinfer.gelu_and_mul` | `torch_npu.npu_swiglu` / 纯 torch |
+| Embedding gather | `python/minisgl/layers/embedding.py` | `minisgl.kernel.indexing`（`kernel/index.py` JIT `.cu`） | 纯 torch `index_select`/scatter 回退 |
+| KV cache 写入 | `python/minisgl/kvcache/mha_pool.py` | `minisgl.kernel.store_cache`（`kernel/store.py` JIT `.cu`） | 纯 torch scatter 回退 |
+| 采样 | `python/minisgl/engine/sample.py:30` | `flashinfer.sampling.top_k_top_p_sampling_from_probs` | 纯 torch top-k/top-p 采样 |
+| MoE gating | `python/minisgl/moe/fused.py:16,71` | `sgl_kernel.topk_softmax`、`sgl_kernel.moe_align_block_size` | 关闭 MoE 路径（Gate 0 外） |
+| MoE Fused GEMM | `python/minisgl/kernel/moe_impl.py:20-21,66`、`python/minisgl/kernel/triton/fused_moe.py:1-2,5,50` | Triton `@triton.jit` | 同上 |
+| PyNCCL 集合通信 | `python/minisgl/kernel/pynccl.py:30-37` | `apache-tvm-ffi` + `pynccl.cu` + NCCL | Gate 1 编写 HCCL 版；Gate 0 通过 `--disable-pynccl` 关闭 |
+| CPU 辅助 | `python/minisgl/kernel/tensor.py`、`radix.py` | AOT `.cpp` | portable，直接保留 |
+
+**结论：Ascend 后端算子替代面广但边界清晰；只要 Gate 0 把这类模块延迟导入并保持 Registry 允许“未注册”的空状态，就能满足最小引导目标。**
+
+## 6. 分布式 / HCCL 迁移分析 (Distributed / HCCL Migration Analysis)
+
+- `python/minisgl/engine/engine.py:114` 使用 `torch.distributed.init_process_group(backend="gloo", ...)` 建立**控制面 CPU 组**——完全设备无关，可原样保留。
+- `python/minisgl/engine/engine.py:128` 使用 `init_process_group(backend="nccl", ...)` 建立**设备通信组**——需要在 Ascend 上切换为 `"hccl"`。
+- `python/minisgl/engine/engine.py:135` 使用 `new_group(backend="gloo", ...)` 建立控制子组，可保留。
+- `python/minisgl/distributed/impl.py` 定义两条实现：
+  - `TorchDistributedImpl`：完全基于 `torch.distributed.all_reduce/all_gather` 的接口，**backend-agnostic**，只要 PyTorch 侧注册了 `hccl` 后端即可复用。
+  - `PyNCCLDistributedImpl`：直接调用 `minisgl.kernel.pynccl`，属自研 NCCL 封装，与 HCCL 完全不兼容。
+- `python/minisgl/distributed/impl.py:73-90` `enable_pynccl_distributed` 工厂根据 `use_pynccl` 选择实现——Gate 0 强制走 Torch 分支；Gate 1 才实现 HCCL 版 `PyHCCLDistributedImpl`。
+- `python/minisgl/kernel/pynccl.py:30` 通过 `apache-tvm-ffi` 的 `load_aot` 编译 `csrc/src/pynccl.cu`，并对 `-lnccl` 硬依赖；`kernel/pynccl.py:37` 注册 `tvm_ffi` 对象 `minisgl.NCCLWrapper`。
+- `python/minisgl/kernel/csrc/include/minisgl/nccl227.h` 与 `python/minisgl/kernel/csrc/src/pynccl.cu` 直接使用 NCCL 2.27 API（`ncclCommInitRank`、`ncclAllReduce`、`ncclAllGather`、`ncclCommWindowRegister`），需要**整体重写**为 HCCL 版本；属 P0 但**不在 Gate 0 内**。
+- `python/minisgl/env.py:PYNCCL_MAX_BUFFER_SIZE`、`python/minisgl/server/args.py:124-129` 的 `--disable-pynccl` 是天然的降级开关；Gate 0 直接令其默认 `True` on Ascend。
+
+**Gate 0 迁移策略：完全绕开 PyNCCL，只保留 `torch.distributed` 的字符串抽象；将 `backend="nccl"` 通过一个新的 `select_device_backend()` 函数在 NPU 上切换为 `"hccl"`。**
+
+## 7. 注意力 / KV 后端分析 (Attention & KV Backend Analysis)
+
+- 注意力后端通过 `python/minisgl/attention/__init__.py` 的 Registry 分发（key: `"trtllm"`, `"fi"`, `"fa"`）。
+- `python/minisgl/attention/fi.py`：FlashInfer 全家桶，含 `CUDAGraphBatchDecodeWithPagedKVCacheWrapper`；也调用 `torch.cuda.Event`（120 行）。属 backend-replacement，但 Gate 0 不需要注册 Ascend 版本，只需容许 Registry 找不到时给出人类可读错误。
+- `python/minisgl/attention/fa.py:158`：`sgl_kernel.flash_attn.flash_attn_with_kvcache`。Gate 1 目标。
+- `python/minisgl/attention/trtllm.py:52-53`：TensorRT-LLM 融合调用。Gate 1 之后再考虑替代。
+- `python/minisgl/attention/base.py`、`utils.py` 完全 device-agnostic（数据形状/元信息计算），portable。
+- KV 缓存：
+  - `python/minisgl/kvcache/base.py`、`naive_cache.py`、`radix_cache.py` 是纯 Python + torch 数据结构，`portable`。
+  - `python/minisgl/kvcache/mha_pool.py` 依赖 `minisgl.kernel.store_cache`（`.cu`）——Gate 1 替换为 torch scatter 回退。
+- 采样：`python/minisgl/engine/sample.py:30` 引用 `flashinfer.sampling`；在 Ascend 上极易用纯 torch 实现 top-k / top-p 替换（P0）。
+
+**结论：注意力/KV 层的 Python 抽象干净，Gate 0 不需要提供 NPU 算子，只需保证 Registry 未注册时不会阻塞引擎启动（当前实现如为强注册需引入延迟加载或 try/except 保护）。**
+
+## 8. 图 / 编译分析 (Graph & Compile Analysis)
+
+- 全仓库 **无 `torch.compile`**（`rg 'torch\.compile'` 无命中），无 `torch.jit.script`；不存在 dynamo/inductor 依赖。
+- CUDA Graph 集中在：
+  - `python/minisgl/engine/graph.py:49-67` `_determine_cuda_graph_bs`——策略函数。
+  - `python/minisgl/engine/graph.py:133` `torch.cuda.CUDAGraph()`。
+  - `python/minisgl/engine/graph.py:140` `torch.cuda.graph(pool=...)`。
+  - `python/minisgl/engine/engine.py:209` `destroy_cuda_graphs()`。
+- Ascend 有 `aclgraph`/`torch_npu` 侧的图捕获路径，但需要 padding 与 stream capture 语义对齐，风险较高——**Gate 0 明确不做**。
+- Gate 0 要求：`config.cuda_graph_max_bs = 0` 时应完全绕开图路径（当前 `python/minisgl/engine/graph.py` 已有相应分支，需要在 config 默认值层面 gate；`python/minisgl/engine/config.py` `cuda_graph_bs`/`cuda_graph_max_bs` 可通过 CLI `--cuda-graph-max-bs 0`（`python/minisgl/server/args.py:148-153`）关闭）。
+
+**动作：Gate 0 之内不新增图相关代码；只保证 `use_cuda_graph=False` 路径 100% 走通。**
+
+## 9. 文件级可移植性矩阵 (File-by-File Portability Matrix)
+
+> P = portable（直接复用）；T = thin-adaptation（微调）；R = backend-replacement（后端替换）；X = major-rewrite（大改）。
+
+**控制面 / 引擎 / 调度**
+
+| 文件 | 判定 | 依据 |
+| :-- | :-- | :-- |
+| `python/minisgl/core.py` | P | 纯 dataclass |
+| `python/minisgl/env.py` | T | 需新增 Ascend 相关默认值 |
+| `python/minisgl/engine/config.py` | T | `cuda_graph_*` / `use_pynccl` 默认值切换 |
+| `python/minisgl/engine/engine.py` | T | 全体 `torch.cuda.*` 走抽象层（第 4 节列举） |
+| `python/minisgl/engine/graph.py` | R | `CUDAGraph()`/`torch.cuda.graph()` 无 Ascend 对应；Gate 0 关闭 |
+| `python/minisgl/engine/sample.py` | R | `flashinfer.sampling`+nvtx；采样重写为 torch |
+| `python/minisgl/scheduler/scheduler.py` | T | `Stream/Event` 抽象化 |
+| `python/minisgl/scheduler/cache.py` | P | `pin_memory` 仅托管 |
+| `python/minisgl/scheduler/prefill.py` | P | 同上 |
+| `python/minisgl/scheduler/io.py` | P | ZMQ+`torch.distributed` CPU |
+| `python/minisgl/scheduler/config.py` | P | dataclass |
+
+**分布式面**
+
+| 文件 | 判定 | 依据 |
+| :-- | :-- | :-- |
+| `python/minisgl/distributed/info.py` | P | dataclass |
+| `python/minisgl/distributed/impl.py::TorchDistributedImpl` | P | 后端字符串驱动 |
+| `python/minisgl/distributed/impl.py::PyNCCLDistributedImpl` | X | 依赖自研 NCCL wrapper |
+| `python/minisgl/distributed/impl.py::enable_pynccl_distributed` | T | Ascend 强制走 Torch 分支 |
+
+**算子面 / kernel/**
+
+| 文件 | 判定 | 依据 |
+| :-- | :-- | :-- |
+| `python/minisgl/kernel/__init__.py` | T | 贪婪导入需 lazy 化 |
+| `python/minisgl/kernel/utils.py` | T | `tvm_ffi.cpp.load/load_inline` 的 CUDA 分支需 gate |
+| `python/minisgl/kernel/pynccl.py` | X | NCCL wrapper（Gate 1） |
+| `python/minisgl/kernel/index.py` | R | JIT `.cu` gather；Ascend 用 torch 回退 |
+| `python/minisgl/kernel/store.py` | R | JIT `.cu` KV 写入；同上 |
+| `python/minisgl/kernel/tensor.py` | P | CPU AOT |
+| `python/minisgl/kernel/radix.py` | P | CPU AOT |
+| `python/minisgl/kernel/moe_impl.py` | R | Triton MoE；Gate 0 禁用 |
+| `python/minisgl/kernel/triton/fused_moe.py` | R | 同上 |
+| `python/minisgl/kernel/csrc/include/minisgl/nccl227.h` | X | NCCL 头 |
+| `python/minisgl/kernel/csrc/src/pynccl.cu` | X | NCCL 实现 |
+
+**注意力 / KV / MoE / 层**
+
+| 文件 | 判定 | 依据 |
+| :-- | :-- | :-- |
+| `python/minisgl/attention/base.py` | P | ABC |
+| `python/minisgl/attention/utils.py` | P | 工具 |
+| `python/minisgl/attention/__init__.py` | T | Registry；Ascend 后端注册在 Gate 1 |
+| `python/minisgl/attention/fi.py` | R | FlashInfer |
+| `python/minisgl/attention/fa.py` | R | sgl_kernel |
+| `python/minisgl/attention/trtllm.py` | R | flashinfer.trtllm.* |
+| `python/minisgl/kvcache/base.py` | P | ABC |
+| `python/minisgl/kvcache/naive_cache.py` | P | 纯 torch |
+| `python/minisgl/kvcache/radix_cache.py` | P | 纯 torch + CPU radix |
+| `python/minisgl/kvcache/mha_pool.py` | R | store_cache（`.cu`） |
+| `python/minisgl/kvcache/__init__.py` | P | Registry |
+| `python/minisgl/moe/fused.py` | R | sgl_kernel + Triton |
+| `python/minisgl/layers/base.py` | P | ABC |
+| `python/minisgl/layers/linear.py` | P | `F.linear` |
+| `python/minisgl/layers/attention.py` | P | 编排 |
+| `python/minisgl/layers/moe.py` | P | 编排（内部路径 Gate 0 关闭） |
+| `python/minisgl/layers/rotary.py` | R | flashinfer |
+| `python/minisgl/layers/norm.py` | R | flashinfer |
+| `python/minisgl/layers/activation.py` | R | flashinfer |
+| `python/minisgl/layers/embedding.py` | R | kernel.indexing |
+
+**模型 / 服务 / 工具 / benchmark**
+
+| 文件 | 判定 | 依据 |
+| :-- | :-- | :-- |
+| `python/minisgl/models/base.py` | P | ABC |
+| `python/minisgl/models/weight.py` | P | HF 权重加载 |
+| `python/minisgl/models/llama.py` | P | LlamaModel |
+| `python/minisgl/models/qwen3_moe.py` | P | MoE 路径 Gate 0 禁用 |
+| `python/minisgl/server/args.py` | T | 增加 Ascend 默认值 / `--disable-pynccl`/`--cuda-graph-max-bs` 默认切换 |
+| `python/minisgl/server/launch.py` | P | mp spawn |
+| `python/minisgl/server/http.py` | P | FastAPI |
+| `python/minisgl/utils/arch.py` | T | 设备探测抽象化 |
+| `python/minisgl/utils/torch_utils.py` | T | nvtx 抽象/懒加载 |
+| `python/minisgl/utils/mp.py` | P | ZMQ+msgpack |
+| `python/minisgl/utils/hf.py` | P | HF 下载 |
+| `python/minisgl/utils/logger.py` | P | logging |
+| `python/minisgl/utils/registry.py` | P | Registry |
+| `python/minisgl/utils/misc.py` | P | 杂项 |
+| `python/minisgl/benchmark/perf.py` | R | 使用 `CUDAGraph`，dev-only |
+
+**统计**（按文件计数，包含 `.py` 与关键 `.cu/.h` 文件）：
+- P（portable）：约 34 个文件
+- T（thin-adaptation）：约 12 个文件
+- R（backend-replacement）：约 13 个文件
+- X（major-rewrite）：约 4 个文件（`kernel/pynccl.py` 及其 `.cu/.h`、`distributed/impl.py::PyNCCLDistributedImpl` 语义等价）
+- **可直接复用比例 ≈ 53%（P）+ 20%（T 边缘复用）≈ 70–73%**。
+
+## 10. 建议的 Ascend 后端边界 (Proposed Ascend Backend Boundary)
+
+新增“设备抽象”和“通信后端选择”是本次迁移的**唯一横切改动**。所有新增文件默认放在：
+- `python/minisgl/utils/device.py` — 提供 `class DeviceContext`：`is_available()`、`device_type()`（`"cuda"`/`"npu"`/`"cpu"`）、`set_device(idx)`、`current_stream()`、`Stream()`、`Event()`、`empty_cache()`、`synchronize()`、`mem_get_info()`、`nvtx_range(name)`；Ascend 分支懒加载 `torch_npu`。
+- `python/minisgl/distributed/backend.py` — 提供 `select_device_backend()`：Ascend 返回 `"hccl"`，否则 `"nccl"`；被 `engine.py:128` 调用。
+- `python/minisgl/kernel/_cuda_optional.py`（可选）— 集中管理 `try: import ... except ImportError` 的 CUDA 依赖入口，令 `kernel/__init__.py` 从贪婪导入改为延迟。
+
+**明确排除**：本轮不新增 NPU 算子文件、`kernel/csrc/src/pyhccl.*` 等；不修改 `pyproject.toml` 的 dependencies 数组（只允许在 Gate 1+ 增加 `[project.optional-dependencies]` 中的 `[ascend]` / `[cuda]` extras）。
+
+## 11. Gate 0 最小改动集 (Gate 0 Minimal Change Set)
+
+**Gate 0 目标：在无 NPU 算子实现的前提下，让 `python -c "import minisgl"` 与 `minisgl-serve --model ... --tp 1 --disable-pynccl --cuda-graph-max-bs 0` 在 Ascend 主机上能拉起进程；不追求推理正确性。**
+
+Gate 0 允许修改/新增的文件（**均属 T / 少量新文件**，无 R/X）：
+
+1. **新增** `python/minisgl/utils/device.py` — 设备抽象层。
+2. **新增** `python/minisgl/distributed/backend.py` — `select_device_backend()`。
+3. **修改** `python/minisgl/utils/arch.py:12,14` — 通过 `device.py` 返回；NPU 上 `is_sm90/sm100` 均为 `False`。
+4. **修改** `python/minisgl/utils/torch_utils.py:24` — `nvtx_annotate` 使用抽象层，Ascend 上退化 no-op。
+5. **修改** `python/minisgl/engine/engine.py:31,35,36,38-39,128,172-174,192,204,209` — 替换直接 `torch.cuda.*` 与 `backend="nccl"` 硬编码为抽象层调用；`destroy_cuda_graphs` 在 `use_cuda_graph=False` 时被跳过。
+6. **修改** `python/minisgl/engine/config.py` — Ascend 上 `cuda_graph_bs=[]`、`cuda_graph_max_bs=0`、`use_pynccl=False` 作为默认。
+7. **修改** `python/minisgl/scheduler/scheduler.py:53-55,128,134` — 抽象层化。
+8. **修改** `python/minisgl/distributed/impl.py:73-90` — Ascend 上 `enable_pynccl_distributed` 强制返回 `TorchDistributedImpl`。
+9. **修改** `python/minisgl/kernel/__init__.py` — 将 `pynccl` / `moe_impl` / `store` / `index` 的 top-level 导入改为**延迟/守护式**（仅在 CUDA 可用时导入；否则暴露占位 `None` 或抛延迟错误）。
+10. **修改** `python/minisgl/kernel/pynccl.py:30-37` — 在无 CUDA / 未开启 pynccl 时短路，不触发 `load_aot`。
+11. **修改** `python/minisgl/server/args.py:124-129,148-153` — Ascend 上 `--disable-pynccl` 默认 `True`、`--cuda-graph-max-bs` 默认 `0`。
+
+Gate 0 **不允许**触碰的项（列入 Gate 1+）：
+- `python/minisgl/kernel/csrc/**` 全部 `.cu`/`.h`。
+- `python/minisgl/attention/{fi,fa,trtllm}.py` 后端实现体。
+- `python/minisgl/layers/{norm,rotary,activation,embedding}.py`（保留 flashinfer/kernel 引用，只要不被启动路径触达即可；如 layer 在 import 阶段直接 `import flashinfer`，则本次改为 `try/except`）。
+- `python/minisgl/moe/fused.py`、`python/minisgl/kernel/moe_impl.py`、`python/minisgl/kernel/triton/fused_moe.py`（MoE 全禁用）。
+- `python/minisgl/engine/graph.py`（Gate 0 走 `use_cuda_graph=False` 分支）。
+- `python/minisgl/engine/sample.py` 中 `flashinfer.sampling`（暂不替换；Gate 0 允许启动失败在采样阶段，或做 lazy import + Ascend 上落回 torch 版——但那已属 Gate 1 内容）。
+- `pyproject.toml`、`uv.lock`、`LICENSE`、`NOTICE`。
+
+## 12. 风险与开放问题 (Risks and Open Questions)
+
+1. **`kernel/__init__.py` 贪婪导入**：当前实现会在 `import minisgl` 时立即触发 `pynccl.load_aot(cuda_files=...)`（`kernel/pynccl.py:30`）。在无 CUDA 主机上会崩溃。Gate 0 必须先解决这条阻塞路径。
+2. **flashinfer 顶层 import**：`python/minisgl/layers/norm.py:10`、`rotary.py:35`、`activation.py:10,16`、`engine/sample.py:30` 都在文件顶层 `import flashinfer`；在无 CUDA 主机 `flashinfer` 未安装时会 `ImportError`。Gate 0 需评估是否让这些模块的顶层导入延迟到函数体或 try/except——但这已经**逼近 Gate 0 边界**，需与用户确认是否允许。
+3. **`sgl_kernel` 顶层 import**：`python/minisgl/attention/fa.py:158`、`python/minisgl/moe/fused.py:16,71` 同样风险。
+4. **PyTorch NPU 后端字符串**：`torch_npu` 注册的分布式后端名（`"hccl"`）与 PyTorch 版本紧密耦合，需在 Gate 0 实机确认。
+5. **`torch_npu.npu.Stream/Event`** 语义与 CUDA 完全对齐——在部分固件/驱动组合下 `Event.wait(stream)` 支持不完整；`scheduler.py` 双流重叠路径需要在 Gate 1 验证。
+6. **`torch.pin_memory=True`** 在部分 NPU 环境不可用；若阻塞，需要在 Gate 1 做 fallback（当前列 P2）。
+7. **`torch.cuda.mem_get_info`**：`torch_npu.npu.mem_get_info` 在旧版 CANN 上可能不存在，Gate 1 要做 try/except。
+8. **License**：仓库无 `NOTICE`；建议 fork 时补充作者/上游引用（不属 Gate 0）。上游 `sgl-project` MIT，无 attribution 阻塞。
+9. **`pyproject.toml` 依赖治理**：`accelerate`、`quack-kernels` 完全无源码引用，是**廉价清理项**，但按硬约束**本次不改**。
+10. **未证实项**：本报告未运行任何代码，`torch_npu` API 兼容性、`hccl` 后端在当前 `torch<2.10.0` 约束下是否可用，均需在 Gate 0 实机执行阶段确认；本报告仅提供源码级导航。

--- a/docs/ascend_port/source_dependency_inventory.csv
+++ b/docs/ascend_port/source_dependency_inventory.csv
@@ -1,0 +1,102 @@
+category,file,line,symbol,current_dependency,role,portability,ascend_action,priority,notes
+build_metadata,pyproject.toml,25,torch<2.10.0,torch(CUDA build),required_runtime,thin-adaptation,switch to torch_npu-compatible torch build; keep version pin loose,P0,Ascend needs matching torch+torch_npu wheel
+build_metadata,pyproject.toml,26,transformers>=4.56.0<=4.57.3,transformers,required_runtime,portable,keep as-is,P2,pure python, device-agnostic
+build_metadata,pyproject.toml,27,flashinfer-python>=0.5.3,flashinfer,attention/norm/rope/sampling,backend-replacement,move to optional cuda extra; add ascend backend alternative,P0,flashinfer is CUDA/PTX only
+build_metadata,pyproject.toml,32,apache-tvm-ffi>=0.1.4,tvm-ffi,JIT/AOT kernel loader,thin-adaptation,keep for CPU AOT parts; skip cuda_files on Ascend,P1,ffi itself is portable; only .cu invocations fail
+build_metadata,pyproject.toml,33,sgl_kernel>=0.3.17.post1,sgl_kernel,attention (fa)/moe helpers,backend-replacement,move to cuda extra; provide ascend equivalent,P0,CUDA-only wheel
+build_metadata,pyproject.toml,34,quack-kernels,quack-kernels,declared not imported,portable,drop from ascend deps,P2,no import found in Python source
+build_metadata,pyproject.toml,22,accelerate,accelerate,declared not imported,portable,drop from ascend deps,P2,no import found in Python source
+build_metadata,pyproject.toml,13,license MIT,MIT,license,portable,retain MIT; add NOTICE if forking upstream sgl-project,P2,fork obligations minimal but recommend NOTICE
+device_probe,python/minisgl/utils/arch.py,12,torch.cuda.is_available,torch.cuda,device capability probe,thin-adaptation,replace with device abstraction that also probes torch_npu,P0,root of arch dispatch (is_sm90/sm100)
+device_probe,python/minisgl/utils/arch.py,14,torch.cuda.get_device_capability,torch.cuda,arch dispatch,thin-adaptation,return None on NPU or map to NPU generation,P0,used by SM90/SM100 gates only
+device_probe,python/minisgl/utils/torch_utils.py,24,torch.cuda.nvtx,torch.cuda.nvtx,profiling annotation,thin-adaptation,make lazy/no-op on NPU or route to torch_npu profiler,P1,decorator can degrade gracefully
+control_plane,python/minisgl/engine/engine.py,31,torch.cuda.is_initialized,torch.cuda,startup guard,thin-adaptation,call device abstraction,P0,eager Ascend startup path
+control_plane,python/minisgl/engine/engine.py,35,f"cuda:{rank}",torch.cuda,device string,thin-adaptation,use device abstraction (npu:{rank}),P0,change torch.device construction only
+control_plane,python/minisgl/engine/engine.py,36,torch.cuda.set_device,torch.cuda,set current device,thin-adaptation,delegate to device abstraction,P0,torch_npu.npu.set_device on NPU
+control_plane,python/minisgl/engine/engine.py,38-39,torch.cuda.Stream+set_stream,torch.cuda,worker stream setup,thin-adaptation,delegate to device abstraction,P0,torch_npu supports Stream API
+control_plane,python/minisgl/engine/engine.py,114,init_process_group backend=gloo,torch.distributed,control-plane group,portable,keep gloo group,P2,CPU broadcast unaffected
+control_plane,python/minisgl/engine/engine.py,128,init_process_group backend=nccl,torch.distributed,device comm group,thin-adaptation,dispatch to hccl on Ascend,P0,backend string selection
+control_plane,python/minisgl/engine/engine.py,135,new_group backend=gloo,torch.distributed,control subgroup,portable,keep as-is,P2,-
+control_plane,python/minisgl/engine/engine.py,172-174,synchronize/empty_cache/reset_peak_memory_stats,torch.cuda,memory ops,thin-adaptation,route through device abstraction,P0,torch_npu.npu.* equivalents exist
+control_plane,python/minisgl/engine/engine.py,192,torch.cuda.current_stream,torch.cuda,stream capture,thin-adaptation,device abstraction,P0,-
+control_plane,python/minisgl/engine/engine.py,204,torch.cuda.Event,torch.cuda,event sync,thin-adaptation,device abstraction (torch_npu.npu.Event),P0,used for stream overlap; NPU supports Event
+control_plane,python/minisgl/engine/engine.py,209,destroy_cuda_graphs,graph module,shutdown hook,thin-adaptation,guard behind graph-supported flag,P1,graph disabled on Ascend Gate 0
+graph_plane,python/minisgl/engine/graph.py,49-67,_determine_cuda_graph_bs,internal,graph capture policy,backend-replacement,disable path entirely on Ascend Gate 0,P1,not in Gate 0 minimal set
+graph_plane,python/minisgl/engine/graph.py,75,mem_get_info,torch.cuda,memory query,thin-adaptation,device abstraction,P1,torch_npu equivalent exists
+graph_plane,python/minisgl/engine/graph.py,112-114,synchronize/empty_cache/reset_peak_memory_stats,torch.cuda,memory ops,thin-adaptation,device abstraction,P1,-
+graph_plane,python/minisgl/engine/graph.py,133,torch.cuda.CUDAGraph,torch.cuda,graph capture,backend-replacement,gate off; no NPU equivalent in Gate 0,P1,NPU has aclgraph but out of scope for Gate 0
+graph_plane,python/minisgl/engine/graph.py,140,torch.cuda.graph,torch.cuda,graph capture ctx,backend-replacement,gate off,P1,-
+control_plane,python/minisgl/engine/sample.py,30,flashinfer.sampling,flashinfer,top_k_top_p_sampling_from_probs,backend-replacement,replace with pure torch sampling or NPU op,P0,fallback torch impl is straightforward
+control_plane,python/minisgl/engine/sample.py,72,torch.cuda.nvtx.range,torch.cuda.nvtx,profiling,thin-adaptation,use decorator abstraction,P1,-
+control_plane,python/minisgl/engine/sample.py,21,pin_memory,torch,H2D staging,portable,portable pin_memory works on NPU,P2,verify on torch_npu; fallback plain tensor
+control_plane,python/minisgl/engine/config.py,-,cuda_graph_bs/cuda_graph_max_bs/use_pynccl,dataclass,run config,thin-adaptation,disable via defaults on Ascend Gate 0,P0,expose --disable-cuda-graph/--disable-pynccl paths
+distributed_plane,python/minisgl/distributed/impl.py,-,TorchDistributedImpl,torch.distributed,all_reduce/all_gather,portable,drives on any backend (nccl/hccl),P0,already backend-agnostic
+distributed_plane,python/minisgl/distributed/impl.py,-,PyNCCLDistributedImpl,minisgl.kernel.pynccl,NCCL wrapper,backend-replacement,disable by default on Ascend Gate 0,P0,requires HCCL rewrite in Gate 1+
+distributed_plane,python/minisgl/distributed/impl.py,73-90,enable_pynccl_distributed,factory,backend selector,thin-adaptation,short-circuit to Torch backend on Ascend,P0,minimal change
+distributed_plane,python/minisgl/distributed/info.py,-,DistributedInfo,dataclass,rank meta,portable,keep as-is,P2,-
+kernel_plane,python/minisgl/kernel/__init__.py,-,eager imports,internal,module init,thin-adaptation,make pynccl/moe_impl imports lazy or CUDA-guarded,P0,blocks import minisgl on hosts without CUDA
+kernel_plane,python/minisgl/kernel/pynccl.py,30,load_aot cuda_files=pynccl.cu,tvm-ffi/NCCL,PyNCCL wrapper,major-rewrite,skip loading on Ascend; provide HCCL twin later,P0,requires HCCL API rewrite
+kernel_plane,python/minisgl/kernel/pynccl.py,37,tvm_ffi.register_object minisgl.NCCLWrapper,tvm-ffi,ABI class,major-rewrite,gated behind CUDA-only import,P0,-
+kernel_plane,python/minisgl/kernel/utils.py,63,tvm_ffi.cpp.load,tvm-ffi,JIT loader,thin-adaptation,allow cpp-only mode; block cuda files on NPU,P1,-
+kernel_plane,python/minisgl/kernel/utils.py,99,tvm_ffi.cpp.load_inline,tvm-ffi,inline loader,thin-adaptation,gate on device,P1,-
+kernel_plane,python/minisgl/kernel/index.py,-,load_jit cuda_files=index.cu,tvm-ffi/CUDA,gather-scatter kernel,backend-replacement,provide torch-native fallback for Ascend,P1,used by embedding layer
+kernel_plane,python/minisgl/kernel/store.py,-,load_jit cuda_files=store.cu,tvm-ffi/CUDA,kv cache store,backend-replacement,torch-native fallback,P1,used by mha_pool
+kernel_plane,python/minisgl/kernel/tensor.py,-,load_aot cpp_files=tensor.cpp,tvm-ffi/CPU,cpu helpers,portable,keep as-is,P2,CPU only
+kernel_plane,python/minisgl/kernel/radix.py,-,load_aot cpp_files=radix.cpp,tvm-ffi/CPU,radix helpers,portable,keep as-is,P2,CPU only
+kernel_plane,python/minisgl/kernel/moe_impl.py,20-21,triton import + @triton.jit,triton,fused MoE,backend-replacement,disable MoE path on Ascend Gate 0,P2,MoE excluded from Gate 0
+kernel_plane,python/minisgl/kernel/moe_impl.py,66,fused_moe kernel dispatch,triton,fused MoE,backend-replacement,disable,P2,-
+kernel_plane,python/minisgl/kernel/triton/fused_moe.py,1-2,triton language,triton,fused MoE,backend-replacement,disable,P2,-
+attention_plane,python/minisgl/attention/fi.py,-,FlashInfer backend,flashinfer,attention,backend-replacement,not needed for Gate 0; keep import lazy,P1,Gate 0 uses different default backend
+attention_plane,python/minisgl/attention/fi.py,120,torch.cuda.Event,torch.cuda,event,thin-adaptation,route via device abstraction,P1,only exercised when FI selected
+attention_plane,python/minisgl/attention/fa.py,158,sgl_kernel.flash_attn_with_kvcache,sgl_kernel,attention,backend-replacement,provide Ascend replacement (torch_npu.npu_incre_flash_attention/npu_prompt_flash_attention),P1,Gate 1 target; Gate 0 keeps registry stub
+attention_plane,python/minisgl/attention/trtllm.py,52,flashinfer.decode.trtllm_batch_decode_with_kv_cache,flashinfer,attention,backend-replacement,provide alternative or disable,P1,-
+attention_plane,python/minisgl/attention/trtllm.py,53,flashinfer.prefill.trtllm_batch_context_with_kv_cache,flashinfer,attention,backend-replacement,provide alternative or disable,P1,-
+attention_plane,python/minisgl/attention/base.py,-,AttentionBackend base,internal,ABC,portable,keep,P2,-
+attention_plane,python/minisgl/attention/utils.py,-,helpers,internal,helpers,portable,keep,P2,-
+attention_plane,python/minisgl/attention/__init__.py,-,Registry factory,internal,dispatch,thin-adaptation,register Ascend backend,P1,-
+kvcache_plane,python/minisgl/kvcache/base.py,-,BaseKvCache,internal,ABC,portable,keep,P2,-
+kvcache_plane,python/minisgl/kvcache/naive_cache.py,-,NaiveKvCache,internal,cache,portable,keep,P2,-
+kvcache_plane,python/minisgl/kvcache/radix_cache.py,-,RadixCache,internal,cache,portable,keep,P2,relies on CPU radix helper
+kvcache_plane,python/minisgl/kvcache/mha_pool.py,-,store_cache,minisgl.kernel.store,cache write,backend-replacement,provide torch-native fallback for Ascend,P1,-
+kvcache_plane,python/minisgl/kvcache/__init__.py,-,Registry factory,internal,dispatch,portable,keep,P2,-
+layers,python/minisgl/layers/rotary.py,35,flashinfer.apply_rope_with_cos_sin_cache_inplace,flashinfer,RoPE,backend-replacement,torch/NPU fallback (either pure torch or torch_npu.npu_rotary_mul),P1,candidate for Gate 1
+layers,python/minisgl/layers/norm.py,10,flashinfer.rmsnorm,flashinfer,RMSNorm,backend-replacement,torch_npu.npu_rms_norm or pure torch,P1,-
+layers,python/minisgl/layers/norm.py,25,flashinfer.fused_add_rmsnorm,flashinfer,RMSNorm,backend-replacement,torch_npu.npu_add_rms_norm or pure torch,P1,-
+layers,python/minisgl/layers/activation.py,10,flashinfer.silu_and_mul,flashinfer,activation,backend-replacement,torch_npu.npu_swiglu or pure torch,P1,-
+layers,python/minisgl/layers/activation.py,16,flashinfer.gelu_and_mul,flashinfer,activation,backend-replacement,pure torch fallback,P1,-
+layers,python/minisgl/layers/embedding.py,-,minisgl.kernel.indexing,minisgl.kernel/CUDA,gather,backend-replacement,torch scatter/index_select fallback,P1,-
+layers,python/minisgl/layers/linear.py,-,F.linear + DistributedCommunicator,torch,linear,portable,keep,P2,-
+layers,python/minisgl/layers/attention.py,-,AttentionLayer,internal,orchestration,portable,keep,P2,-
+layers,python/minisgl/layers/moe.py,-,MoELayer,internal,orchestration,portable,keep (path disabled Gate 0),P2,-
+layers,python/minisgl/layers/base.py,-,LayerBase,internal,ABC,portable,keep,P2,-
+moe_plane,python/minisgl/moe/fused.py,16,sgl_kernel.topk_softmax,sgl_kernel,MoE gating,backend-replacement,disable MoE Gate 0,P2,-
+moe_plane,python/minisgl/moe/fused.py,71,sgl_kernel.moe_align_block_size,sgl_kernel,MoE align,backend-replacement,disable MoE Gate 0,P2,-
+core_dataclasses,python/minisgl/core.py,-,Batch/Req/Context/SamplingParams,internal,dataclasses,portable,keep,P2,-
+env,python/minisgl/env.py,-,PYNCCL_MAX_BUFFER_SIZE,env var,tunables,thin-adaptation,add Ascend-specific envs and default off pynccl,P1,-
+scheduler,python/minisgl/scheduler/scheduler.py,53-55,Stream/stream/set_stream,torch.cuda,scheduler streams,thin-adaptation,device abstraction,P0,two-stream overlap logic
+scheduler,python/minisgl/scheduler/scheduler.py,128,current_stream,torch.cuda,stream fetch,thin-adaptation,device abstraction,P0,-
+scheduler,python/minisgl/scheduler/scheduler.py,134,synchronize,torch.cuda,sync,thin-adaptation,device abstraction,P0,-
+scheduler,python/minisgl/scheduler/scheduler.py,238,pin_memory,torch,H2D staging,portable,keep,P2,-
+scheduler,python/minisgl/scheduler/scheduler.py,253,pin_memory,torch,H2D staging,portable,keep,P2,-
+scheduler,python/minisgl/scheduler/scheduler.py,264,pin_memory,torch,H2D staging,portable,keep,P2,-
+scheduler,python/minisgl/scheduler/scheduler.py,266,pin_memory,torch,H2D staging,portable,keep,P2,-
+scheduler,python/minisgl/scheduler/cache.py,134-135,pin_memory,torch,H2D staging,portable,keep,P2,-
+scheduler,python/minisgl/scheduler/prefill.py,60,pin_memory,torch,H2D staging,portable,keep,P2,-
+scheduler,python/minisgl/scheduler/prefill.py,81,pin_memory,torch,H2D staging,portable,keep,P2,-
+scheduler,python/minisgl/scheduler/io.py,-,ZMQ+CPU broadcast,zmq/torch.distributed,IO plane,portable,keep,P2,-
+scheduler,python/minisgl/scheduler/config.py,-,SchedulerConfig,dataclass,config,portable,keep,P2,-
+server,python/minisgl/server/args.py,124-129,--disable-pynccl,cli,flag,portable,default true on Ascend,P0,already available
+server,python/minisgl/server/args.py,148-153,--cuda-graph-max-bs,cli,flag,thin-adaptation,default 0 or gate on Ascend,P0,disable capture path
+server,python/minisgl/server/launch.py,-,mp.set_start_method spawn,mp,startup,portable,keep,P2,-
+models,python/minisgl/models/base.py,-,Model base,internal,ABC,portable,keep,P2,-
+models,python/minisgl/models/weight.py,-,weight loader,internal,IO,portable,keep,P2,-
+models,python/minisgl/models/llama.py,-,LlamaModel,internal,model,portable,keep,P2,-
+models,python/minisgl/models/qwen3_moe.py,-,QwenMoE,internal,model,portable,keep (MoE gated),P2,-
+utils,python/minisgl/utils/mp.py,-,ZMQ queues,zmq/msgpack,IPC,portable,keep,P2,-
+utils,python/minisgl/utils/hf.py,-,HF loaders,transformers,IO,portable,keep,P2,-
+utils,python/minisgl/utils/logger.py,-,init_logger,logging,logs,portable,keep,P2,-
+utils,python/minisgl/utils/registry.py,-,Registry,internal,dispatch,portable,keep,P2,-
+utils,python/minisgl/utils/misc.py,-,misc,internal,helpers,portable,keep,P2,-
+benchmark,python/minisgl/benchmark/perf.py,-,CUDAGraph benchmarks,torch.cuda,dev tool,backend-replacement,not required for Gate 0,P2,-
+kernel_native,python/minisgl/kernel/csrc/include/minisgl/nccl227.h,-,NCCL 2.27 header,NCCL,C header,major-rewrite,replace with HCCL header,P0,Gate 1 target; excluded from Gate 0
+kernel_native,python/minisgl/kernel/csrc/src/pynccl.cu,-,ncclCommInitRank/ncclAllReduce/ncclAllGather/ncclCommWindowRegister,NCCL,C++/CUDA,major-rewrite,full HCCL rewrite,P0,Gate 1 target; Gate 0 disables PyNCCL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,12 +32,20 @@ dependencies = [
     "fastapi",
     "prompt_toolkit",
     "openai",
+    # apache-tvm-ffi drives the AOT-compiled CPU helpers in
+    # ``minisgl.kernel.{radix,tensor}`` — ``fast_compare_key`` is invoked by
+    # ``RadixPrefixCache._tree_walk`` on every prefix match, so it is
+    # required on ALL devices (CUDA, Ascend NPU, CPU). Keeping it in the
+    # ``[cuda]`` extra caused clean Ascend installs to fail with
+    # ``ModuleNotFoundError: No module named 'tvm_ffi'`` at the first
+    # prefill scheduling call (Gate 2.1e). Membership belongs in the base
+    # dependency list, not in a device-specific extra.
+    "apache-tvm-ffi>=0.1.4",
 ]
 
 [project.optional-dependencies]
 cuda = [
     "flashinfer-python>=0.5.3",
-    "apache-tvm-ffi>=0.1.4",
     "sgl_kernel>=0.3.17.post1",
     "quack-kernels",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,18 +27,20 @@ dependencies = [
     "modelscope",
     "torch<2.10.0",
     "transformers>=4.56.0,<=4.57.3",
-    "flashinfer-python>=0.5.3",
     "pyzmq",
     "uvicorn",
     "fastapi",
     "prompt_toolkit",
     "openai",
+]
+
+[project.optional-dependencies]
+cuda = [
+    "flashinfer-python>=0.5.3",
     "apache-tvm-ffi>=0.1.4",
     "sgl_kernel>=0.3.17.post1",
     "quack-kernels",
 ]
-
-[project.optional-dependencies]
 dev = [
     "pytest>=6.0",
     "pytest-cov>=2.0",

--- a/python/minisgl/attention/__init__.py
+++ b/python/minisgl/attention/__init__.py
@@ -40,6 +40,15 @@ def create_fa_backend(config: ModelConfig):
     return FlashAttentionBackend(config)
 
 
+@SUPPORTED_ATTENTION_BACKENDS.register("npu_fia")
+def create_npu_fia_backend(config: ModelConfig):
+    # Lazy import: only reached when the caller explicitly selects "npu_fia".
+    # This keeps ascend_fia.py off the import path for pure-CUDA runs.
+    from .ascend_fia import AscendFIABackend
+
+    return AscendFIABackend(config)
+
+
 def validate_attn_backend(backend: str, allow_auto: bool = True):
     if backend != "auto":
         required_backends = backend.split(",") if "," in backend else [backend]

--- a/python/minisgl/attention/ascend_fia.py
+++ b/python/minisgl/attention/ascend_fia.py
@@ -176,8 +176,110 @@ class AscendFIABackend(BaseAttnBackend):
         layer_id: int,
         batch: "Batch",
     ) -> "torch.Tensor":
-        # Preserved verbatim from Gate 1.8a — the FIA op call lands in a
-        # separate Gate on top of Gate 1.8c's metadata builder.
-        raise NotImplementedError(
-            "Ascend FIA forward is not implemented until Gate 1.8b"
+        """Run one paged-KV FIA attention step (single-request BSND).
+
+        Execution order (mirrors the spec for Gate 1.8e):
+
+        1. validate ``batch.attn_metadata`` is a :class:`FIAMetadata`;
+        2. re-check we're still on the single-request path (defense-in-depth
+           against a caller that mutated ``padded_reqs`` between
+           :meth:`prepare_metadata` and here);
+        3. write this layer's new K/V into the paged cache;
+        4. no-copy view the flat query ``[Tq, Hq, D]`` as BSND
+           ``[1, Tq, Hq, D]``;
+        5. fetch the FIA-native BnNBsD cache tensors — passed verbatim,
+           no permute / contiguous;
+        6. build the causal ``atten_mask`` (or ``None`` for the single-Q
+           case) padded to the block boundary FIA's tiling requires;
+        7. dynamic-import ``torch_npu`` and call
+           :func:`torch_npu.npu_fused_infer_attention_score`;
+        8. take the first tensor of the returned tuple (softmax_lse is
+           unused in inference mode);
+        9. no-copy view back to the flat ``[Tq, Hq, D]`` shape.
+        """
+        # 1. metadata type check
+        metadata = batch.attn_metadata
+        if not isinstance(metadata, FIAMetadata):
+            raise TypeError(
+                "Ascend FIA forward expects batch.attn_metadata to be "
+                f"FIAMetadata, got {type(metadata).__name__}"
+            )
+        # 2. still B=1
+        if len(metadata.actual_seq_lengths) != 1:
+            raise NotImplementedError(
+                "Ascend FIA forward currently supports batch size 1 only"
+            )
+
+        # Lazy imports keep the module import-safe on CUDA / CPU hosts.
+        import torch
+        from minisgl.core import get_global_ctx
+
+        ctx = get_global_ctx()
+
+        # 3. write this layer's new K/V into the paged cache. store_kv covers
+        # both nhd and bnbsd layouts internally; the FIA path is always bnbsd
+        # so store_kv writes directly with the raw-slot scatter from Gate 1.7f.
+        ctx.kv_cache.store_kv(k, v, batch.out_loc, layer_id)
+
+        # 4. no-copy view [Tq, Hq, D] -> [1, Tq, Hq, D]. unsqueeze is a
+        # guaranteed non-copy view regardless of contiguity.
+        query_bsnd = q.unsqueeze(0)
+
+        # 5. BnNBsD paged caches — passed verbatim, no permute/contiguous.
+        key_cache = ctx.kv_cache.k_cache(layer_id)
+        value_cache = ctx.kv_cache.v_cache(layer_id)
+
+        # 6. Causal mask. Decode / single-Q path uses ``None`` (FIA elides
+        # masking). Prefill builds an offset causal mask, then pads the KV
+        # axis to ``num_blocks * page_size`` because FIA's tiling requires
+        # ``atten_mask.shape[-1] >= num_blocks * block_size`` — the extra
+        # columns are all masked out (``True``) so they can never
+        # participate. This constraint was surfaced by the Gate 1.8d probe.
+        if metadata.query_seq_len == 1:
+            atten_mask = None
+        else:
+            padded_kv_len = metadata.block_table.shape[1] * ctx.page_size
+            cached_len = metadata.kv_seq_len - metadata.query_seq_len
+            q_pos = cached_len + torch.arange(
+                metadata.query_seq_len, device=q.device
+            )
+            k_pos = torch.arange(padded_kv_len, device=q.device)
+            atten_mask = k_pos.unsqueeze(0) > q_pos.unsqueeze(1)
+
+        # 7. Dynamic import of torch_npu. Gate 1.8a forbids this at module
+        # top level; only here inside forward() is it allowed. Surface a
+        # clean RuntimeError so downstream operators aren't left staring at
+        # a bare ImportError.
+        try:
+            import torch_npu
+        except ImportError as exc:
+            raise RuntimeError(
+                "Ascend FIA forward requires torch_npu to be importable; "
+                "install torch_npu on the host to use the 'npu_fia' "
+                "attention backend."
+            ) from exc
+
+        # 8. Call FIA. ``scale`` — not ``scale_value`` — matches the aclnn v3
+        # binding. ``num_heads`` is Hq from the flat query (q.shape[1]);
+        # ``num_key_value_heads`` is Hkv from the paged cache
+        # (key_cache.shape[1] under BnNBsD).
+        result = torch_npu.npu_fused_infer_attention_score(
+            query_bsnd,
+            key_cache,
+            value_cache,
+            atten_mask=atten_mask,
+            actual_seq_lengths=metadata.actual_seq_lengths,
+            actual_seq_lengths_kv=metadata.actual_seq_lengths_kv,
+            block_table=metadata.block_table,
+            num_heads=q.shape[1],
+            num_key_value_heads=key_cache.shape[1],
+            scale=q.shape[-1] ** -0.5,
+            input_layout="BSND",
+            block_size=ctx.page_size,
+            sparse_mode=0,
         )
+
+        # 9. FIA returns ``(attention_out, softmax_lse)``; softmax_lse is
+        # empty in inference. Reshape back to the caller's flat layout.
+        attention_out = result[0]
+        return attention_out.view(q.shape)

--- a/python/minisgl/attention/ascend_fia.py
+++ b/python/minisgl/attention/ascend_fia.py
@@ -1,14 +1,23 @@
-"""Ascend Fused Infer Attention (FIA) backend — Gate 1.8c metadata builder.
+"""Ascend Fused Infer Attention (FIA) backend.
 
-Gate 1.8a landed the class scaffolding. Gate 1.8c fills in the metadata
-constructor for the single-request (B=1) BSND path only — multi-request
-TND, NPU-graph capture wiring, and the FIA call itself remain deferred.
+Gate 2.2c generalises the wrapper from single-request BSND to equal-length
+multi-request BSND. The underlying FIA operator was proven to accept
+``B >= 1`` batched prefill/decode by the Gate 2.2b contract probe; only the
+wrapper's ``len(reqs) != 1`` guard needed lifting.
+
+Supported today:
+  * ``B >= 1`` where every real request in ``batch.padded_reqs`` shares the
+    same ``extend_len``, ``cached_len`` and ``device_len`` (equal-length
+    batch, prefill OR decode).
+
+Explicitly refused (``NotImplementedError``):
+  * Ragged batches — any variance across ``extend_len``/``cached_len``/
+    ``device_len``. The TND path lands in a later Gate.
 
 The module stays torch-free at import time: ``torch`` and ``minisgl.core``
-are pulled in lazily inside the metadata methods so that importing
+are pulled in lazily inside method bodies so importing
 ``minisgl.attention.ascend_fia`` on a CUDA / CPU host is safe. The module
-must never reference ``torch_npu`` (top-level or lazy) — the FIA op wiring
-lands in a later Gate.
+must never reference ``torch_npu`` outside :meth:`AscendFIABackend.forward`.
 """
 from __future__ import annotations
 
@@ -29,67 +38,68 @@ def _ceil_div(a: int, b: int) -> int:
 
 @dataclass
 class FIAMetadata(BaseAttnMetadata):
-    """Metadata for the single-request BSND Ascend FIA path.
-
-    The multi-request TND path and the NPU-graph replay path will extend
-    this dataclass in later Gates; today we only surface the fields needed
-    for B=1 prefill / decode.
+    """Metadata for the equal-length multi-request BSND Ascend FIA path.
 
     Fields:
-        block_table:            [1, num_blocks] int32 on the KV-cache device;
-                                each entry is a physical **page id** (not raw
-                                slot) — matches the layout FIA's
-                                ``block_table`` argument expects.
-        actual_seq_lengths:     per-request query length; a Python list
-                                (length == 1 today) so it can be passed
-                                straight to ``torch_npu.npu_fused_infer_...``
+        block_table:            ``[B, num_blocks]`` int32 on the KV-cache
+                                device. Row ``b`` lists the physical page
+                                ids backing request ``b`` — stride-then-
+                                divide of the global ``page_table``.
+        actual_seq_lengths:     per-request query length; a Python list of
+                                length ``B`` with a shared value
+                                (equal-length batching). Passed straight to
+                                ``torch_npu.npu_fused_infer_attention_score``
                                 without a device round-trip.
-        actual_seq_lengths_kv:  per-request total KV length (cached + extend).
-        input_layout:           ``"BSND"`` for the single-request path.
-        query_seq_len:          == ``actual_seq_lengths[0]``, kept for cheap
-                                indexing.
-        kv_seq_len:             == ``actual_seq_lengths_kv[0]``.
+        actual_seq_lengths_kv:  per-request total KV length (cached + extend);
+                                same layout, shared value.
+        input_layout:           ``"BSND"``.
+        batch_size:             ``B`` — cached so :meth:`forward` can
+                                ``reshape`` the flat query without a
+                                ``len(...)`` call on the metadata list.
+        query_seq_len:          shared ``extend_len`` across the batch —
+                                equal to ``actual_seq_lengths[0]``.
+        kv_seq_len:             shared ``device_len`` across the batch —
+                                equal to ``actual_seq_lengths_kv[0]``.
     """
 
     block_table: "torch.Tensor"
     actual_seq_lengths: List[int]
     actual_seq_lengths_kv: List[int]
     input_layout: str
+    batch_size: int
     query_seq_len: int
     kv_seq_len: int
 
     def get_last_indices(self, bs: int) -> "torch.Tensor":
-        """Return the index of the last query token per request.
+        """Return the index of the last query token per request in the flat
+        query buffer.
 
-        For the single-request path this is a 1-element tensor:
-
-        * prefill: ``query_seq_len - 1`` (last new token in the flat Q buffer)
-        * decode:  ``0`` (``query_seq_len == 1``)
-
-        Multi-request wiring lands with the TND path; ``bs != 1`` is rejected
-        explicitly rather than silently returning a mis-shaped tensor.
+        Under equal-length batching the flat query is laid out as
+        ``[req0_tok0, ..., req0_tokS-1, req1_tok0, ...]`` so the last index
+        of request ``b`` is ``(b + 1) * query_seq_len - 1``. This matches the
+        semantics of ``cu_seqlens_q[1:1+bs] - 1`` used by the CUDA backends.
         """
-        if bs != 1:
-            raise NotImplementedError(
-                "Ascend FIA get_last_indices currently supports batch size 1 only"
-            )
         # Lazy import so the module stays torch-free at import time.
         import torch
 
-        return torch.tensor(
-            [self.query_seq_len - 1],
-            dtype=torch.int32,
-            device=self.block_table.device,
+        return (
+            torch.arange(
+                1,
+                bs + 1,
+                dtype=torch.int32,
+                device=self.block_table.device,
+            )
+            * self.query_seq_len
+            - 1
         )
 
 
 class AscendFIABackend(BaseAttnBackend):
-    """Skeleton for the Ascend FIA paged-KV attention backend.
+    """Ascend FIA paged-KV attention backend (equal-length multi-request).
 
     The constructor signature mirrors what :func:`create_attention_backend`
     already passes to :class:`FlashInferBackend` / :class:`FlashAttentionBackend`
-    / :class:`TensorRTLLMBackend`: a single ``ModelConfig`` positional. We only
-    stash the config for later gates; no NPU state is materialised yet.
+    / :class:`TensorRTLLMBackend`: a single ``ModelConfig`` positional.
     """
 
     def __init__(self, config: "ModelConfig") -> None:
@@ -97,7 +107,7 @@ class AscendFIABackend(BaseAttnBackend):
 
     # --------------------------------------------------------------- graph
     def init_capture_graph(self, max_seq_len: int, bs_list: List[int]) -> None:
-        # Real NPU-graph capture wiring lands with the FIA call in a later Gate.
+        # NPU-graph capture wiring lands with a later Gate.
         return None
 
     def prepare_for_capture(self, batch: "Batch") -> None:
@@ -108,16 +118,16 @@ class AscendFIABackend(BaseAttnBackend):
 
     # ------------------------------------------------------------ metadata
     def prepare_metadata(self, batch: "Batch") -> None:
-        """Build :class:`FIAMetadata` for the single-request BSND path.
+        """Build :class:`FIAMetadata` for the equal-length BSND path.
 
-        Only ``len(batch.padded_reqs) == 1`` is supported today. The
-        multi-request TND and NPU-graph decode paths are separate Gates.
+        Accepts ``B >= 1`` when every real request in ``batch.padded_reqs``
+        shares the same ``extend_len``, ``cached_len`` and ``device_len``.
+        Ragged batches raise :class:`NotImplementedError` — the TND path is a
+        future Gate.
         """
         reqs = batch.padded_reqs
-        if len(reqs) != 1:
-            raise NotImplementedError(
-                "Ascend FIA metadata currently supports batch size 1 only"
-            )
+        if not reqs:
+            raise ValueError("Ascend FIA metadata received an empty request list")
 
         # Lazy imports keep the module import-safe on CUDA / CPU hosts and
         # avoid pulling ``minisgl.core`` (which imports torch) at registration
@@ -125,31 +135,56 @@ class AscendFIABackend(BaseAttnBackend):
         import torch
         from minisgl.core import get_global_ctx
 
-        req = reqs[0]
-        query_seq_len = req.extend_len
-        kv_seq_len = req.device_len
+        # Equal-length invariant: every real request in the batch must share
+        # the same (extend_len, device_len, cached_len). We derive the shared
+        # value from reqs[0] and check the rest — anything ragged is refused
+        # with an explicit NotImplementedError instead of silently building a
+        # wrong batched metadata.
+        head = reqs[0]
+        query_seq_len = head.extend_len
+        kv_seq_len = head.device_len
+        cached_len_head = kv_seq_len - query_seq_len
+        for idx, r in enumerate(reqs[1:], start=1):
+            r_cached_len = r.device_len - r.extend_len
+            if (
+                r.extend_len != query_seq_len
+                or r.device_len != kv_seq_len
+                or r_cached_len != cached_len_head
+            ):
+                raise NotImplementedError(
+                    "Ascend FIA metadata requires all requests in the batch to "
+                    "share the same extend_len, cached_len and device_len "
+                    "(ragged batches are not supported yet). "
+                    f"req[0]: extend_len={query_seq_len} device_len={kv_seq_len} "
+                    f"cached_len={cached_len_head}; "
+                    f"req[{idx}]: extend_len={r.extend_len} "
+                    f"device_len={r.device_len} cached_len={r_cached_len}"
+                )
 
         ctx = get_global_ctx()
         page_table = ctx.page_table
         page_size = ctx.page_size
         num_blocks = _ceil_div(kv_seq_len, page_size)
+        batch_size = len(reqs)
 
-        # The global page_table stores raw slots (page_id * page_size + offset).
-        # We stride by ``page_size`` to pick the first slot of each page, then
-        # divide to recover the physical page id. Stride-then-divide matches
-        # the pattern already used by ``FlashAttentionBackend`` (fa.py:93) and
-        # ``TensorRTLLMBackend`` (trtllm.py:117). ``num_blocks * page_size`` is
-        # the stop bound (exclusive) — safe because the row is allocated to
-        # ``aligned_max_seq_len >= num_blocks * page_size``.
-        raw_slots = page_table[
-            req.table_idx,
-            : num_blocks * page_size : page_size,
+        # Stride-then-divide (see fa.py:93 / trtllm.py:117 / Gate 1.8c). Under
+        # BnNBsD the global page_table stores raw slots (page_id * page_size +
+        # offset); striding by ``page_size`` picks the first slot of each page
+        # and dividing recovers the physical page id.
+        #
+        # For B>=1 we build the block_table row-by-row via a stack — cheap for
+        # the batch sizes we care about (max_running_req is O(8)) and keeps
+        # the raw-slot → page-id conversion unambiguous under fragmentation.
+        row_views = [
+            page_table[r.table_idx, : num_blocks * page_size : page_size]
+            for r in reqs
         ]
-        block_table = (raw_slots // page_size).view(1, num_blocks)
+        block_table = (torch.stack(row_views, dim=0) // page_size).contiguous()
 
         # Structural invariants FIA relies on. Cheap enough to keep at runtime.
-        assert block_table.shape == (1, num_blocks), (
-            f"expected block_table shape (1, {num_blocks}), got {tuple(block_table.shape)}"
+        assert block_table.shape == (batch_size, num_blocks), (
+            f"expected block_table shape ({batch_size}, {num_blocks}), "
+            f"got {tuple(block_table.shape)}"
         )
         assert block_table.dtype == torch.int32, (
             f"expected block_table dtype int32, got {block_table.dtype}"
@@ -160,9 +195,10 @@ class AscendFIABackend(BaseAttnBackend):
 
         batch.attn_metadata = FIAMetadata(
             block_table=block_table,
-            actual_seq_lengths=[query_seq_len],
-            actual_seq_lengths_kv=[kv_seq_len],
+            actual_seq_lengths=[query_seq_len] * batch_size,
+            actual_seq_lengths_kv=[kv_seq_len] * batch_size,
             input_layout="BSND",
+            batch_size=batch_size,
             query_seq_len=query_seq_len,
             kv_seq_len=kv_seq_len,
         )
@@ -176,26 +212,27 @@ class AscendFIABackend(BaseAttnBackend):
         layer_id: int,
         batch: "Batch",
     ) -> "torch.Tensor":
-        """Run one paged-KV FIA attention step (single-request BSND).
+        """Run one paged-KV FIA attention step (equal-length BSND).
 
-        Execution order (mirrors the spec for Gate 1.8e):
+        Execution order:
 
         1. validate ``batch.attn_metadata`` is a :class:`FIAMetadata`;
-        2. re-check we're still on the single-request path (defense-in-depth
-           against a caller that mutated ``padded_reqs`` between
-           :meth:`prepare_metadata` and here);
-        3. write this layer's new K/V into the paged cache;
-        4. no-copy view the flat query ``[Tq, Hq, D]`` as BSND
-           ``[1, Tq, Hq, D]``;
-        5. fetch the FIA-native BnNBsD cache tensors — passed verbatim,
-           no permute / contiguous;
-        6. build the causal ``atten_mask`` (or ``None`` for the single-Q
-           case) padded to the block boundary FIA's tiling requires;
+        2. validate the flat query token count matches
+           ``batch_size * query_seq_len`` (guards a caller that mutated
+           ``padded_reqs`` between :meth:`prepare_metadata` and here);
+        3. store this layer's new K/V into the paged cache — the scatter is
+           keyed by ``batch.out_loc`` (per-request raw slots concatenated by
+           the scheduler), so page isolation is inherited from the caller;
+        4. reshape the flat query ``[B*S, Hq, D]`` to BSND ``[B, S, Hq, D]``;
+        5. fetch the FIA-native BnNBsD cache tensors — passed verbatim;
+        6. build a shared causal ``atten_mask`` ``[S, padded_kv_len]``
+           (or ``None`` for the single-Q decode path); mask visibility
+           includes the shared cached prefix;
         7. dynamic-import ``torch_npu`` and call
            :func:`torch_npu.npu_fused_infer_attention_score`;
         8. take the first tensor of the returned tuple (softmax_lse is
            unused in inference mode);
-        9. no-copy view back to the flat ``[Tq, Hq, D]`` shape.
+        9. view back to the flat ``[B*S, Hq, D]`` shape the caller expects.
         """
         # 1. metadata type check
         metadata = batch.attn_metadata
@@ -204,10 +241,21 @@ class AscendFIABackend(BaseAttnBackend):
                 "Ascend FIA forward expects batch.attn_metadata to be "
                 f"FIAMetadata, got {type(metadata).__name__}"
             )
-        # 2. still B=1
-        if len(metadata.actual_seq_lengths) != 1:
-            raise NotImplementedError(
-                "Ascend FIA forward currently supports batch size 1 only"
+
+        batch_size = metadata.batch_size
+        query_seq_len = metadata.query_seq_len
+        expected_tokens = batch_size * query_seq_len
+
+        # 2. flat token count must match the metadata layout — catches a caller
+        # that mutated ``padded_reqs`` (or ``batch.out_loc``) between
+        # ``prepare_metadata`` and here.
+        if q.shape[0] != expected_tokens:
+            raise ValueError(
+                "Ascend FIA forward: flat query token count "
+                f"{q.shape[0]} does not match batch_size * query_seq_len "
+                f"({batch_size} * {query_seq_len} = {expected_tokens}); "
+                "either the metadata or the flat query was mutated after "
+                "prepare_metadata()"
             )
 
         # Lazy imports keep the module import-safe on CUDA / CPU hosts.
@@ -216,33 +264,39 @@ class AscendFIABackend(BaseAttnBackend):
 
         ctx = get_global_ctx()
 
-        # 3. write this layer's new K/V into the paged cache. store_kv covers
-        # both nhd and bnbsd layouts internally; the FIA path is always bnbsd
-        # so store_kv writes directly with the raw-slot scatter from Gate 1.7f.
+        # 3. Persist this layer's new K/V into the paged cache. ``out_loc``
+        # already carries the per-request raw slots concatenated in flat order
+        # by the scheduler; store_kv scatters slot-by-slot, so page isolation
+        # between requests is preserved without any per-request looping here.
         ctx.kv_cache.store_kv(k, v, batch.out_loc, layer_id)
 
-        # 4. no-copy view [Tq, Hq, D] -> [1, Tq, Hq, D]. unsqueeze is a
-        # guaranteed non-copy view regardless of contiguity.
-        query_bsnd = q.unsqueeze(0)
+        # 4. Reshape flat [B*S, Hq, D] -> [B, S, Hq, D]. ``reshape`` handles
+        # both contiguous and non-contiguous q (falling back to a copy only if
+        # strictly necessary); the model's Attention.forward already produces
+        # a contiguous flat q, so this is a view in practice.
+        head_dim = q.shape[-1]
+        num_qo_heads = q.shape[-2]
+        query_bsnd = q.reshape(batch_size, query_seq_len, num_qo_heads, head_dim)
 
-        # 5. BnNBsD paged caches — passed verbatim, no permute/contiguous.
+        # 5. BnNBsD paged caches — passed verbatim, no permute / contiguous.
         key_cache = ctx.kv_cache.k_cache(layer_id)
         value_cache = ctx.kv_cache.v_cache(layer_id)
 
-        # 6. Causal mask. Decode / single-Q path uses ``None`` (FIA elides
-        # masking). Prefill builds an offset causal mask, then pads the KV
-        # axis to ``num_blocks * page_size`` because FIA's tiling requires
-        # ``atten_mask.shape[-1] >= num_blocks * block_size`` — the extra
-        # columns are all masked out (``True``) so they can never
-        # participate. This constraint was surfaced by the Gate 1.8d probe.
-        if metadata.query_seq_len == 1:
+        # 6. Causal mask.
+        #  * decode (query_seq_len == 1): FIA elides masking with atten_mask=None.
+        #  * prefill: shared [S, padded_kv_len] causal mask offset by the
+        #    common cached prefix. FIA requires the KV axis to be padded to
+        #    ``num_blocks * page_size`` (Gate 1.8d); padded columns are all
+        #    True (== masked out) so they cannot contribute to any row. The
+        #    same mask is broadcast across all B requests — legal because
+        #    every real request in the batch shares the same cached prefix
+        #    and the same extend length under the equal-length invariant.
+        if query_seq_len == 1:
             atten_mask = None
         else:
             padded_kv_len = metadata.block_table.shape[1] * ctx.page_size
-            cached_len = metadata.kv_seq_len - metadata.query_seq_len
-            q_pos = cached_len + torch.arange(
-                metadata.query_seq_len, device=q.device
-            )
+            cached_len = metadata.kv_seq_len - query_seq_len
+            q_pos = cached_len + torch.arange(query_seq_len, device=q.device)
             k_pos = torch.arange(padded_kv_len, device=q.device)
             atten_mask = k_pos.unsqueeze(0) > q_pos.unsqueeze(1)
 
@@ -260,7 +314,7 @@ class AscendFIABackend(BaseAttnBackend):
             ) from exc
 
         # 8. Call FIA. ``scale`` — not ``scale_value`` — matches the aclnn v3
-        # binding. ``num_heads`` is Hq from the flat query (q.shape[1]);
+        # binding. ``num_heads`` is Hq from the flat query (q.shape[-2]);
         # ``num_key_value_heads`` is Hkv from the paged cache
         # (key_cache.shape[1] under BnNBsD).
         result = torch_npu.npu_fused_infer_attention_score(
@@ -271,15 +325,17 @@ class AscendFIABackend(BaseAttnBackend):
             actual_seq_lengths=metadata.actual_seq_lengths,
             actual_seq_lengths_kv=metadata.actual_seq_lengths_kv,
             block_table=metadata.block_table,
-            num_heads=q.shape[1],
+            num_heads=num_qo_heads,
             num_key_value_heads=key_cache.shape[1],
-            scale=q.shape[-1] ** -0.5,
+            scale=head_dim ** -0.5,
             input_layout="BSND",
             block_size=ctx.page_size,
             sparse_mode=0,
         )
 
         # 9. FIA returns ``(attention_out, softmax_lse)``; softmax_lse is
-        # empty in inference. Reshape back to the caller's flat layout.
+        # empty in inference. Reshape back to the caller's flat layout —
+        # attention_out is [B, S, Hq, D] contiguous, so ``.view`` is a
+        # zero-copy view of the same storage.
         attention_out = result[0]
         return attention_out.view(q.shape)

--- a/python/minisgl/attention/ascend_fia.py
+++ b/python/minisgl/attention/ascend_fia.py
@@ -1,0 +1,66 @@
+"""Ascend Fused Infer Attention (FIA) backend — Gate 1.8a skeleton.
+
+This module provides the class scaffolding + attribute wiring for the
+BnNBsD paged-KV attention path on 910B1. All runtime behaviour is deferred
+to Gate 1.8b:
+
+* graph capture hooks are no-op (real capture wiring lands with FIA).
+* ``prepare_metadata`` is a no-op.
+* ``forward`` explicitly raises :class:`NotImplementedError`.
+
+The module deliberately avoids importing ``torch_npu`` (and any Ascend
+runtime bindings). It must stay import-safe on CUDA / CPU hosts so the
+attention registry keeps its lazy semantics.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List
+
+from .base import BaseAttnBackend
+
+if TYPE_CHECKING:
+    import torch
+    from minisgl.core import Batch
+    from minisgl.models import ModelConfig
+
+
+class AscendFIABackend(BaseAttnBackend):
+    """Skeleton for the Ascend FIA paged-KV attention backend.
+
+    The constructor signature mirrors what :func:`create_attention_backend`
+    already passes to :class:`FlashInferBackend` / :class:`FlashAttentionBackend`
+    / :class:`TensorRTLLMBackend`: a single ``ModelConfig`` positional. We only
+    stash the config for later gates; no NPU state is materialised yet.
+    """
+
+    def __init__(self, config: "ModelConfig") -> None:
+        self.config = config
+
+    # --------------------------------------------------------------- graph
+    def init_capture_graph(self, max_seq_len: int, bs_list: List[int]) -> None:
+        # Real NPU-graph capture wiring lands with the FIA call in Gate 1.8b.
+        return None
+
+    def prepare_for_capture(self, batch: "Batch") -> None:
+        return None
+
+    def prepare_for_replay(self, batch: "Batch") -> None:
+        return None
+
+    # ------------------------------------------------------------ metadata
+    def prepare_metadata(self, batch: "Batch") -> None:
+        # No FIA metadata layout is committed until Gate 1.8b lands.
+        return None
+
+    # ------------------------------------------------------------- forward
+    def forward(
+        self,
+        q: "torch.Tensor",
+        k: "torch.Tensor",
+        v: "torch.Tensor",
+        layer_id: int,
+        batch: "Batch",
+    ) -> "torch.Tensor":
+        raise NotImplementedError(
+            "Ascend FIA forward is not implemented until Gate 1.8b"
+        )

--- a/python/minisgl/attention/ascend_fia.py
+++ b/python/minisgl/attention/ascend_fia.py
@@ -1,27 +1,86 @@
-"""Ascend Fused Infer Attention (FIA) backend — Gate 1.8a skeleton.
+"""Ascend Fused Infer Attention (FIA) backend — Gate 1.8c metadata builder.
 
-This module provides the class scaffolding + attribute wiring for the
-BnNBsD paged-KV attention path on 910B1. All runtime behaviour is deferred
-to Gate 1.8b:
+Gate 1.8a landed the class scaffolding. Gate 1.8c fills in the metadata
+constructor for the single-request (B=1) BSND path only — multi-request
+TND, NPU-graph capture wiring, and the FIA call itself remain deferred.
 
-* graph capture hooks are no-op (real capture wiring lands with FIA).
-* ``prepare_metadata`` is a no-op.
-* ``forward`` explicitly raises :class:`NotImplementedError`.
-
-The module deliberately avoids importing ``torch_npu`` (and any Ascend
-runtime bindings). It must stay import-safe on CUDA / CPU hosts so the
-attention registry keeps its lazy semantics.
+The module stays torch-free at import time: ``torch`` and ``minisgl.core``
+are pulled in lazily inside the metadata methods so that importing
+``minisgl.attention.ascend_fia`` on a CUDA / CPU host is safe. The module
+must never reference ``torch_npu`` (top-level or lazy) — the FIA op wiring
+lands in a later Gate.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, List
 
-from .base import BaseAttnBackend
+from .base import BaseAttnBackend, BaseAttnMetadata
 
 if TYPE_CHECKING:
     import torch
     from minisgl.core import Batch
     from minisgl.models import ModelConfig
+
+
+def _ceil_div(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+@dataclass
+class FIAMetadata(BaseAttnMetadata):
+    """Metadata for the single-request BSND Ascend FIA path.
+
+    The multi-request TND path and the NPU-graph replay path will extend
+    this dataclass in later Gates; today we only surface the fields needed
+    for B=1 prefill / decode.
+
+    Fields:
+        block_table:            [1, num_blocks] int32 on the KV-cache device;
+                                each entry is a physical **page id** (not raw
+                                slot) — matches the layout FIA's
+                                ``block_table`` argument expects.
+        actual_seq_lengths:     per-request query length; a Python list
+                                (length == 1 today) so it can be passed
+                                straight to ``torch_npu.npu_fused_infer_...``
+                                without a device round-trip.
+        actual_seq_lengths_kv:  per-request total KV length (cached + extend).
+        input_layout:           ``"BSND"`` for the single-request path.
+        query_seq_len:          == ``actual_seq_lengths[0]``, kept for cheap
+                                indexing.
+        kv_seq_len:             == ``actual_seq_lengths_kv[0]``.
+    """
+
+    block_table: "torch.Tensor"
+    actual_seq_lengths: List[int]
+    actual_seq_lengths_kv: List[int]
+    input_layout: str
+    query_seq_len: int
+    kv_seq_len: int
+
+    def get_last_indices(self, bs: int) -> "torch.Tensor":
+        """Return the index of the last query token per request.
+
+        For the single-request path this is a 1-element tensor:
+
+        * prefill: ``query_seq_len - 1`` (last new token in the flat Q buffer)
+        * decode:  ``0`` (``query_seq_len == 1``)
+
+        Multi-request wiring lands with the TND path; ``bs != 1`` is rejected
+        explicitly rather than silently returning a mis-shaped tensor.
+        """
+        if bs != 1:
+            raise NotImplementedError(
+                "Ascend FIA get_last_indices currently supports batch size 1 only"
+            )
+        # Lazy import so the module stays torch-free at import time.
+        import torch
+
+        return torch.tensor(
+            [self.query_seq_len - 1],
+            dtype=torch.int32,
+            device=self.block_table.device,
+        )
 
 
 class AscendFIABackend(BaseAttnBackend):
@@ -38,7 +97,7 @@ class AscendFIABackend(BaseAttnBackend):
 
     # --------------------------------------------------------------- graph
     def init_capture_graph(self, max_seq_len: int, bs_list: List[int]) -> None:
-        # Real NPU-graph capture wiring lands with the FIA call in Gate 1.8b.
+        # Real NPU-graph capture wiring lands with the FIA call in a later Gate.
         return None
 
     def prepare_for_capture(self, batch: "Batch") -> None:
@@ -49,8 +108,64 @@ class AscendFIABackend(BaseAttnBackend):
 
     # ------------------------------------------------------------ metadata
     def prepare_metadata(self, batch: "Batch") -> None:
-        # No FIA metadata layout is committed until Gate 1.8b lands.
-        return None
+        """Build :class:`FIAMetadata` for the single-request BSND path.
+
+        Only ``len(batch.padded_reqs) == 1`` is supported today. The
+        multi-request TND and NPU-graph decode paths are separate Gates.
+        """
+        reqs = batch.padded_reqs
+        if len(reqs) != 1:
+            raise NotImplementedError(
+                "Ascend FIA metadata currently supports batch size 1 only"
+            )
+
+        # Lazy imports keep the module import-safe on CUDA / CPU hosts and
+        # avoid pulling ``minisgl.core`` (which imports torch) at registration
+        # time.
+        import torch
+        from minisgl.core import get_global_ctx
+
+        req = reqs[0]
+        query_seq_len = req.extend_len
+        kv_seq_len = req.device_len
+
+        ctx = get_global_ctx()
+        page_table = ctx.page_table
+        page_size = ctx.page_size
+        num_blocks = _ceil_div(kv_seq_len, page_size)
+
+        # The global page_table stores raw slots (page_id * page_size + offset).
+        # We stride by ``page_size`` to pick the first slot of each page, then
+        # divide to recover the physical page id. Stride-then-divide matches
+        # the pattern already used by ``FlashAttentionBackend`` (fa.py:93) and
+        # ``TensorRTLLMBackend`` (trtllm.py:117). ``num_blocks * page_size`` is
+        # the stop bound (exclusive) — safe because the row is allocated to
+        # ``aligned_max_seq_len >= num_blocks * page_size``.
+        raw_slots = page_table[
+            req.table_idx,
+            : num_blocks * page_size : page_size,
+        ]
+        block_table = (raw_slots // page_size).view(1, num_blocks)
+
+        # Structural invariants FIA relies on. Cheap enough to keep at runtime.
+        assert block_table.shape == (1, num_blocks), (
+            f"expected block_table shape (1, {num_blocks}), got {tuple(block_table.shape)}"
+        )
+        assert block_table.dtype == torch.int32, (
+            f"expected block_table dtype int32, got {block_table.dtype}"
+        )
+        assert block_table.device == page_table.device, (
+            f"expected block_table on {page_table.device}, got {block_table.device}"
+        )
+
+        batch.attn_metadata = FIAMetadata(
+            block_table=block_table,
+            actual_seq_lengths=[query_seq_len],
+            actual_seq_lengths_kv=[kv_seq_len],
+            input_layout="BSND",
+            query_seq_len=query_seq_len,
+            kv_seq_len=kv_seq_len,
+        )
 
     # ------------------------------------------------------------- forward
     def forward(
@@ -61,6 +176,8 @@ class AscendFIABackend(BaseAttnBackend):
         layer_id: int,
         batch: "Batch",
     ) -> "torch.Tensor":
+        # Preserved verbatim from Gate 1.8a — the FIA op call lands in a
+        # separate Gate on top of Gate 1.8c's metadata builder.
         raise NotImplementedError(
             "Ascend FIA forward is not implemented until Gate 1.8b"
         )

--- a/python/minisgl/attention/ascend_fia.py
+++ b/python/minisgl/attention/ascend_fia.py
@@ -1,18 +1,27 @@
 """Ascend Fused Infer Attention (FIA) backend.
 
 Gate 2.2c generalises the wrapper from single-request BSND to equal-length
-multi-request BSND. The underlying FIA operator was proven to accept
-``B >= 1`` batched prefill/decode by the Gate 2.2b contract probe; only the
-wrapper's ``len(reqs) != 1`` guard needed lifting.
+multi-request BSND. Gate 2.2f extends the wrapper to **ragged prefill**
+where every request has ``cached_len == 0`` but individual ``extend_len``
+values differ. The underlying FIA operator was proven to accept ragged
+BSND prefill (see Gate 2.2e-r1 contract probe) via right-padded query
+plus per-batch ``actual_seq_lengths``.
 
 Supported today:
-  * ``B >= 1`` where every real request in ``batch.padded_reqs`` shares the
-    same ``extend_len``, ``cached_len`` and ``device_len`` (equal-length
-    batch, prefill OR decode).
+  * ``B >= 1`` decode (all requests ``extend_len == 1``, arbitrary
+    ``cached_len`` shared across the batch).
+  * ``B >= 1`` prefill when every real request shares the same
+    ``extend_len``/``cached_len``/``device_len`` (equal-length path).
+  * ``B >= 1`` prefill when every real request has ``cached_len == 0``
+    while ``extend_len`` (== ``device_len``) may differ per request
+    (ragged path, Gate 2.2f).
 
 Explicitly refused (``NotImplementedError``):
-  * Ragged batches — any variance across ``extend_len``/``cached_len``/
-    ``device_len``. The TND path lands in a later Gate.
+  * Ragged batches where any request has ``cached_len != 0`` — the mixed
+    cached-prefix ragged case still lands in a later Gate.
+  * Decode batches where ``cached_len`` differs per request — the
+    per-batch KV lengths are already supported by the operator but the
+    scheduler currently never emits this shape.
 
 The module stays torch-free at import time: ``torch`` and ``minisgl.core``
 are pulled in lazily inside method bodies so importing
@@ -38,28 +47,58 @@ def _ceil_div(a: int, b: int) -> int:
 
 @dataclass
 class FIAMetadata(BaseAttnMetadata):
-    """Metadata for the equal-length multi-request BSND Ascend FIA path.
+    """Metadata for the BSND Ascend FIA path.
 
     Fields:
-        block_table:            ``[B, num_blocks]`` int32 on the KV-cache
+        block_table:            ``[B, max_blocks]`` int32 on the KV-cache
                                 device. Row ``b`` lists the physical page
                                 ids backing request ``b`` — stride-then-
-                                divide of the global ``page_table``.
-        actual_seq_lengths:     per-request query length; a Python list of
-                                length ``B`` with a shared value
-                                (equal-length batching). Passed straight to
+                                divide of the global ``page_table``. Under
+                                ragged prefill every row is padded to the
+                                same ``max_blocks`` width; unused columns
+                                are filled with ``0`` (an in-range but
+                                unused page id — safe because the causal
+                                mask hides every slot in a padded page for
+                                the padded query rows).
+        actual_seq_lengths:     per-request query length (a Python list of
+                                length ``B``). Under equal-length batching
+                                every entry is the same; under ragged
+                                prefill entries differ per request. Passed
+                                straight to
                                 ``torch_npu.npu_fused_infer_attention_score``
                                 without a device round-trip.
-        actual_seq_lengths_kv:  per-request total KV length (cached + extend);
-                                same layout, shared value.
+        actual_seq_lengths_kv:  per-request total KV length (cached +
+                                extend); same shape as
+                                ``actual_seq_lengths``.
         input_layout:           ``"BSND"``.
-        batch_size:             ``B`` — cached so :meth:`forward` can
-                                ``reshape`` the flat query without a
-                                ``len(...)`` call on the metadata list.
-        query_seq_len:          shared ``extend_len`` across the batch —
-                                equal to ``actual_seq_lengths[0]``.
-        kv_seq_len:             shared ``device_len`` across the batch —
-                                equal to ``actual_seq_lengths_kv[0]``.
+        batch_size:             ``B`` — cached so :meth:`forward` can build
+                                the packed BSND query without a ``len(...)``
+                                call on the metadata list.
+        query_seq_lens:         per-request query length as a plain Python
+                                ``list[int]``. Duplicates
+                                ``actual_seq_lengths`` but kept separate to
+                                keep the forward path free of aliasing —
+                                the operator kwarg may be mutated by a
+                                future guard without affecting the pack
+                                logic.
+        kv_seq_lens:            per-request total KV length as ``list[int]``.
+        max_query_len:          ``max(query_seq_lens)`` — the padded S
+                                dimension of the BSND query tensor handed
+                                to FIA.
+        query_offsets:          cumulative start offsets of each request
+                                in the flat query buffer;
+                                ``[0, q0, q0+q1, ..., sum_qi]`` of length
+                                ``B + 1``. Used by :meth:`forward` to scatter
+                                the flat query into the padded BSND tensor
+                                and gather the output back.
+        query_seq_len:          shared ``extend_len`` across the batch under
+                                the equal-length path. Under ragged prefill
+                                this is ``None`` — callers must consult
+                                ``query_seq_lens`` / ``max_query_len``
+                                instead.
+        kv_seq_len:             shared ``device_len`` across the batch under
+                                the equal-length path. ``None`` under
+                                ragged prefill.
     """
 
     block_table: "torch.Tensor"
@@ -67,35 +106,41 @@ class FIAMetadata(BaseAttnMetadata):
     actual_seq_lengths_kv: List[int]
     input_layout: str
     batch_size: int
-    query_seq_len: int
-    kv_seq_len: int
+    query_seq_lens: List[int]
+    kv_seq_lens: List[int]
+    max_query_len: int
+    query_offsets: List[int]
+    # Legacy equal-length shortcuts (None under ragged prefill).
+    query_seq_len: "int | None"
+    kv_seq_len: "int | None"
 
     def get_last_indices(self, bs: int) -> "torch.Tensor":
         """Return the index of the last query token per request in the flat
         query buffer.
 
-        Under equal-length batching the flat query is laid out as
-        ``[req0_tok0, ..., req0_tokS-1, req1_tok0, ...]`` so the last index
-        of request ``b`` is ``(b + 1) * query_seq_len - 1``. This matches the
-        semantics of ``cu_seqlens_q[1:1+bs] - 1`` used by the CUDA backends.
+        The flat query is laid out as
+        ``[req0_tok0, ..., req0_tokQ0-1, req1_tok0, ..., req1_tokQ1-1, ...]``
+        so the last index of request ``b`` is ``query_offsets[b+1] - 1``.
+        Under equal-length batching this reduces to
+        ``(b + 1) * query_seq_len - 1`` — matching the semantics of
+        ``cu_seqlens_q[1:1+bs] - 1`` used by the CUDA backends and
+        preserving the Gate 2.2c contract.
         """
         # Lazy import so the module stays torch-free at import time.
         import torch
 
-        return (
-            torch.arange(
-                1,
-                bs + 1,
-                dtype=torch.int32,
-                device=self.block_table.device,
-            )
-            * self.query_seq_len
-            - 1
+        # ``query_offsets`` has length B+1; last index of request b is
+        # offsets[b+1] - 1. Slice offsets[1:1+bs] gives one value per request.
+        ends = self.query_offsets[1 : 1 + bs]
+        return torch.tensor(
+            [e - 1 for e in ends],
+            dtype=torch.int32,
+            device=self.block_table.device,
         )
 
 
 class AscendFIABackend(BaseAttnBackend):
-    """Ascend FIA paged-KV attention backend (equal-length multi-request).
+    """Ascend FIA paged-KV attention backend (equal-length + ragged prefill).
 
     The constructor signature mirrors what :func:`create_attention_backend`
     already passes to :class:`FlashInferBackend` / :class:`FlashAttentionBackend`
@@ -118,12 +163,17 @@ class AscendFIABackend(BaseAttnBackend):
 
     # ------------------------------------------------------------ metadata
     def prepare_metadata(self, batch: "Batch") -> None:
-        """Build :class:`FIAMetadata` for the equal-length BSND path.
+        """Build :class:`FIAMetadata` for the BSND path.
 
-        Accepts ``B >= 1`` when every real request in ``batch.padded_reqs``
-        shares the same ``extend_len``, ``cached_len`` and ``device_len``.
-        Ragged batches raise :class:`NotImplementedError` — the TND path is a
-        future Gate.
+        Accepts:
+          * equal-length batches (``B >= 1``, shared
+            ``extend_len``/``cached_len``/``device_len``) — legacy path
+            from Gate 2.2c; and
+          * ragged prefill batches (``B >= 1``) where **every** request
+            has ``cached_len == 0`` while ``extend_len`` may vary. Ragged
+            decode batches (different ``cached_len``) still raise
+            :class:`NotImplementedError`, as do ragged prefill batches
+            with any non-zero ``cached_len``.
         """
         reqs = batch.padded_reqs
         if not reqs:
@@ -135,55 +185,91 @@ class AscendFIABackend(BaseAttnBackend):
         import torch
         from minisgl.core import get_global_ctx
 
-        # Equal-length invariant: every real request in the batch must share
-        # the same (extend_len, device_len, cached_len). We derive the shared
-        # value from reqs[0] and check the rest — anything ragged is refused
-        # with an explicit NotImplementedError instead of silently building a
-        # wrong batched metadata.
+        # Classify the batch:
+        #   * equal-length (all reqs share (extend_len, cached_len, device_len))
+        #     — the legacy path from Gate 2.2c.
+        #   * ragged prefill (all cached_len == 0, extend_len may vary)
+        #     — the Gate 2.2f path.
         head = reqs[0]
-        query_seq_len = head.extend_len
-        kv_seq_len = head.device_len
-        cached_len_head = kv_seq_len - query_seq_len
-        for idx, r in enumerate(reqs[1:], start=1):
-            r_cached_len = r.device_len - r.extend_len
+        head_query = head.extend_len
+        head_kv = head.device_len
+        head_cached = head_kv - head_query
+
+        all_equal = True
+        all_cached_zero = head_cached == 0
+        pure_decode = head_query == 1
+        for r in reqs[1:]:
+            r_cached = r.device_len - r.extend_len
             if (
-                r.extend_len != query_seq_len
-                or r.device_len != kv_seq_len
-                or r_cached_len != cached_len_head
+                r.extend_len != head_query
+                or r.device_len != head_kv
+                or r_cached != head_cached
             ):
-                raise NotImplementedError(
-                    "Ascend FIA metadata requires all requests in the batch to "
-                    "share the same extend_len, cached_len and device_len "
-                    "(ragged batches are not supported yet). "
-                    f"req[0]: extend_len={query_seq_len} device_len={kv_seq_len} "
-                    f"cached_len={cached_len_head}; "
-                    f"req[{idx}]: extend_len={r.extend_len} "
-                    f"device_len={r.device_len} cached_len={r_cached_len}"
-                )
+                all_equal = False
+            if r_cached != 0:
+                all_cached_zero = False
+            if r.extend_len != 1:
+                pure_decode = False
+
+        if not (all_equal or all_cached_zero or pure_decode):
+            # Ragged batch that is neither purely ragged prefill (all
+            # cached_len == 0) nor purely decode (all extend_len == 1) and
+            # has some non-zero cached_len on at least one request. This is
+            # the mixed-prefix-hit ragged case with extend_len > 1 —
+            # reserved for a later Gate. Report the earliest offender so
+            # the caller can trace the batch.
+            for idx, r in enumerate(reqs):
+                r_cached = r.device_len - r.extend_len
+                if r_cached != 0 and r.extend_len > 1:
+                    raise NotImplementedError(
+                        "Ascend FIA metadata: ragged batches with a non-zero "
+                        "cached_len and extend_len>1 are not supported yet "
+                        "(Gate 2.2f covers the cached_len==0 ragged prefill "
+                        "case and the pure-decode ragged case). Offender "
+                        f"req[{idx}]: extend_len={r.extend_len} "
+                        f"device_len={r.device_len} cached_len={r_cached}."
+                    )
+            # Fallback — shouldn't reach here given the classification above.
+            raise NotImplementedError(
+                "Ascend FIA metadata: unsupported ragged batch shape."
+            )
 
         ctx = get_global_ctx()
         page_table = ctx.page_table
         page_size = ctx.page_size
-        num_blocks = _ceil_div(kv_seq_len, page_size)
         batch_size = len(reqs)
+
+        # Per-request block-count and shared max across the batch. Under the
+        # equal-length path every req has the same ``kv_seq_len`` and hence
+        # the same block count; under ragged prefill each row's block count
+        # is ``ceil(extend_len / page_size)``.
+        blocks_per_req = [_ceil_div(r.device_len, page_size) for r in reqs]
+        max_blocks = max(blocks_per_req)
 
         # Stride-then-divide (see fa.py:93 / trtllm.py:117 / Gate 1.8c). Under
         # BnNBsD the global page_table stores raw slots (page_id * page_size +
         # offset); striding by ``page_size`` picks the first slot of each page
         # and dividing recovers the physical page id.
         #
-        # For B>=1 we build the block_table row-by-row via a stack — cheap for
-        # the batch sizes we care about (max_running_req is O(8)) and keeps
-        # the raw-slot → page-id conversion unambiguous under fragmentation.
-        row_views = [
-            page_table[r.table_idx, : num_blocks * page_size : page_size]
-            for r in reqs
-        ]
-        block_table = (torch.stack(row_views, dim=0) // page_size).contiguous()
+        # We build ``block_table`` row-by-row: each row is the request's own
+        # page-id sequence, right-padded with ``0`` to ``max_blocks`` under
+        # ragged prefill. Padding page ``0`` is safe because the causal mask
+        # hides every KV slot that is not in the real KV region for that
+        # request; the operator therefore never reads through the padded
+        # entries. (The scheduler always keeps real page id ``0`` allocated
+        # to some other request; picking any in-range value works.)
+        rows: List[torch.Tensor] = []
+        for r, nb in zip(reqs, blocks_per_req):
+            real_row = page_table[r.table_idx, : nb * page_size : page_size] // page_size
+            if nb < max_blocks:
+                pad = torch.zeros(max_blocks - nb, dtype=real_row.dtype, device=real_row.device)
+                rows.append(torch.cat([real_row, pad], dim=0))
+            else:
+                rows.append(real_row)
+        block_table = torch.stack(rows, dim=0).contiguous()
 
-        # Structural invariants FIA relies on. Cheap enough to keep at runtime.
-        assert block_table.shape == (batch_size, num_blocks), (
-            f"expected block_table shape ({batch_size}, {num_blocks}), "
+        assert block_table.shape == (batch_size, max_blocks), (
+            f"expected block_table shape ({batch_size}, {max_blocks}), "
             f"got {tuple(block_table.shape)}"
         )
         assert block_table.dtype == torch.int32, (
@@ -193,14 +279,29 @@ class AscendFIABackend(BaseAttnBackend):
             f"expected block_table on {page_table.device}, got {block_table.device}"
         )
 
+        query_seq_lens = [r.extend_len for r in reqs]
+        kv_seq_lens = [r.device_len for r in reqs]
+        max_query_len = max(query_seq_lens)
+
+        # Cumulative offsets: [0, q0, q0+q1, ..., sum_qi]. Length B+1.
+        query_offsets = [0]
+        acc = 0
+        for q in query_seq_lens:
+            acc += q
+            query_offsets.append(acc)
+
         batch.attn_metadata = FIAMetadata(
             block_table=block_table,
-            actual_seq_lengths=[query_seq_len] * batch_size,
-            actual_seq_lengths_kv=[kv_seq_len] * batch_size,
+            actual_seq_lengths=list(query_seq_lens),
+            actual_seq_lengths_kv=list(kv_seq_lens),
             input_layout="BSND",
             batch_size=batch_size,
-            query_seq_len=query_seq_len,
-            kv_seq_len=kv_seq_len,
+            query_seq_lens=list(query_seq_lens),
+            kv_seq_lens=list(kv_seq_lens),
+            max_query_len=max_query_len,
+            query_offsets=query_offsets,
+            query_seq_len=head_query if all_equal else None,
+            kv_seq_len=head_kv if all_equal else None,
         )
 
     # ------------------------------------------------------------- forward
@@ -212,27 +313,34 @@ class AscendFIABackend(BaseAttnBackend):
         layer_id: int,
         batch: "Batch",
     ) -> "torch.Tensor":
-        """Run one paged-KV FIA attention step (equal-length BSND).
+        """Run one paged-KV FIA attention step (equal-length or ragged BSND).
 
         Execution order:
 
         1. validate ``batch.attn_metadata`` is a :class:`FIAMetadata`;
         2. validate the flat query token count matches
-           ``batch_size * query_seq_len`` (guards a caller that mutated
+           ``sum(query_seq_lens)`` (guards a caller that mutated
            ``padded_reqs`` between :meth:`prepare_metadata` and here);
         3. store this layer's new K/V into the paged cache — the scatter is
            keyed by ``batch.out_loc`` (per-request raw slots concatenated by
-           the scheduler), so page isolation is inherited from the caller;
-        4. reshape the flat query ``[B*S, Hq, D]`` to BSND ``[B, S, Hq, D]``;
+           the scheduler in the same order as ``query_offsets``), so page
+           isolation is inherited from the caller;
+        4. pack the flat query ``[sum_q, Hq, D]`` into padded BSND
+           ``[B, max_query_len, Hq, D]`` — real rows first, tail rows zero;
         5. fetch the FIA-native BnNBsD cache tensors — passed verbatim;
-        6. build a shared causal ``atten_mask`` ``[S, padded_kv_len]``
-           (or ``None`` for the single-Q decode path); mask visibility
-           includes the shared cached prefix;
+        6. build the atten_mask:
+           * decode (max_query_len == 1): ``None``;
+           * equal-length prefill: shared ``[max_query_len, padded_kv_len]``
+             causal mask offset by the common cached prefix;
+           * ragged prefill: per-batch ``[B, 1, max_query_len, padded_kv_len]``
+             causal mask; padded query rows are fully masked;
         7. dynamic-import ``torch_npu`` and call
            :func:`torch_npu.npu_fused_infer_attention_score`;
         8. take the first tensor of the returned tuple (softmax_lse is
            unused in inference mode);
-        9. view back to the flat ``[B*S, Hq, D]`` shape the caller expects.
+        9. unpad the ``[B, max_query_len, Hq, D]`` output back to the flat
+           ``[sum_q, Hq, D]`` shape the caller expects, then reshape to the
+           original ``q`` layout (``[sum_q, Hq*D]``).
         """
         # 1. metadata type check
         metadata = batch.attn_metadata
@@ -243,8 +351,10 @@ class AscendFIABackend(BaseAttnBackend):
             )
 
         batch_size = metadata.batch_size
-        query_seq_len = metadata.query_seq_len
-        expected_tokens = batch_size * query_seq_len
+        query_seq_lens = metadata.query_seq_lens
+        max_query_len = metadata.max_query_len
+        query_offsets = metadata.query_offsets
+        expected_tokens = query_offsets[-1]
 
         # 2. flat token count must match the metadata layout — catches a caller
         # that mutated ``padded_reqs`` (or ``batch.out_loc``) between
@@ -252,8 +362,8 @@ class AscendFIABackend(BaseAttnBackend):
         if q.shape[0] != expected_tokens:
             raise ValueError(
                 "Ascend FIA forward: flat query token count "
-                f"{q.shape[0]} does not match batch_size * query_seq_len "
-                f"({batch_size} * {query_seq_len} = {expected_tokens}); "
+                f"{q.shape[0]} does not match sum(query_seq_lens) "
+                f"({query_seq_lens} -> {expected_tokens}); "
                 "either the metadata or the flat query was mutated after "
                 "prepare_metadata()"
             )
@@ -270,35 +380,57 @@ class AscendFIABackend(BaseAttnBackend):
         # between requests is preserved without any per-request looping here.
         ctx.kv_cache.store_kv(k, v, batch.out_loc, layer_id)
 
-        # 4. Reshape flat [B*S, Hq, D] -> [B, S, Hq, D]. ``reshape`` handles
-        # both contiguous and non-contiguous q (falling back to a copy only if
-        # strictly necessary); the model's Attention.forward already produces
-        # a contiguous flat q, so this is a view in practice.
+        # 4. Pack flat [sum_q, Hq, D] -> padded BSND [B, max_query_len, Hq, D].
         head_dim = q.shape[-1]
         num_qo_heads = q.shape[-2]
-        query_bsnd = q.reshape(batch_size, query_seq_len, num_qo_heads, head_dim)
+        if all(q_len == max_query_len for q_len in query_seq_lens):
+            # Uniform S — a single reshape is a view over the flat q buffer.
+            query_bsnd = q.reshape(batch_size, max_query_len, num_qo_heads, head_dim)
+        else:
+            # Ragged: allocate a zero-init padded tensor and copy each
+            # request's rows into place. Tail rows stay zero — the mask
+            # ensures they never contribute to any output row (and the
+            # operator returns zero for fully-masked rows, per Gate 2.2e-r1).
+            query_bsnd = q.new_zeros((batch_size, max_query_len, num_qo_heads, head_dim))
+            for b, (start, end) in enumerate(zip(query_offsets[:-1], query_offsets[1:])):
+                length = end - start
+                query_bsnd[b, :length] = q[start:end]
 
         # 5. BnNBsD paged caches — passed verbatim, no permute / contiguous.
         key_cache = ctx.kv_cache.k_cache(layer_id)
         value_cache = ctx.kv_cache.v_cache(layer_id)
 
         # 6. Causal mask.
-        #  * decode (query_seq_len == 1): FIA elides masking with atten_mask=None.
-        #  * prefill: shared [S, padded_kv_len] causal mask offset by the
-        #    common cached prefix. FIA requires the KV axis to be padded to
-        #    ``num_blocks * page_size`` (Gate 1.8d); padded columns are all
-        #    True (== masked out) so they cannot contribute to any row. The
-        #    same mask is broadcast across all B requests — legal because
-        #    every real request in the batch shares the same cached prefix
-        #    and the same extend length under the equal-length invariant.
-        if query_seq_len == 1:
+        #  * decode (max_query_len == 1): FIA elides masking with atten_mask=None.
+        #  * equal-length prefill: shared [S, padded_kv_len] causal mask offset
+        #    by the common cached prefix. Same mask broadcast across B.
+        #  * ragged prefill: per-batch [B, 1, S, padded_kv_len] causal mask.
+        #    Padded query rows (index >= this request's query_seq_len) are
+        #    fully masked (all True) so they cannot contribute to real rows.
+        padded_kv_len = metadata.block_table.shape[1] * ctx.page_size
+        if max_query_len == 1:
             atten_mask = None
-        else:
-            padded_kv_len = metadata.block_table.shape[1] * ctx.page_size
-            cached_len = metadata.kv_seq_len - query_seq_len
-            q_pos = cached_len + torch.arange(query_seq_len, device=q.device)
+        elif metadata.query_seq_len is not None:
+            # Equal-length prefill: shared 2D causal mask (Gate 2.2c).
+            cached_len = metadata.kv_seq_len - metadata.query_seq_len
+            q_pos = cached_len + torch.arange(metadata.query_seq_len, device=q.device)
             k_pos = torch.arange(padded_kv_len, device=q.device)
             atten_mask = k_pos.unsqueeze(0) > q_pos.unsqueeze(1)
+        else:
+            # Ragged prefill (Gate 2.2f): per-batch causal mask.
+            atten_mask = torch.ones(
+                (batch_size, 1, max_query_len, padded_kv_len),
+                dtype=torch.bool,
+                device=q.device,
+            )
+            k_pos_row = torch.arange(padded_kv_len, device=q.device)
+            for b, (q_len, kv_len) in enumerate(zip(query_seq_lens, metadata.kv_seq_lens)):
+                cached_len_b = kv_len - q_len
+                q_pos_b = cached_len_b + torch.arange(q_len, device=q.device)
+                # Standard causal for real query rows: mask when k > q.
+                atten_mask[b, 0, :q_len, :] = k_pos_row.unsqueeze(0) > q_pos_b.unsqueeze(1)
+                # Padded query rows (index q_len..max_query_len-1) stay fully
+                # masked (all True) — already the initial value.
 
         # 7. Dynamic import of torch_npu. Gate 1.8a forbids this at module
         # top level; only here inside forward() is it allowed. Surface a
@@ -334,8 +466,15 @@ class AscendFIABackend(BaseAttnBackend):
         )
 
         # 9. FIA returns ``(attention_out, softmax_lse)``; softmax_lse is
-        # empty in inference. Reshape back to the caller's flat layout —
-        # attention_out is [B, S, Hq, D] contiguous, so ``.view`` is a
-        # zero-copy view of the same storage.
+        # empty in inference. Under the equal-length path attention_out is
+        # already [B, S, Hq, D] and ``.view(q.shape)`` is a zero-copy view.
+        # Under the ragged path we gather each request's real rows back into
+        # the flat layout before reshape.
         attention_out = result[0]
-        return attention_out.view(q.shape)
+        if all(q_len == max_query_len for q_len in query_seq_lens):
+            return attention_out.view(q.shape)
+        flat = q.new_empty((expected_tokens, num_qo_heads, head_dim))
+        for b, (start, end) in enumerate(zip(query_offsets[:-1], query_offsets[1:])):
+            length = end - start
+            flat[start:end] = attention_out[b, :length]
+        return flat.view(q.shape)

--- a/python/minisgl/core.py
+++ b/python/minisgl/core.py
@@ -19,6 +19,12 @@ class SamplingParams:
     top_p: float = 1.0
     ignore_eos: bool = False
     max_tokens: int = 1024
+    # Explicit per-request stop tokens. Immutable tuple by design — a mutable
+    # list default would be shared across instances. Membership is checked in
+    # Scheduler._process_last_data *independent* of ignore_eos: ignore_eos
+    # only silences the tokenizer's EOS, it does not disable user-declared
+    # stop tokens. Empty tuple keeps the pre-Gate-2.1c behavior verbatim.
+    stop_token_ids: tuple[int, ...] = ()
 
     @property
     def is_greedy(self) -> bool:

--- a/python/minisgl/distributed/__init__.py
+++ b/python/minisgl/distributed/__init__.py
@@ -1,5 +1,27 @@
-from .impl import DistributedCommunicator, destroy_distributed, enable_pynccl_distributed
-from .info import DistributedInfo, get_tp_info, set_tp_info, try_get_tp_info
+"""Distributed subpackage for minisgl.
+
+The historical eager re-exports (``from .impl import ...``, ``from .info
+import ...``) forced ``torch`` and the PyNCCL wrapper to load just to reach
+device-agnostic helpers such as :mod:`minisgl.distributed.backend` and
+:mod:`minisgl.distributed.runtime`. They now resolve lazily through PEP 562
+``__getattr__`` so:
+
+    import minisgl.distributed.backend    # never touches .impl / torch
+    import minisgl.distributed.runtime    # never touches .impl / torch
+
+remain safe on Ascend hosts (or a bare macOS dev box) that lack the CUDA
+runtime, PyNCCL, or ``torch_npu``. Legacy consumers using
+``from minisgl.distributed import DistributedInfo`` etc. continue to work
+untouched — the owning submodule executes on first access instead of at
+import time.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only imports
+    from .impl import DistributedCommunicator, destroy_distributed, enable_pynccl_distributed
+    from .info import DistributedInfo, get_tp_info, set_tp_info, try_get_tp_info
 
 __all__ = [
     "DistributedInfo",
@@ -10,3 +32,31 @@ __all__ = [
     "try_get_tp_info",
     "destroy_distributed",
 ]
+
+_LAZY_ATTR_TO_SUBMODULE: dict[str, str] = {
+    "DistributedCommunicator": ".impl",
+    "destroy_distributed": ".impl",
+    "enable_pynccl_distributed": ".impl",
+    "DistributedInfo": ".info",
+    "get_tp_info": ".info",
+    "set_tp_info": ".info",
+    "try_get_tp_info": ".info",
+}
+
+
+def __getattr__(name: str) -> Any:
+    submod_name = _LAZY_ATTR_TO_SUBMODULE.get(name)
+    if submod_name is None:
+        raise AttributeError(
+            f"module 'minisgl.distributed' has no attribute {name!r}"
+        )
+    import importlib
+
+    submod = importlib.import_module(submod_name, __name__)
+    value = getattr(submod, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted({*globals().keys(), *__all__})

--- a/python/minisgl/distributed/backend.py
+++ b/python/minisgl/distributed/backend.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from ..utils.device import DeviceType, get_device_type
+
+DistributedBackend = Literal["nccl", "hccl", "gloo"]
+
+__all__ = ["DistributedBackend", "get_distributed_backend"]
+
+
+# Single source of truth for the device → backend string mapping. Kept as a
+# plain dict so it is trivially inspectable by callers/tests, but the module's
+# only public contract is ``get_distributed_backend``.
+_DEVICE_TO_BACKEND: dict[str, DistributedBackend] = {
+    "cuda": "nccl",
+    "npu": "hccl",
+    "cpu": "gloo",
+}
+
+
+def get_distributed_backend(device_type: DeviceType | None = None) -> DistributedBackend:
+    """Return the ``torch.distributed`` backend string for the given device.
+
+    Mapping::
+
+        cuda -> nccl
+        npu  -> hccl
+        cpu  -> gloo
+
+    When ``device_type`` is ``None`` the function defers to
+    :func:`minisgl.utils.device.get_device_type` (which itself is cached and
+    side-effect free). When an explicit value is supplied the device layer is
+    **not** re-probed — the caller's choice is honored verbatim.
+
+    This helper is a pure lookup: it does not import ``torch_npu``, does not
+    call ``torch.distributed.init_process_group``, does not touch any device
+    or environment variable, and does not read rank/world-size state.
+
+    Raises:
+        ValueError: if ``device_type`` is not one of ``"cuda"``, ``"npu"``,
+            ``"cpu"``.
+    """
+    resolved = device_type if device_type is not None else get_device_type()
+    try:
+        return _DEVICE_TO_BACKEND[resolved]
+    except KeyError:
+        supported = ", ".join(sorted(_DEVICE_TO_BACKEND))
+        raise ValueError(
+            f"unsupported device_type {resolved!r}; expected one of: {supported}"
+        ) from None

--- a/python/minisgl/distributed/runtime.py
+++ b/python/minisgl/distributed/runtime.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from ..utils.device import DeviceType, get_device_type
+from .backend import DistributedBackend, get_distributed_backend
+
+__all__ = ["DistributedRuntime", "initialize_distributed_from_env"]
+
+
+@dataclass(frozen=True)
+class DistributedRuntime:
+    """Resolved single-process view of the distributed job.
+
+    Frozen so callers can safely stash it on module- or engine-level state
+    without worrying about mutation. Populated exclusively by
+    :func:`initialize_distributed_from_env` — no other constructors are
+    supported.
+    """
+
+    device_type: DeviceType
+    backend: DistributedBackend
+    local_rank: int
+    rank: int
+    world_size: int
+    device: str
+
+
+_REQUIRED_ENV = ("LOCAL_RANK", "RANK", "WORLD_SIZE")
+
+
+def _read_int_env(name: str) -> int:
+    """Parse a required int environment variable; raise ``RuntimeError`` otherwise."""
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        raise RuntimeError(
+            f"required environment variable {name!r} is not set; "
+            f"expected all of {list(_REQUIRED_ENV)} to be set by the launcher"
+        )
+    try:
+        return int(raw)
+    except ValueError:
+        raise RuntimeError(
+            f"environment variable {name!r} must be an integer, got {raw!r}"
+        ) from None
+
+
+def _bind_device(device_type: DeviceType, local_rank: int) -> str:
+    """Bind the current process to its local device and return the device string.
+
+    * ``cuda``: ``torch.cuda.set_device(local_rank)`` → ``"cuda:{local_rank}"``
+    * ``npu``: dynamic ``import torch_npu`` (which patches ``torch.npu`` onto
+      ``torch``), then ``torch.npu.set_device(local_rank)`` → ``"npu:{local_rank}"``
+    * ``cpu``: no-op → ``"cpu"``
+
+    ``torch_npu`` is *never* imported at module scope; only this branch, only
+    when the resolved device is ``npu``.
+    """
+    if device_type == "cuda":
+        import torch  # lazy: only touched on CUDA hosts
+
+        torch.cuda.set_device(local_rank)
+        return f"cuda:{local_rank}"
+
+    if device_type == "npu":
+        # Safe dynamic import — kept out of module scope so macOS / CPU-only
+        # hosts stay importable.
+        try:
+            import torch_npu  # noqa: F401  (import-for-side-effect: patches torch.npu)
+        except Exception as exc:
+            raise RuntimeError(
+                "device_type is 'npu' but 'torch_npu' could not be imported; "
+                "install the matching torch_npu wheel on the Ascend host"
+            ) from exc
+
+        import torch
+
+        torch.npu.set_device(local_rank)
+        return f"npu:{local_rank}"
+
+    if device_type == "cpu":
+        return "cpu"
+
+    raise ValueError(f"unsupported device_type for binding: {device_type!r}")
+
+
+def initialize_distributed_from_env() -> DistributedRuntime:
+    """Read env vars, bind the local device, and initialise ``torch.distributed``.
+
+    Steps, in order:
+
+    1. Parse ``LOCAL_RANK`` / ``RANK`` / ``WORLD_SIZE`` from the environment
+       and validate their ranges. Env-var errors surface as ``RuntimeError``
+       (missing/non-integer) or ``ValueError`` (out of range).
+    2. Resolve ``device_type`` via :func:`get_device_type` and ``backend``
+       via :func:`get_distributed_backend`.
+    3. Guard against double init: raise ``RuntimeError`` if
+       ``torch.distributed.is_initialized()`` is already true. The device is
+       not touched in that case.
+    4. Bind the local device (``torch.cuda.set_device`` / ``torch.npu.set_device``
+       / no-op).
+    5. Call ``torch.distributed.init_process_group(backend=backend)`` with
+       no ``init_method``, no ``rank``/``world_size`` overrides — the launcher
+       (torchrun, MPI, etc.) is expected to supply them via env vars.
+    6. Return a frozen :class:`DistributedRuntime`.
+
+    This function does not run any collective, does not call ``barrier``,
+    does not register any destroy hook, and does not touch PyNCCL or the
+    engine layer. It is idempotent-guarded but not idempotent itself — call
+    it exactly once per process.
+    """
+    local_rank = _read_int_env("LOCAL_RANK")
+    rank = _read_int_env("RANK")
+    world_size = _read_int_env("WORLD_SIZE")
+
+    if world_size < 1:
+        raise ValueError(f"WORLD_SIZE must be >= 1, got {world_size}")
+    if rank < 0 or rank >= world_size:
+        raise ValueError(
+            f"RANK must satisfy 0 <= RANK < WORLD_SIZE (WORLD_SIZE={world_size}), "
+            f"got RANK={rank}"
+        )
+    if local_rank < 0:
+        raise ValueError(f"LOCAL_RANK must be >= 0, got {local_rank}")
+
+    device_type: DeviceType = get_device_type()
+    backend: DistributedBackend = get_distributed_backend(device_type)
+
+    import torch.distributed as dist  # lazy: import only at initialisation time
+
+    if dist.is_initialized():
+        raise RuntimeError(
+            "torch.distributed is already initialised; "
+            "initialize_distributed_from_env() must run at most once per process"
+        )
+
+    device = _bind_device(device_type, local_rank)
+    dist.init_process_group(backend=backend)
+
+    return DistributedRuntime(
+        device_type=device_type,
+        backend=backend,
+        local_rank=local_rank,
+        rank=rank,
+        world_size=world_size,
+        device=device,
+    )

--- a/python/minisgl/distributed/runtime.py
+++ b/python/minisgl/distributed/runtime.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from ..utils.device import DeviceType, get_device_type
 from .backend import DistributedBackend, get_distributed_backend
 
-__all__ = ["DistributedRuntime", "initialize_distributed_from_env"]
+__all__ = ["DistributedRuntime", "bind_local_device", "initialize_distributed_from_env"]
 
 
 @dataclass(frozen=True)
@@ -46,8 +46,13 @@ def _read_int_env(name: str) -> int:
         ) from None
 
 
-def _bind_device(device_type: DeviceType, local_rank: int) -> str:
+def bind_local_device(device_type: DeviceType, local_rank: int) -> str:
     """Bind the current process to its local device and return the device string.
+
+    This is the shared, side-effect-scoped device-binding primitive used by
+    both :func:`initialize_distributed_from_env` and the engine bootstrap.
+    It does **not** touch ``torch.distributed`` — callers remain in charge of
+    process-group init.
 
     * ``cuda``: ``torch.cuda.set_device(local_rank)`` → ``"cuda:{local_rank}"``
     * ``npu``: dynamic ``import torch_npu`` (which patches ``torch.npu`` onto
@@ -55,7 +60,14 @@ def _bind_device(device_type: DeviceType, local_rank: int) -> str:
     * ``cpu``: no-op → ``"cpu"``
 
     ``torch_npu`` is *never* imported at module scope; only this branch, only
-    when the resolved device is ``npu``.
+    when the resolved device is ``npu``. Callers on a macOS / CPU-only host
+    may import this module freely.
+
+    Raises:
+        RuntimeError: if ``device_type == "npu"`` but ``torch_npu`` cannot be
+            imported.
+        ValueError: if ``device_type`` is not one of ``"cuda"``, ``"npu"``,
+            ``"cpu"``.
     """
     if device_type == "cuda":
         import torch  # lazy: only touched on CUDA hosts
@@ -135,7 +147,7 @@ def initialize_distributed_from_env() -> DistributedRuntime:
             "initialize_distributed_from_env() must run at most once per process"
         )
 
-    device = _bind_device(device_type, local_rank)
+    device = bind_local_device(device_type, local_rank)
     dist.init_process_group(backend=backend)
 
     return DistributedRuntime(

--- a/python/minisgl/engine/engine.py
+++ b/python/minisgl/engine/engine.py
@@ -87,12 +87,14 @@ class Engine:
         # ======================= KV cache initialization ========================
         self.num_pages = self._determine_num_pages(init_free_memory, config)
         num_tokens = self.num_pages * config.page_size
+        kv_cache_layout = "bnbsd" if self.device_type == "npu" else "nhd"
         self.ctx.kv_cache = self.kv_cache = create_kvcache_pool(
             model_config=config.model_config,
             num_pages=self.num_pages + 1,  # +1 for dummy page
             page_size=config.page_size,
             device=self.device,
             dtype=self.dtype,
+            layout=kv_cache_layout,
         )
 
         # ======================= Page table initialization ========================

--- a/python/minisgl/engine/engine.py
+++ b/python/minisgl/engine/engine.py
@@ -145,7 +145,21 @@ class Engine:
             dummy_req=self.dummy_req,
         )
 
-    def _init_communication(self, config: EngineConfig) -> torch.distributed.ProcessGroup:
+    def _init_communication(
+        self, config: EngineConfig
+    ) -> torch.distributed.ProcessGroup | None:
+        # NPU + TP=1: standalone single-rank deployment. Skip torch.distributed
+        # bootstrap entirely — no HCCL group, no gloo sidecar, no pynccl helper.
+        # The CUDA-flavoured pynccl bootstrap unconditionally reaches for
+        # ``minisgl.kernel`` (a CUDA-only compile artefact), and the accelerator
+        # collectives themselves would be no-ops at world_size=1 anyway. The
+        # CUDA path stays untouched: CUDA TP=1 still initialises gloo + calls
+        # ``enable_pynccl_distributed`` (which itself is a no-op at size=1) so
+        # test_engine_device's guardrails and the existing GPU control flow
+        # remain unchanged.
+        if self.device_type == "npu" and config.tp_info.size == 1:
+            return None
+
         if config.tp_info.size == 1 or config.use_pynccl:
             torch.distributed.init_process_group(
                 backend="gloo",
@@ -213,6 +227,11 @@ class Engine:
         empty_device_cache(self.device_type)
         reset_peak_memory_stats(self.device_type)
         free_memory = get_free_memory(self.device_type, self.device)
+        # NPU + TP=1 no-dist fast path: there is no gloo sidecar group, so
+        # skip the all_reduce entirely. min == max == the local free_memory
+        # value — the imbalance check below is a no-op in that case.
+        if self.tp_cpu_group is None:
+            return free_memory, free_memory
         free_mem_tensor = torch.tensor([free_memory, -free_memory], device="cpu", dtype=torch.int64)
         torch.distributed.all_reduce(
             free_mem_tensor, op=torch.distributed.ReduceOp.MIN, group=self.tp_cpu_group
@@ -249,7 +268,11 @@ class Engine:
         # TODO(gate-1.2+): CUDA-graph capture/destroy still routes through
         # torch.cuda; NPU graph capture will land in a later Gate.
         self.graph_runner.destroy_cuda_graphs()
-        torch.distributed.destroy_process_group()
+        # NPU + TP=1 skipped the whole torch.distributed bootstrap, so there
+        # is nothing to destroy here. Mirror the same guard used in
+        # _sync_get_memory / _init_communication.
+        if self.tp_cpu_group is not None:
+            torch.distributed.destroy_process_group()
         destroy_distributed()
 
 

--- a/python/minisgl/engine/engine.py
+++ b/python/minisgl/engine/engine.py
@@ -19,8 +19,11 @@ from minisgl.utils.device_runtime import (
     create_event,
     create_stream,
     current_stream,
+    empty_device_cache,
     record_event,
+    reset_peak_memory_stats,
     set_stream,
+    synchronize_device,
 )
 
 from .config import EngineConfig
@@ -203,11 +206,9 @@ class Engine:
 
     def _sync_get_memory(self) -> Tuple[int, int]:
         """Get the min and max free memory across TP ranks."""
-        # TODO(gate-1.2+): synchronize / empty_cache / reset_peak_memory_stats
-        # are still CUDA-only. Route through an ACL RT abstraction once it lands.
-        torch.cuda.synchronize(self.device)
-        torch.cuda.empty_cache()
-        torch.cuda.reset_peak_memory_stats(self.device)
+        synchronize_device(self.device_type)
+        empty_device_cache(self.device_type)
+        reset_peak_memory_stats(self.device_type)
         free_memory = get_free_memory(self.device)
         free_mem_tensor = torch.tensor([free_memory, -free_memory], device="cpu", dtype=torch.int64)
         torch.distributed.all_reduce(

--- a/python/minisgl/engine/engine.py
+++ b/python/minisgl/engine/engine.py
@@ -255,10 +255,32 @@ class Engine:
             else:
                 logits = self.model.forward()
 
+        # Gate 2.3c: request-state atomicity across sampler failures. The commit
+        # to req.cached_len / req.device_len must only happen once we know the
+        # sampler produced a usable tensor for THIS batch — otherwise a raise
+        # inside sample() would leave requests advanced by one step with no
+        # matching token in token_pool, and subsequent scheduling rounds would
+        # write into the wrong page_table slot.
+        next_tokens_gpu = self.sampler.sample(logits[: batch.size], args).to(torch.int32)
+        # Basic shape validation *before* the commit: downstream code assumes a
+        # 1-D tensor of length batch.size (token_pool[output_mapping] indexes it
+        # positionally, and _process_last_data iterates next_tokens_cpu[i] for
+        # i in range(batch.size)). Anything else means either the sampler
+        # returned garbage or somebody swapped in an incompatible implementation
+        # — either way, we must raise BEFORE complete_one() to preserve request
+        # state exactly as it was on entry.
+        if next_tokens_gpu.dim() != 1 or next_tokens_gpu.shape[0] != batch.size:
+            raise RuntimeError(
+                f"Sampler returned tensor of shape {tuple(next_tokens_gpu.shape)},"
+                f" expected ({batch.size},); refusing to commit request state."
+            )
+
+        # All-or-nothing commit. complete_one() is pure Python attribute
+        # arithmetic on the Req dataclass and cannot itself raise, so this loop
+        # either advances every real request in batch.reqs or none of them.
         for req in batch.reqs:
             req.complete_one()
 
-        next_tokens_gpu = self.sampler.sample(logits[: batch.size], args).to(torch.int32)
         next_tokens_cpu = next_tokens_gpu.to("cpu", non_blocking=True)
         copy_done_event = create_event(self.device_type)
         record_event(self.device_type, copy_done_event, self.stream)

--- a/python/minisgl/engine/engine.py
+++ b/python/minisgl/engine/engine.py
@@ -7,11 +7,14 @@ import torch
 from minisgl.attention import create_attention_backend
 from minisgl.core import Batch, Context, Req, set_global_ctx
 from minisgl.distributed import destroy_distributed, enable_pynccl_distributed, set_tp_info
+from minisgl.distributed.backend import get_distributed_backend
+from minisgl.distributed.runtime import bind_local_device
 from minisgl.kvcache import create_kvcache_pool
 from minisgl.layers import set_rope_device
 from minisgl.models import create_model, load_weight
 from minisgl.moe import create_moe_backend
 from minisgl.utils import div_even, init_logger, is_sm90_supported, is_sm100_supported, torch_dtype
+from minisgl.utils.device import DeviceType, get_device_type
 
 from .config import EngineConfig
 from .graph import GraphRunner, get_free_memory, mem_GB
@@ -23,18 +26,33 @@ logger = init_logger(__name__)
 class ForwardOutput(NamedTuple):
     next_tokens_gpu: torch.Tensor
     next_tokens_cpu: torch.Tensor
+    # TODO(gate-1.2+): abstract Event/stream across cuda + npu once the ACL RT
+    # abstraction lands; today this annotation is CUDA-only.
     copy_done_event: torch.cuda.Event
 
 
 class Engine:
     def __init__(self, config: EngineConfig):
-        assert not torch.cuda.is_initialized()
+        self.device_type: DeviceType = get_device_type()
+        # CUDA has a global "initialised" flag we can assert against for a
+        # clean-slate check. NPU / CPU expose no such API, so the guard is
+        # scoped to the CUDA path rather than silently passing on other hosts.
+        if self.device_type == "cuda":
+            assert not torch.cuda.is_initialized()
         set_tp_info(rank=config.tp_info.rank, size=config.tp_info.size)
         _adjust_config(config)
 
-        self.device = torch.device(f"cuda:{config.tp_info.rank}")
-        torch.cuda.set_device(self.device)
+        # Delegate device selection + binding to the shared runtime helper so
+        # that Engine and initialize_distributed_from_env() cannot drift on
+        # cuda/npu/cpu handling. bind_local_device sets torch.{cuda,npu}.set_device
+        # (or no-ops on CPU) and returns the canonical device string, which we
+        # wrap into a torch.device for the rest of Engine to consume.
+        self.device = torch.device(
+            bind_local_device(self.device_type, config.tp_info.rank)
+        )
         torch.manual_seed(42)
+        # TODO(gate-1.2+): Stream / set_stream are still CUDA-only. Ported in
+        # a later Gate once the ACL RT stream abstraction is available.
         self.stream = torch.cuda.Stream()
         torch.cuda.set_stream(self.stream)
         self.dtype = config.dtype
@@ -125,8 +143,12 @@ class Engine:
             )
             enable_pynccl_distributed(config.tp_info, tp_cpu_group, max_bytes)
         else:
+            # Device-agnostic accelerator collective backend:
+            #   cuda → "nccl", npu → "hccl", cpu → "gloo"
+            # `gloo` remains the CPU-side sidecar group regardless of accelerator.
+            accel_backend = get_distributed_backend(self.device_type)
             torch.distributed.init_process_group(
-                backend="nccl",
+                backend=accel_backend,
                 rank=config.tp_info.rank,
                 world_size=config.tp_info.size,
                 timeout=timedelta(seconds=config.distributed_timeout),
@@ -169,6 +191,8 @@ class Engine:
 
     def _sync_get_memory(self) -> Tuple[int, int]:
         """Get the min and max free memory across TP ranks."""
+        # TODO(gate-1.2+): synchronize / empty_cache / reset_peak_memory_stats
+        # are still CUDA-only. Route through an ACL RT abstraction once it lands.
         torch.cuda.synchronize(self.device)
         torch.cuda.empty_cache()
         torch.cuda.reset_peak_memory_stats(self.device)
@@ -189,6 +213,8 @@ class Engine:
         return min_free_memory, max_free_memory
 
     def forward_batch(self, batch: Batch, args: BatchSamplingArgs) -> ForwardOutput:
+        # TODO(gate-1.2+): current_stream() is CUDA-only; port when stream
+        # abstraction is available for NPU.
         assert torch.cuda.current_stream() == self.stream
         with self.ctx.forward_batch(batch):
             if self.graph_runner.can_use_cuda_graph(batch):
@@ -201,11 +227,14 @@ class Engine:
 
         next_tokens_gpu = self.sampler.sample(logits[: batch.size], args).to(torch.int32)
         next_tokens_cpu = next_tokens_gpu.to("cpu", non_blocking=True)
+        # TODO(gate-1.2+): Event is CUDA-only; port alongside the stream abstraction.
         copy_done_event = torch.cuda.Event()
         copy_done_event.record(self.stream)
         return ForwardOutput(next_tokens_gpu, next_tokens_cpu, copy_done_event)
 
     def shutdown(self) -> None:
+        # TODO(gate-1.2+): CUDA-graph capture/destroy still routes through
+        # torch.cuda; NPU graph capture will land in a later Gate.
         self.graph_runner.destroy_cuda_graphs()
         torch.distributed.destroy_process_group()
         destroy_distributed()

--- a/python/minisgl/engine/engine.py
+++ b/python/minisgl/engine/engine.py
@@ -51,7 +51,7 @@ class Engine:
         if self.device_type == "cuda":
             assert not torch.cuda.is_initialized()
         set_tp_info(rank=config.tp_info.rank, size=config.tp_info.size)
-        _adjust_config(config)
+        _adjust_config(config, self.device_type)
 
         # Delegate device selection + binding to the shared runtime helper so
         # that Engine and initialize_distributed_from_env() cannot drift on
@@ -257,12 +257,17 @@ def _align_up_32(num: int) -> int:
     return (num + 31) // 32 * 32
 
 
-def _adjust_config(config: EngineConfig):
+def _adjust_config(config: EngineConfig, device_type: DeviceType):
     def override(attr: str, value: Any):  # this is dangerous, use with caution
         object.__setattr__(config, attr, value)
 
     if config.attention_backend == "auto":
-        backend = "trtllm" if is_sm100_supported() else ("fa,fi" if is_sm90_supported() else "fi")
+        if device_type == "npu":
+            # Ascend NPU uses the FIA-based backend by default; CUDA/CPU
+            # continue to fall through the SM100/SM90/other selection.
+            backend = "npu_fia"
+        else:
+            backend = "trtllm" if is_sm100_supported() else ("fa,fi" if is_sm90_supported() else "fi")
         override("attention_backend", backend)
         logger.info_rank0(f"Auto-selected attention backend: {config.attention_backend}")
 

--- a/python/minisgl/engine/engine.py
+++ b/python/minisgl/engine/engine.py
@@ -15,7 +15,13 @@ from minisgl.models import create_model, load_weight
 from minisgl.moe import create_moe_backend
 from minisgl.utils import div_even, init_logger, is_sm90_supported, is_sm100_supported, torch_dtype
 from minisgl.utils.device import DeviceType, get_device_type
-from minisgl.utils.device_runtime import create_stream, set_stream
+from minisgl.utils.device_runtime import (
+    create_event,
+    create_stream,
+    current_stream,
+    record_event,
+    set_stream,
+)
 
 from .config import EngineConfig
 from .graph import GraphRunner, get_free_memory, mem_GB
@@ -27,9 +33,10 @@ logger = init_logger(__name__)
 class ForwardOutput(NamedTuple):
     next_tokens_gpu: torch.Tensor
     next_tokens_cpu: torch.Tensor
-    # TODO(gate-1.2+): abstract Event/stream across cuda + npu once the ACL RT
-    # abstraction lands; today this annotation is CUDA-only.
-    copy_done_event: torch.cuda.Event
+    # Device-agnostic event handle: torch.cuda.Event on CUDA, torch.npu.Event on
+    # NPU, or None on CPU. The scheduler only calls ``.synchronize()`` on it, so
+    # the concrete backend type is deliberately not exposed here.
+    copy_done_event: Any | None
 
 
 class Engine:
@@ -55,8 +62,9 @@ class Engine:
         # Stream creation + binding routed through the shared device_runtime
         # dispatch layer: cuda -> torch.cuda.Stream + set_stream, npu -> the
         # torch.npu equivalents (dynamic Ascend runtime import), cpu -> None +
-        # no-op. Gate 1.2b handles __init__ only; forward_batch's current_stream
-        # and Event usage is deferred to a later Gate.
+        # no-op. Gate 1.3c completes the migration for forward_batch's
+        # current_stream / Event calls too; graph capture + memory helpers are
+        # still deferred.
         self.stream = create_stream(self.device_type)
         set_stream(self.device_type, self.stream)
         self.dtype = config.dtype
@@ -217,9 +225,7 @@ class Engine:
         return min_free_memory, max_free_memory
 
     def forward_batch(self, batch: Batch, args: BatchSamplingArgs) -> ForwardOutput:
-        # TODO(gate-1.2+): current_stream() is CUDA-only; port when stream
-        # abstraction is available for NPU.
-        assert torch.cuda.current_stream() == self.stream
+        assert current_stream(self.device_type) == self.stream
         with self.ctx.forward_batch(batch):
             if self.graph_runner.can_use_cuda_graph(batch):
                 logits = self.graph_runner.replay(batch)
@@ -231,9 +237,8 @@ class Engine:
 
         next_tokens_gpu = self.sampler.sample(logits[: batch.size], args).to(torch.int32)
         next_tokens_cpu = next_tokens_gpu.to("cpu", non_blocking=True)
-        # TODO(gate-1.2+): Event is CUDA-only; port alongside the stream abstraction.
-        copy_done_event = torch.cuda.Event()
-        copy_done_event.record(self.stream)
+        copy_done_event = create_event(self.device_type)
+        record_event(self.device_type, copy_done_event, self.stream)
         return ForwardOutput(next_tokens_gpu, next_tokens_cpu, copy_done_event)
 
     def shutdown(self) -> None:

--- a/python/minisgl/engine/engine.py
+++ b/python/minisgl/engine/engine.py
@@ -15,6 +15,7 @@ from minisgl.models import create_model, load_weight
 from minisgl.moe import create_moe_backend
 from minisgl.utils import div_even, init_logger, is_sm90_supported, is_sm100_supported, torch_dtype
 from minisgl.utils.device import DeviceType, get_device_type
+from minisgl.utils.device_runtime import create_stream, set_stream
 
 from .config import EngineConfig
 from .graph import GraphRunner, get_free_memory, mem_GB
@@ -51,10 +52,13 @@ class Engine:
             bind_local_device(self.device_type, config.tp_info.rank)
         )
         torch.manual_seed(42)
-        # TODO(gate-1.2+): Stream / set_stream are still CUDA-only. Ported in
-        # a later Gate once the ACL RT stream abstraction is available.
-        self.stream = torch.cuda.Stream()
-        torch.cuda.set_stream(self.stream)
+        # Stream creation + binding routed through the shared device_runtime
+        # dispatch layer: cuda -> torch.cuda.Stream + set_stream, npu -> the
+        # torch.npu equivalents (dynamic Ascend runtime import), cpu -> None +
+        # no-op. Gate 1.2b handles __init__ only; forward_batch's current_stream
+        # and Event usage is deferred to a later Gate.
+        self.stream = create_stream(self.device_type)
+        set_stream(self.device_type, self.stream)
         self.dtype = config.dtype
         self.ctx = Context(config.page_size)
         set_global_ctx(self.ctx)

--- a/python/minisgl/engine/engine.py
+++ b/python/minisgl/engine/engine.py
@@ -132,6 +132,7 @@ class Engine:
         self.graph_runner = GraphRunner(
             stream=self.stream,
             device=self.device,
+            device_type=self.device_type,
             model=self.model,
             attn_backend=self.attn_backend,
             cuda_graph_bs=config.cuda_graph_bs,
@@ -209,7 +210,7 @@ class Engine:
         synchronize_device(self.device_type)
         empty_device_cache(self.device_type)
         reset_peak_memory_stats(self.device_type)
-        free_memory = get_free_memory(self.device)
+        free_memory = get_free_memory(self.device_type, self.device)
         free_mem_tensor = torch.tensor([free_memory, -free_memory], device="cpu", dtype=torch.int64)
         torch.distributed.all_reduce(
             free_mem_tensor, op=torch.distributed.ReduceOp.MIN, group=self.tp_cpu_group

--- a/python/minisgl/engine/graph.py
+++ b/python/minisgl/engine/graph.py
@@ -9,7 +9,12 @@ from minisgl.core import Batch, Req, get_global_ctx
 from minisgl.distributed import get_tp_info
 from minisgl.utils import init_logger
 from minisgl.utils.device import DeviceType
-from minisgl.utils.device_runtime import get_free_memory_bytes
+from minisgl.utils.device_runtime import (
+    empty_device_cache,
+    get_free_memory_bytes,
+    reset_peak_memory_stats,
+    synchronize_device,
+)
 from tqdm import tqdm
 
 if TYPE_CHECKING:
@@ -116,9 +121,9 @@ class GraphRunner:
 
         self.attn_backend.init_capture_graph(max_seq_len=max_seq_len, bs_list=self.graph_bs_list)
 
-        torch.cuda.synchronize(self.device)
-        torch.cuda.empty_cache()
-        torch.cuda.reset_peak_memory_stats(self.device)
+        synchronize_device(self.device_type)
+        empty_device_cache(self.device_type)
+        reset_peak_memory_stats(self.device_type)
 
         logger.info_rank0(f"Start capturing CUDA graphs with sizes: {self.graph_bs_list}")
         free_memory = get_free_memory(self.device_type, self.device)

--- a/python/minisgl/engine/graph.py
+++ b/python/minisgl/engine/graph.py
@@ -8,6 +8,8 @@ import torch
 from minisgl.core import Batch, Req, get_global_ctx
 from minisgl.distributed import get_tp_info
 from minisgl.utils import init_logger
+from minisgl.utils.device import DeviceType
+from minisgl.utils.device_runtime import get_free_memory_bytes
 from tqdm import tqdm
 
 if TYPE_CHECKING:
@@ -71,8 +73,11 @@ def mem_GB(size: int) -> str:
     return f"{size / (1024**3):.2f} GiB"
 
 
-def get_free_memory(device: torch.device) -> int:
-    return torch.cuda.mem_get_info(device)[0]
+def get_free_memory(
+    device_type: DeviceType,
+    device,
+) -> int:
+    return get_free_memory_bytes(device_type, device)
 
 
 class GraphRunner:
@@ -80,6 +85,7 @@ class GraphRunner:
         self,
         stream: torch.cuda.Stream,
         device: torch.device,
+        device_type: DeviceType,
         model: BaseLLMModel,
         attn_backend: BaseAttnBackend,
         cuda_graph_bs: List[int] | None,
@@ -100,6 +106,7 @@ class GraphRunner:
         self.dummy_req = dummy_req
         self.stream = stream
         self.device = device
+        self.device_type = device_type
         self._capture_graphs(max_seq_len, vocab_size, model)
 
     def _capture_graphs(self, max_seq_len: int, vocab_size: int, model: BaseLLMModel):
@@ -114,7 +121,7 @@ class GraphRunner:
         torch.cuda.reset_peak_memory_stats(self.device)
 
         logger.info_rank0(f"Start capturing CUDA graphs with sizes: {self.graph_bs_list}")
-        free_memory = get_free_memory(self.device)
+        free_memory = get_free_memory(self.device_type, self.device)
         logger.info_rank0(f"Free GPU memory before capturing CUDA graphs: {mem_GB(free_memory)}")
 
         self.buffer = GraphCaptureBuffer.init(self.max_graph_bs, vocab_size, self.device)
@@ -127,7 +134,7 @@ class GraphRunner:
         )
         pool = None
         for bs in pbar:
-            free_memory = get_free_memory(self.device)
+            free_memory = get_free_memory(self.device_type, self.device)
             pbar.desc = f"Capturing graphs: bs = {bs:<3} | avail_mem = {mem_GB(free_memory)}"
             pbar.refresh()
             graph = torch.cuda.CUDAGraph()
@@ -143,7 +150,7 @@ class GraphRunner:
                 pool = graph.pool()  # reuse cuda graph handle to reduce memory
             self.graph_map[bs] = graph
 
-        free_memory = get_free_memory(self.device)
+        free_memory = get_free_memory(self.device_type, self.device)
         logger.info_rank0(f"Free GPU memory after capturing CUDA graphs: {mem_GB(free_memory)}")
 
     def can_use_cuda_graph(self, batch: Batch) -> bool:

--- a/python/minisgl/engine/sample.py
+++ b/python/minisgl/engine/sample.py
@@ -69,7 +69,9 @@ class Sampler:
 
     @nvtx_annotate("Sampler")
     def sample(self, logits: torch.Tensor, args: BatchSamplingArgs) -> torch.Tensor:
-        with torch.cuda.nvtx.range("Sampler"):
-            if args.temperatures is None:  # greedy sampling
-                return torch.argmax(logits, dim=-1)
-            return sample_impl(logits.float(), args.temperatures, args.top_k, args.top_p)
+        # NOTE: the outer @nvtx_annotate("Sampler") already brackets this method
+        # via the cross-device-safe nvtx shim (torch.cuda.nvtx.range would raise
+        # on Torch builds without CUDA/NVTX, e.g. the Ascend container).
+        if args.temperatures is None:  # greedy sampling
+            return torch.argmax(logits, dim=-1)
+        return sample_impl(logits.float(), args.temperatures, args.top_k, args.top_p)

--- a/python/minisgl/kvcache/__init__.py
+++ b/python/minisgl/kvcache/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Literal, Protocol
 
 from minisgl.utils import Registry
 
@@ -30,6 +30,7 @@ def create_kvcache_pool(
     page_size: int,
     dtype: torch.dtype,
     device: torch.device,
+    layout: Literal["nhd", "bnbsd"] = "nhd",
 ) -> BaseKVCachePool:
     from .mha_pool import MHAKVCache  # TODO: support other variants (e.g. MLA)
 
@@ -41,6 +42,7 @@ def create_kvcache_pool(
         head_dim=model_config.head_dim,
         device=device,
         dtype=dtype,
+        layout=layout,
     )
 
 

--- a/python/minisgl/kvcache/mha_pool.py
+++ b/python/minisgl/kvcache/mha_pool.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal
+
 import torch
 from minisgl.distributed import get_tp_info
 from minisgl.utils import div_even
@@ -22,14 +24,30 @@ class MHAKVCache(BaseKVCachePool):
         page_size: int,
         dtype: torch.dtype,
         device: torch.device,
+        layout: Literal["nhd", "bnbsd"] = "nhd",
     ) -> None:
+        if layout not in ("nhd", "bnbsd"):
+            raise ValueError(
+                f"MHAKVCache layout must be 'nhd' or 'bnbsd', got {layout!r}"
+            )
         tp_info = get_tp_info()
         local_kv_heads = div_even(num_kv_heads, tp_info.size, allow_replicate=True)
-        self._kv_buffer = torch.empty(
-            (2, num_layers, num_pages, page_size, local_kv_heads, head_dim),
-            device=device,
-            dtype=dtype,
-        )
+        if layout == "nhd":
+            self._kv_buffer = torch.empty(
+                (2, num_layers, num_pages, page_size, local_kv_heads, head_dim),
+                device=device,
+                dtype=dtype,
+            )
+        else:  # bnbsd — FIA paged-KV native layout on Ascend
+            self._kv_buffer = torch.empty(
+                (2, num_layers, num_pages, local_kv_heads, page_size, head_dim),
+                device=device,
+                dtype=dtype,
+            )
+        self._layout = layout
+        self._page_size = page_size
+        self._local_kv_heads = local_kv_heads
+        self._head_dim = head_dim
         self._num_layers = num_layers
         self._k_buffer = self._kv_buffer[0]
         self._v_buffer = self._kv_buffer[1]
@@ -45,15 +63,23 @@ class MHAKVCache(BaseKVCachePool):
     def store_kv(
         self, k: torch.Tensor, v: torch.Tensor, out_loc: torch.Tensor, layer_id: int
     ) -> None:
-        from minisgl.kernel import store_cache
+        if self._layout == "nhd":
+            from minisgl.kernel import store_cache
 
-        store_cache(
-            k_cache=self._k_buffer[layer_id].view(self._storage_shape),
-            v_cache=self._v_buffer[layer_id].view(self._storage_shape),
-            indices=out_loc,
-            k=k,
-            v=v,
-        )
+            store_cache(
+                k_cache=self._k_buffer[layer_id].view(self._storage_shape),
+                v_cache=self._v_buffer[layer_id].view(self._storage_shape),
+                indices=out_loc,
+                k=k,
+                v=v,
+            )
+        else:  # bnbsd — pure PyTorch scatter, no CUDA kernel dependency
+            page_ids = out_loc // self._page_size
+            offsets = out_loc % self._page_size
+            k_values = k.view(-1, self._local_kv_heads, self._head_dim)
+            v_values = v.view(-1, self._local_kv_heads, self._head_dim)
+            self._k_buffer[layer_id][page_ids, :, offsets, :] = k_values
+            self._v_buffer[layer_id][page_ids, :, offsets, :] = v_values
 
     @property
     def device(self) -> torch.device:

--- a/python/minisgl/layers/activation.py
+++ b/python/minisgl/layers/activation.py
@@ -1,15 +1,65 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    import torch
+import torch
+import torch.nn.functional as F
 
 
 def silu_and_mul(x: torch.Tensor, out: torch.Tensor | None = None):
-    from flashinfer import silu_and_mul
+    if x.shape[-1] % 2 != 0:
+        raise ValueError("silu_and_mul requires an even last dimension")
 
-    return silu_and_mul(x, out=out)
+    expected_shape = (*x.shape[:-1], x.shape[-1] // 2)
+    if out is not None:
+        if tuple(out.shape) != tuple(expected_shape):
+            raise ValueError(
+                f"silu_and_mul: out.shape {tuple(out.shape)} does not match "
+                f"expected {tuple(expected_shape)}"
+            )
+        if out.dtype != x.dtype:
+            raise ValueError(
+                f"silu_and_mul: out.dtype {out.dtype} does not match x.dtype {x.dtype}"
+            )
+        if out.device != x.device:
+            raise ValueError(
+                f"silu_and_mul: out.device {out.device} does not match x.device {x.device}"
+            )
+
+    device_type = x.device.type
+
+    if device_type == "cuda":
+        try:
+            from flashinfer import silu_and_mul as flashinfer_silu_and_mul
+        except ImportError as exc:
+            raise RuntimeError(
+                "CUDA silu_and_mul requires flashinfer to be importable"
+            ) from exc
+
+        return flashinfer_silu_and_mul(x, out=out)
+
+    if device_type == "npu":
+        try:
+            import torch_npu
+        except ImportError as exc:
+            raise RuntimeError(
+                "NPU silu_and_mul requires torch_npu to be importable"
+            ) from exc
+
+        result = torch_npu.npu_swiglu(x, dim=-1)
+
+        if out is not None:
+            out.copy_(result)
+            return out
+
+        return result
+
+    gate, up = x.float().chunk(2, dim=-1)
+    result = (F.silu(gate) * up).to(x.dtype)
+
+    if out is not None:
+        out.copy_(result)
+        return out
+
+    return result
 
 
 def gelu_and_mul(x: torch.Tensor, out: torch.Tensor | None = None):

--- a/python/minisgl/layers/attention.py
+++ b/python/minisgl/layers/attention.py
@@ -47,11 +47,13 @@ class AttentionLayer(StateLessOP):
     def forward(self, qkv: torch.Tensor) -> torch.Tensor:
         ctx = get_global_ctx()
         q, k, v = qkv.split([self.qo_attn_dim, self.kv_attn_dim, self.kv_attn_dim], dim=-1)
-        if self.q_norm is not None:
-            self.q_norm.forward_inplace(q.view(-1, self.num_qo_heads, self.head_dim))
-        if self.k_norm is not None:
-            self.k_norm.forward_inplace(k.view(-1, self.num_kv_heads, self.head_dim))
-        q, k = self.rotary.forward(ctx.batch.positions, q, k)
         q = q.view(-1, self.num_qo_heads, self.head_dim)
+        k = k.view(-1, self.num_kv_heads, self.head_dim)
+        v = v.view(-1, self.num_kv_heads, self.head_dim)
+        if self.q_norm is not None:
+            self.q_norm.forward_inplace(q)
+        if self.k_norm is not None:
+            self.k_norm.forward_inplace(k)
+        q, k = self.rotary.forward(ctx.batch.positions, q, k)
         o = ctx.attn_backend.forward(q, k, v, self.layer_id, ctx.batch)
         return o.view(-1, self.qo_attn_dim)

--- a/python/minisgl/layers/embedding.py
+++ b/python/minisgl/layers/embedding.py
@@ -31,15 +31,32 @@ class VocabParallelEmbedding(BaseOP):
 
     @nvtx_annotate("Embedding")
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        from minisgl.kernel import indexing
+        tp_size = self.tp_size
 
-        y = indexing(
-            weights=self.weight,
-            indices=x,
-            vocab_range=self.vocab_range if self.tp_size > 1 else None,
-        )
+        if x.device.type == "cuda":
+            from minisgl.kernel import indexing
 
-        return self._comm.all_reduce(y) if self.tp_size > 1 else y
+            y = indexing(
+                weights=self.weight,
+                indices=x,
+                vocab_range=self.vocab_range if tp_size > 1 else None,
+            )
+            if tp_size > 1:
+                self._comm.all_reduce(y)
+            return y
+
+        # NPU / CPU — pure PyTorch gather. No index dtype coercion.
+        if tp_size == 1:
+            return F.embedding(x, self.weight)
+
+        start, length = self.vocab_range
+        local_ids = x - start
+        out_of_range = (local_ids < 0) | (local_ids >= length)
+        safe_ids = local_ids.masked_fill(out_of_range, 0)
+        y = F.embedding(safe_ids, self.weight)
+        y = y.masked_fill(out_of_range.unsqueeze(-1), 0)
+        self._comm.all_reduce(y)
+        return y
 
 
 class ParallelLMHead(VocabParallelEmbedding):

--- a/python/minisgl/layers/norm.py
+++ b/python/minisgl/layers/norm.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 import torch
@@ -5,34 +7,126 @@ import torch
 from .base import BaseOP
 
 
+# --------------------------------------------------------------- helpers
+def _rmsnorm_cpu(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    # fp32 reduction — fp16 pow/mean loses precision on hidden sizes >= 1024.
+    x_fp32 = x.float()
+    variance = x_fp32.pow(2).mean(dim=-1, keepdim=True)
+    y = x_fp32 * torch.rsqrt(variance + eps)
+    return (y * weight.float()).to(x.dtype)
+
+
+def _load_flashinfer_rmsnorm():
+    try:
+        from flashinfer import rmsnorm
+    except ImportError as exc:
+        raise RuntimeError(
+            "CUDA RMSNorm requires flashinfer to be importable; install "
+            "flashinfer on the host to use RMSNorm/RMSNormFused on CUDA tensors."
+        ) from exc
+    return rmsnorm
+
+
+def _load_flashinfer_fused_add_rmsnorm():
+    try:
+        from flashinfer import fused_add_rmsnorm
+    except ImportError as exc:
+        raise RuntimeError(
+            "CUDA fused-add RMSNorm requires flashinfer to be importable; "
+            "install flashinfer on the host to use RMSNormFused on CUDA tensors."
+        ) from exc
+    return fused_add_rmsnorm
+
+
+def _load_torch_npu():
+    try:
+        import torch_npu
+    except ImportError as exc:
+        raise RuntimeError(
+            "NPU RMSNorm requires torch_npu to be importable; install "
+            "torch_npu on the host to use RMSNorm/RMSNormFused on NPU tensors."
+        ) from exc
+    return torch_npu
+
+
+# --------------------------------------------------------------- RMSNorm
 class RMSNorm(BaseOP):
     def __init__(self, size: int, eps: float) -> None:
-        from flashinfer import rmsnorm
-
+        # No device library imports at construction time — dispatch happens on
+        # the first forward, keyed off ``x.device.type``.
         self.eps = eps
         self.weight = torch.empty(size)
-        self.rmsnorm = rmsnorm
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.rmsnorm(x, self.weight, self.eps)
+        device_type = x.device.type
+        if device_type == "cuda":
+            rmsnorm = _load_flashinfer_rmsnorm()
+            return rmsnorm(x, self.weight, self.eps)
+        if device_type == "npu":
+            torch_npu = _load_torch_npu()
+            # npu_rms_norm returns (y, rstd); rstd is a backward intermediate
+            # unused in inference.
+            return torch_npu.npu_rms_norm(x, self.weight, self.eps)[0]
+        return _rmsnorm_cpu(x, self.weight, self.eps)
 
     def forward_inplace(self, x: torch.Tensor) -> None:
-        self.rmsnorm(x, self.weight, self.eps, out=x)
+        device_type = x.device.type
+        if device_type == "cuda":
+            rmsnorm = _load_flashinfer_rmsnorm()
+            rmsnorm(x, self.weight, self.eps, out=x)
+            return None
+        if device_type == "npu":
+            torch_npu = _load_torch_npu()
+            # NPU op has no ``out=`` — allocate then copy back into the caller's
+            # buffer so the downstream rotary / attention reads see the update.
+            y = torch_npu.npu_rms_norm(x, self.weight, self.eps)[0]
+            x.copy_(y)
+            return None
+        y = _rmsnorm_cpu(x, self.weight, self.eps)
+        x.copy_(y)
+        return None
 
 
+# ---------------------------------------------------------- RMSNormFused
 class RMSNormFused(BaseOP):
     def __init__(self, size: int, eps: float) -> None:
-        from flashinfer import fused_add_rmsnorm, rmsnorm
-
         self.eps = eps
         self.weight = torch.empty(size)
-        self.rmsnorm = rmsnorm
-        self.fused_add_rmsnorm = fused_add_rmsnorm
 
     def forward(
         self, x: torch.Tensor, residual: torch.Tensor | None = None
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        device_type = x.device.type
+
         if residual is None:
-            return self.rmsnorm(x, self.weight, self.eps), x
-        self.fused_add_rmsnorm(x, residual, self.weight, self.eps)
-        return x, residual
+            # Every device returns (normalized, x) — the second slot passes the
+            # original ``x`` object through as the next block's residual.
+            if device_type == "cuda":
+                rmsnorm = _load_flashinfer_rmsnorm()
+                return rmsnorm(x, self.weight, self.eps), x
+            if device_type == "npu":
+                torch_npu = _load_torch_npu()
+                return torch_npu.npu_rms_norm(x, self.weight, self.eps)[0], x
+            return _rmsnorm_cpu(x, self.weight, self.eps), x
+
+        if device_type == "cuda":
+            # FlashInfer semantics: fused_add_rmsnorm writes normalized(x+r)
+            # back into x and (x+r) back into residual. Return the same
+            # tensor objects — callers rely on this identity.
+            fused_add_rmsnorm = _load_flashinfer_fused_add_rmsnorm()
+            fused_add_rmsnorm(x, residual, self.weight, self.eps)
+            return x, residual
+
+        if device_type == "npu":
+            # npu_add_rms_norm returns (normalized, rstd, summed) as **fresh**
+            # allocations; inputs are not mutated. The rstd slot is a backward
+            # intermediate unused in inference.
+            torch_npu = _load_torch_npu()
+            normalized, _, summed = torch_npu.npu_add_rms_norm(
+                x, residual, self.weight, self.eps
+            )
+            return normalized, summed
+
+        summed = x + residual
+        normalized = _rmsnorm_cpu(summed, self.weight, self.eps)
+        return normalized, summed

--- a/python/minisgl/layers/rotary.py
+++ b/python/minisgl/layers/rotary.py
@@ -226,11 +226,108 @@ _ROPE_DEVICE: torch.device | None = None
 
 
 def set_rope_device(device: torch.device):
+    """Register the default target device for RoPE cache construction.
+
+    Only rebinds a module-global; the cache is not flushed. Callers that
+    need a clean cache after switching devices should invoke
+    :func:`get_rope.cache_clear` explicitly. Two engines that live in the
+    same process on different devices coexist safely because ``device`` is
+    part of the cache key (see :func:`_get_rope_cached`).
+    """
     global _ROPE_DEVICE
     _ROPE_DEVICE = device
 
 
+def _normalize_device(device: torch.device) -> torch.device:
+    """Canonicalise a device for use as a cache key.
+
+    * ``cpu`` and ``meta`` collapse to type-only — they have no meaningful
+      index and ``torch.device('cpu')`` / ``torch.device('cpu', 0)`` would
+      otherwise key different cache entries.
+    * Accelerator devices (cuda, npu, xpu, mps, …) **must** carry an
+      explicit index. Silently mapping ``torch.device('npu')`` to
+      ``torch.device('npu', 0)`` would mask real bugs on multi-rank hosts
+      where the intended device is ``npu:{local_rank}``. Production Engine
+      always passes ``cuda:{rank}`` / ``npu:{rank}`` via
+      ``bind_local_device``, so this stays a no-op for the real call site.
+
+    Raises:
+        ValueError: if ``device`` is an accelerator without an explicit
+            index.
+    """
+    device = torch.device(device)
+    if device.type in ("cpu", "meta"):
+        return torch.device(device.type)
+    if device.index is None:
+        raise ValueError(
+            f"Accelerator RoPE device must include an explicit index: {device}"
+        )
+    return torch.device(device.type, device.index)
+
+
+def _resolve_rope_device() -> torch.device:
+    """Pick the device on which a fresh RoPE cache should materialise.
+
+    Precedence:
+
+    1. If :func:`set_rope_device` has been called, honour it — even when the
+       ambient default device is CPU. This lets the Engine populate the
+       cache on ``npu:0`` before opening ``with torch.device('meta')`` and
+       ensures the same call outside a meta scope still lands on ``npu:0``.
+    2. Otherwise use ``torch.tensor([]).device`` (the ambient default).
+    3. If the ambient default is ``meta`` and no setter is registered,
+       raise ``RuntimeError``. A meta cache cannot back any forward path.
+    """
+    if _ROPE_DEVICE is not None:
+        return _normalize_device(_ROPE_DEVICE)
+    current = torch.tensor([]).device
+    if current.type == "meta":
+        raise RuntimeError(
+            "Cannot construct RoPE on meta device. Call set_rope_device(...) "
+            "with a concrete target device (e.g. torch.device('npu:0')) "
+            "before entering a ``with torch.device('meta'):`` scope."
+        )
+    return _normalize_device(current)
+
+
+def _build_rope(
+    head_dim: int,
+    rotary_dim: int,
+    max_position: int,
+    base: float,
+    rope_scaling: Tuple[Tuple[str, Any], ...] | None,
+    device: torch.device,
+) -> RotaryEmbedding:
+    """Materialise a ``RotaryEmbedding`` under ``torch.device(device)``.
+
+    Isolated from :func:`_get_rope_cached` so hermetic tests can substitute
+    a stub without going through PyTorch's device dispatch (which would
+    require a live runtime for accelerator device types).
+    """
+    rope_map = dict(rope_scaling) if rope_scaling is not None else None
+    with torch.device(device):
+        return _get_rope(head_dim, rotary_dim, max_position, base, rope_map)
+
+
 @functools.cache
+def _get_rope_cached(
+    head_dim: int,
+    rotary_dim: int,
+    max_position: int,
+    base: float,
+    rope_scaling: Tuple[Tuple[str, Any], ...] | None,
+    device: torch.device,
+) -> RotaryEmbedding:
+    """One ``RotaryEmbedding`` per (dims, base, scaling, device) tuple.
+
+    ``device`` is part of the cache key so ``cpu`` / ``npu:0`` / ``npu:1``
+    populations never alias. First-writer-wins semantics are eliminated:
+    two consecutive calls with the same parameters but different devices
+    each get their own module, and each stays on its intended device.
+    """
+    return _build_rope(head_dim, rotary_dim, max_position, base, rope_scaling, device)
+
+
 def get_rope(
     head_dim: int,
     rotary_dim: int,
@@ -238,17 +335,17 @@ def get_rope(
     base: float,
     rope_scaling: Tuple[Tuple[str, Any], ...] | None = None,
 ) -> RotaryEmbedding:
-    rope_map = dict(rope_scaling) if rope_scaling is not None else None
-    t = torch.tensor([])
-    if t.device == torch.device("meta"):
-        # we cannot use meta device for rope
-        if _ROPE_DEVICE is None:
-            raise RuntimeError(
-                "We cannot use meta device for rope. Please call set_rope_device() first."
-            )
-        with torch.device(_ROPE_DEVICE):
-            return _get_rope(head_dim, rotary_dim, max_position, base, rope_map)
-    return _get_rope(head_dim, rotary_dim, max_position, base, rope_map)
+    target_device = _resolve_rope_device()
+    return _get_rope_cached(
+        head_dim, rotary_dim, max_position, base, rope_scaling, target_device
+    )
+
+
+# Preserve the diagnostic surface the previous ``@functools.cache``-decorated
+# ``get_rope`` exposed. External callers (tests, tooling) can keep calling
+# ``get_rope.cache_info()`` / ``get_rope.cache_clear()`` unchanged.
+get_rope.cache_info = _get_rope_cached.cache_info  # type: ignore[attr-defined]
+get_rope.cache_clear = _get_rope_cached.cache_clear  # type: ignore[attr-defined]
 
 
 __all__ = ["get_rope", "RotaryEmbedding", "set_rope_device"]

--- a/python/minisgl/layers/rotary.py
+++ b/python/minisgl/layers/rotary.py
@@ -9,6 +9,71 @@ import torch
 from .base import StateLessOP
 
 
+# --------------------------------------------------------------- helpers
+def _cos_sin_full_from_cache(
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    rotary_dim: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Split the FlashInfer-style ``[cos | sin]`` cache and duplicate each
+    half to reach the full ``rotary_dim`` width used by NeoX rotate_half.
+
+    The cache is laid out as ``cat([cos, sin], dim=-1)`` with shape
+    ``(max_position, rotary_dim)``, i.e. the first ``rotary_dim // 2`` columns
+    hold ``cos`` and the second half holds ``sin``. Returns tensors of shape
+    ``(T, rotary_dim)`` on the cache's device, with the cache's dtype.
+    """
+    half = rotary_dim // 2
+    # Direct index — no dtype coercion, no CPU copy. Positions carry the
+    # dtype the caller chose (int32 / int64); torch's advanced-indexing
+    # accepts both without materialising a converted copy.
+    selected = cos_sin_cache[positions]                  # (T, rotary_dim)
+    cos_half = selected[..., :half]                      # (T, half)
+    sin_half = selected[..., half:]                      # (T, half)
+    cos_full = torch.cat((cos_half, cos_half), dim=-1)   # (T, rotary_dim)
+    sin_full = torch.cat((sin_half, sin_half), dim=-1)   # (T, rotary_dim)
+    return cos_full, sin_full
+
+
+def _rope_neox_cpu(
+    x: torch.Tensor, cos_full: torch.Tensor, sin_full: torch.Tensor
+) -> torch.Tensor:
+    """NeoX rotate_half applied in fp32; result cast back to ``x.dtype``.
+
+    ``cos_full`` / ``sin_full`` broadcast over the head dimension and are
+    expected to be fp32 with shape ``(T, 1, rotary_dim)``.
+    """
+    x_f = x.float()
+    half = x_f.shape[-1] // 2
+    x1 = x_f[..., :half]
+    x2 = x_f[..., half:]
+    rotated = torch.cat((-x2, x1), dim=-1)
+    return (x_f * cos_full + rotated * sin_full).to(x.dtype)
+
+
+def _load_flashinfer_apply_rope():
+    try:
+        from flashinfer import apply_rope_with_cos_sin_cache_inplace
+    except ImportError as exc:
+        raise RuntimeError(
+            "CUDA RoPE requires flashinfer to be importable; install "
+            "flashinfer on the host to use RotaryEmbedding on CUDA tensors."
+        ) from exc
+    return apply_rope_with_cos_sin_cache_inplace
+
+
+def _load_torch_npu():
+    try:
+        import torch_npu
+    except ImportError as exc:
+        raise RuntimeError(
+            "NPU RoPE requires torch_npu to be importable; install "
+            "torch_npu on the host to use RotaryEmbedding on NPU tensors."
+        ) from exc
+    return torch_npu
+
+
+# ---------------------------------------------------------- RotaryEmbedding
 class RotaryEmbedding(StateLessOP):
     def __init__(
         self,
@@ -18,8 +83,14 @@ class RotaryEmbedding(StateLessOP):
         base: float,
         post_process: None | Callable[[torch.Tensor], torch.Tensor] = None,
     ) -> None:
+        # No device-library imports at construction time — dispatch happens on
+        # the first forward, keyed off ``query.device.type``.
         super().__init__()
         self.head_size = head_size
+        # ``rotary_dim`` is asserted equal to ``head_size`` in the current
+        # model zoo; kept as a distinct attribute so the NPU/CPU helpers can
+        # split the cache along the rotary axis without recomputing ``//2``.
+        self.rotary_dim = rotary_dim
         assert rotary_dim == head_size
         inv_freq = 1.0 / (base ** (torch.arange(0, rotary_dim, 2, dtype=torch.float) / rotary_dim))
         if post_process is not None:
@@ -28,13 +99,11 @@ class RotaryEmbedding(StateLessOP):
         freqs = torch.einsum("i,j -> ij", t, inv_freq)
         cos = freqs.cos()
         sin = freqs.sin()
-        # buffer, so don't load/save
+        # buffer, so don't load/save. FlashInfer stores (cos | sin) along the
+        # last dim; the NPU/CPU paths re-split and duplicate each half to
+        # reach the full rotary_dim used by NeoX rotate_half.
         self._cos_sin_cache = torch.cat((cos, sin), dim=-1)
         assert self.head_size in [64, 128, 256, 512]
-
-        from flashinfer import apply_rope_with_cos_sin_cache_inplace
-
-        self.apply_rope_with_cos_sin_cache_inplace = apply_rope_with_cos_sin_cache_inplace
 
     def forward(
         self,
@@ -42,14 +111,53 @@ class RotaryEmbedding(StateLessOP):
         query: torch.Tensor,
         key: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        self.apply_rope_with_cos_sin_cache_inplace(
-            positions=positions,
-            query=query,
-            key=key,
-            head_size=self.head_size,
-            cos_sin_cache=self._cos_sin_cache,
+        device_type = query.device.type
+
+        if device_type == "cuda":
+            apply_rope = _load_flashinfer_apply_rope()
+            # FlashInfer semantics: rotates ``query`` and ``key`` in-place and
+            # returns ``None``. We return the same objects so callers see the
+            # identity contract that downstream attention relies on.
+            apply_rope(
+                positions=positions,
+                query=query,
+                key=key,
+                head_size=self.head_size,
+                cos_sin_cache=self._cos_sin_cache,
+            )
+            return query, key
+
+        if device_type == "npu":
+            torch_npu = _load_torch_npu()
+            cos_full, sin_full = _cos_sin_full_from_cache(
+                self._cos_sin_cache, positions, self.rotary_dim
+            )
+            cos_full = cos_full.to(dtype=query.dtype)
+            sin_full = sin_full.to(dtype=query.dtype)
+            T = query.shape[0]
+            Hq = query.shape[1]
+            Hk = key.shape[1]
+            D = self.head_size
+            q_4d = query.view(1, T, Hq, D)
+            k_4d = key.view(1, T, Hk, D)
+            cos_4d = cos_full.view(1, T, 1, D)
+            sin_4d = sin_full.view(1, T, 1, D)
+            # npu_rotary_mul with rotary_mode="half" is NeoX rotate_half; it
+            # returns a fresh allocation, so inputs are untouched (no copy_,
+            # no clone, no contiguous).
+            q_rot = torch_npu.npu_rotary_mul(q_4d, cos_4d, sin_4d, rotary_mode="half")
+            k_rot = torch_npu.npu_rotary_mul(k_4d, cos_4d, sin_4d, rotary_mode="half")
+            return q_rot.squeeze(0), k_rot.squeeze(0)
+
+        # CPU path — pure PyTorch NeoX rotate_half with fp32 mid-calc.
+        cos_full, sin_full = _cos_sin_full_from_cache(
+            self._cos_sin_cache, positions, self.rotary_dim
         )
-        return query, key
+        cos_b = cos_full.unsqueeze(1)                    # (T, 1, D)
+        sin_b = sin_full.unsqueeze(1)                    # (T, 1, D)
+        q_out = _rope_neox_cpu(query, cos_b, sin_b)
+        k_out = _rope_neox_cpu(key, cos_b, sin_b)
+        return q_out, k_out
 
 
 def _get_rope(

--- a/python/minisgl/message/__init__.py
+++ b/python/minisgl/message/__init__.py
@@ -1,9 +1,18 @@
 from .backend import AbortBackendMsg, BaseBackendMsg, BatchBackendMsg, ExitMsg, UserMsg
-from .frontend import BaseFrontendMsg, BatchFrontendMsg, UserReply
-from .tokenizer import AbortMsg, BaseTokenizerMsg, BatchTokenizerMsg, DetokenizeMsg, TokenizeMsg
+from .frontend import AbortAckReply, BaseFrontendMsg, BatchFrontendMsg, UserReply
+from .tokenizer import (
+    AbortAckMsg,
+    AbortMsg,
+    BaseTokenizerMsg,
+    BatchTokenizerMsg,
+    DetokenizeMsg,
+    TokenizeMsg,
+)
 
 __all__ = [
     "AbortMsg",
+    "AbortAckMsg",
+    "AbortAckReply",
     "AbortBackendMsg",
     "BaseBackendMsg",
     "BatchBackendMsg",

--- a/python/minisgl/message/frontend.py
+++ b/python/minisgl/message/frontend.py
@@ -27,3 +27,15 @@ class UserReply(BaseFrontendMsg):
     uid: int
     incremental_output: str
     finished: bool
+
+
+# Gate 2.3f: Tokenizer → Frontend confirmation that the Scheduler has
+# finished acting on an abort. Emitted 1:1 with an incoming AbortAckMsg
+# from the Scheduler. Deliberately does NOT reuse UserReply: a UserReply
+# with a synthesised token would force downstream stream consumers to
+# distinguish "real token" from "cancellation stub" via heuristics.
+# AbortAckReply is a distinct type so the Frontend's abort-pending state
+# machine can dispatch on isinstance alone.
+@dataclass
+class AbortAckReply(BaseFrontendMsg):
+    uid: int

--- a/python/minisgl/message/tokenizer.py
+++ b/python/minisgl/message/tokenizer.py
@@ -41,3 +41,16 @@ class TokenizeMsg(BaseTokenizerMsg):
 @dataclass
 class AbortMsg(BaseTokenizerMsg):
     uid: int
+
+
+# Gate 2.3f: Scheduler → Tokenizer ack that a previously-received
+# AbortBackendMsg has been fully honoured (resources released, or uid
+# confirmed unknown). Deliberately carries only the uid — no token, no
+# text — so the Frontend cleanup path never has to synthesise a "fake"
+# stop token to represent cancellation. Idempotent: emitted at most once
+# per abort in the Scheduler code path, but the Frontend handler is
+# expected to tolerate duplicates in case the same uid receives a
+# duplicate AbortBackendMsg from a re-tried caller.
+@dataclass
+class AbortAckMsg(BaseTokenizerMsg):
+    uid: int

--- a/python/minisgl/scheduler/cache.py
+++ b/python/minisgl/scheduler/cache.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, List, Tuple
 
 import torch
@@ -10,6 +11,28 @@ from minisgl.utils import div_ceil
 
 if TYPE_CHECKING:
     from .utils import PendingReq
+
+
+@dataclass
+class AllocationToken:
+    """Rollback token for one ``CacheManager.allocate_paged`` call.
+
+    Records exactly what that call mutated so ``rollback`` can undo it
+    without touching any pre-existing prefix / retained pages.
+
+    Fields:
+        allocated: Flat token-level slots handed to ``_write_page_table``
+            (empty when no new pages were needed). ``[::page_size]`` of this
+            tensor is the page-aligned list of physical pages to return to
+            ``free_slots`` on rollback — matches ``_free``'s convention.
+        overwrites: For every page_table region rewritten by this call, a
+            ``(table_idx, first_pos, last_pos, old_slice)`` tuple where
+            ``old_slice`` is a **clone** of the destination region as it was
+            before the write. Clones live on the page_table's device.
+    """
+
+    allocated: torch.Tensor
+    overwrites: List[Tuple[int, int, int, torch.Tensor]] = field(default_factory=list)
 
 
 class CacheManager:
@@ -39,7 +62,18 @@ class CacheManager:
     def unlock(self, handle: BaseCacheHandle) -> None:
         self.prefix_cache.lock_handle(handle, unlock=True)
 
-    def allocate_paged(self, reqs: List[Req]) -> None:
+    def allocate_paged(self, reqs: List[Req]) -> AllocationToken:
+        """Allocate new pages for ``reqs`` and record a rollback token.
+
+        The token snapshots exactly the mutations this call performs — the
+        physical pages drawn from ``free_slots`` (and possibly refilled from
+        ``prefix_cache.evict``) plus the pre-write contents of every
+        ``page_table`` region we are about to overwrite. Gate 2.3b's
+        transactional path relies on this being a strict superset of what
+        ``rollback`` needs to undo, and a strict subset of the caller's
+        prefix / retained pages (those are never touched by
+        ``allocate_paged`` and therefore never appear in the token).
+        """
         needed_pages = 0
         allocation_info: List[Tuple[int, int, int]] = []
         for req in reqs:
@@ -48,9 +82,41 @@ class CacheManager:
             if last_page > first_page:
                 needed_pages += last_page - first_page
                 allocation_info.append((req.table_idx, first_page, last_page))
-        if needed_pages > 0:
-            allocated = self._page_to_token(self._allocate(needed_pages))
-            _write_page_table(self.page_table, allocated, allocation_info, self.page_size)
+        if needed_pages == 0:
+            empty = torch.empty(0, dtype=torch.int32, device=self.device)
+            return AllocationToken(allocated=empty)
+
+        allocated = self._page_to_token(self._allocate(needed_pages))
+        overwrites: List[Tuple[int, int, int, torch.Tensor]] = []
+        for table_idx, first_page, last_page in allocation_info:
+            first_pos = first_page * self.page_size
+            last_pos = last_page * self.page_size
+            # Clone so a later in-place write into page_table does not shadow
+            # what we captured. The clone lives on the page_table's device;
+            # rollback writes it back with the same index shape it came from.
+            old_slice = self.page_table[table_idx, first_pos:last_pos].clone()
+            overwrites.append((table_idx, first_pos, last_pos, old_slice))
+        _write_page_table(self.page_table, allocated, allocation_info, self.page_size)
+        return AllocationToken(allocated=allocated, overwrites=overwrites)
+
+    def rollback_allocation(self, token: AllocationToken) -> None:
+        """Undo a single ``allocate_paged`` call.
+
+        Restores every recorded page_table slice to its pre-call contents and
+        returns every newly-allocated physical page to ``free_slots``. The
+        prefix cache, cache handles, refcounts, and any pages that pre-dated
+        this ``allocate_paged`` call are deliberately not touched.
+
+        Safe to call with an "empty" token (no new pages, no overwrites) — a
+        no-op path used by the transactional caller when nothing needed
+        allocation.
+        """
+        for table_idx, first_pos, last_pos, old_slice in token.overwrites:
+            self.page_table[table_idx, first_pos:last_pos] = old_slice
+        if len(token.allocated) > 0:
+            # ``_free`` slices with ``[::page_size]`` — same convention that
+            # ``allocate_paged`` produced via ``_page_to_token``.
+            self._free(token.allocated)
 
     def cache_req(self, req: Req, *, finished: bool) -> None:
         # ==================================== valid cache region ====================================

--- a/python/minisgl/scheduler/io.py
+++ b/python/minisgl/scheduler/io.py
@@ -74,6 +74,11 @@ class SchedulerIOMixin:
         raise NotImplementedError("should be implemented")
 
     def sync_all_ranks(self) -> None:
+        # TP=1 NPU / offline / any single-rank host has no ProcessGroup — a CPU
+        # barrier is meaningless in that case. Guard on group presence rather
+        # than device type so the branch stays orthogonal to the accelerator.
+        if self.tp_cpu_group is None:
+            return
         self.tp_cpu_group.barrier().wait()
 
     def _recv_msg_single_rank(self, blocking: bool = False) -> List[BaseBackendMsg]:

--- a/python/minisgl/scheduler/io.py
+++ b/python/minisgl/scheduler/io.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Final, List
 
 import torch
-from minisgl.message import BaseBackendMsg, BaseTokenizerMsg, BatchTokenizerMsg, DetokenizeMsg
+from minisgl.message import BaseBackendMsg, BaseTokenizerMsg, BatchTokenizerMsg
 from minisgl.utils import ZmqPubQueue, ZmqPullQueue, ZmqPushQueue, ZmqSubQueue, init_logger
 
 if TYPE_CHECKING:
@@ -70,7 +70,7 @@ class SchedulerIOMixin:
     def offline_receive_msg(self, blocking: bool = False) -> List[BaseBackendMsg]:
         raise NotImplementedError("should be implemented")
 
-    def offline_send_result(self, reply: List[DetokenizeMsg]) -> None:
+    def offline_send_result(self, reply: List[BaseTokenizerMsg]) -> None:
         raise NotImplementedError("should be implemented")
 
     def sync_all_ranks(self) -> None:
@@ -126,7 +126,7 @@ class SchedulerIOMixin:
             pending_msgs.append(self._recv_from_rank0.get())
         return pending_msgs
 
-    def _reply_tokenizer_rank0(self, reply: List[DetokenizeMsg]) -> None:
+    def _reply_tokenizer_rank0(self, reply: List[BaseTokenizerMsg]) -> None:
         num_reply = len(reply)
         logger.debug_rank0(f"Replying to tokenizer: {num_reply} messages")
         if num_reply == 1:
@@ -134,5 +134,5 @@ class SchedulerIOMixin:
         elif num_reply > 1:
             self._send_into_tokenizer.put(BatchTokenizerMsg(data=reply))  # type: ignore
 
-    def _reply_tokenizer_rank1(self, reply: List[DetokenizeMsg]) -> None:
+    def _reply_tokenizer_rank1(self, reply: List[BaseTokenizerMsg]) -> None:
         _ = reply  # do nothing for non-primary ranks

--- a/python/minisgl/scheduler/scheduler.py
+++ b/python/minisgl/scheduler/scheduler.py
@@ -14,6 +14,13 @@ from minisgl.message import (
     UserMsg,
 )
 from minisgl.utils import init_logger, load_tokenizer
+from minisgl.utils.device_runtime import (
+    create_stream,
+    current_stream,
+    set_stream,
+    stream_context,
+    synchronize_device,
+)
 
 from .cache import CacheManager
 from .config import SchedulerConfig
@@ -50,9 +57,14 @@ class Scheduler(SchedulerIOMixin):
 
         # use another stream to overlap metadata processing with computation
         self.device = self.engine.device
-        self.stream = torch.cuda.Stream(device=self.device)
-        self.engine_stream_ctx = torch.cuda.stream(self.engine.stream)
-        torch.cuda.set_stream(self.stream)
+        # Stream lifecycle routes through the shared device_runtime dispatch so
+        # cuda / npu / cpu hosts all follow the same call graph. Engine already
+        # committed to this layer for its own stream — Scheduler reuses the
+        # engine's device_type so the two managers can never drift apart.
+        self.device_type = self.engine.device_type
+        self.stream = create_stream(self.device_type)
+        self.engine_stream_ctx = stream_context(self.device_type, self.engine.stream)
+        set_stream(self.device_type, self.stream)
 
         # initialize other managers
         self.table_manager = TableManager(config.max_running_req, self.engine.page_table)
@@ -125,13 +137,13 @@ class Scheduler(SchedulerIOMixin):
                 while True:
                     self.normal_loop()
         else:
-            assert torch.cuda.current_stream() == self.stream
+            assert current_stream(self.device_type) == self.stream
             data = None
             while True:
                 data = self.overlap_loop(data)
 
     def shutdown(self) -> None:
-        torch.cuda.synchronize(self.device)
+        synchronize_device(self.device_type)
         self.sync_all_ranks()
         self.engine.shutdown()
 

--- a/python/minisgl/scheduler/scheduler.py
+++ b/python/minisgl/scheduler/scheduler.py
@@ -78,6 +78,9 @@ class Scheduler(SchedulerIOMixin):
 
         # some alias for easy access
         self.finished_reqs: Set[Req] = set()
+        # Gate 2.3e: overlap-loop abort fence state. See _apply_deferred_aborts.
+        self.inflight_uids: Set[int] = set()
+        self.deferred_abort_uids: Set[int] = set()
         self.tokenizer = load_tokenizer(config.model_path)
         self.eos_token_id = self.tokenizer.eos_token_id
         self.token_pool = self.table_manager.token_pool
@@ -99,6 +102,15 @@ class Scheduler(SchedulerIOMixin):
         It will overlap the execution of current batch and processing of last batch's results,
         which can effectively hide CPU latency and improve GPU utilization.
         """
+        # Gate 2.3e: publish the set of uids whose device-side compute is done
+        # but whose CPU-side post-processing has NOT run yet. Any abort msg for
+        # a uid in this set must be deferred: freeing its table/KV now would
+        # race with _process_last_data reading req.can_decode and reissuing a
+        # stale DetokenizeMsg. Empty on the very first tick (no last_data).
+        self.inflight_uids = (
+            {r.uid for r in last_data[0].batch.reqs} if last_data is not None else set()
+        )
+
         blocking = not (
             last_data is not None  # don't block if we have a batch to be processed
             or self.prefill_manager.runnable
@@ -115,6 +127,16 @@ class Scheduler(SchedulerIOMixin):
                 ongoing_data = (forward_input, self._forward(forward_input))
 
         self._process_last_data(last_data)
+        # Gate 2.3e: with last_data now fully drained (CPU-side reads done,
+        # replies sent for non-aborted reqs), it is safe to free the resources
+        # of every deferred-abort req in that batch. Runs BEFORE we clear
+        # inflight_uids so the apply helper can trust the batch identity.
+        self._apply_deferred_aborts(last_data)
+        # Fence lifetime ends here — the next overlap_loop tick will re-populate
+        # inflight_uids from its own last_data, and abort msgs arriving between
+        # loop ticks (i.e. while no batch is inflight) must take the immediate
+        # free path.
+        self.inflight_uids = set()
         return ongoing_data
 
     def normal_loop(self) -> None:
@@ -250,6 +272,14 @@ class Scheduler(SchedulerIOMixin):
             for i, req in enumerate(batch.reqs):
                 if isinstance(req, ChunkedReq):
                     continue
+                # Gate 2.3e: the abort msg landed inside overlap_loop's fence
+                # window (after forward, before this post-process). The req's
+                # device-side sampled token is discarded — no DetokenizeMsg is
+                # emitted, req.append_host is skipped so the host token buffer
+                # is not extended, and the resource free is deferred to
+                # _apply_deferred_aborts so the id() dedup runs once.
+                if req.uid in self.deferred_abort_uids:
+                    continue
                 next_token = next_tokens_cpu[i]
                 req.append_host(next_token.unsqueeze(0))
                 next_token = int(next_token.item())
@@ -277,6 +307,56 @@ class Scheduler(SchedulerIOMixin):
         self.finished_reqs = new_finished_reqs
         self.send_result(reply)
 
+    def _apply_deferred_aborts(self, last_data: ForwardData | None) -> None:
+        """Free the resources of every deferred-abort req in ``last_data``.
+
+        Gate 2.3e post-processing helper. Runs from ``overlap_loop`` AFTER
+        ``_process_last_data`` has completed — by that point every CPU-side
+        consumer of the inflight batch (host-token append, DetokenizeMsg
+        emission, second-free guard update) has already finished, so it is
+        safe to return table_idx to ``table_manager`` and hand KV pages
+        back to ``cache_manager`` without racing anyone.
+
+        Guarantees:
+
+        * Each deferred uid whose Req actually appeared in
+          ``last_data.batch.reqs`` is freed exactly once. ``id(req)``-based
+          dedup mirrors ``_drain_requests`` — two batch entries pointing at
+          the same Req (which would already be a bug elsewhere) still yield
+          one free.
+        * A deferred uid whose Req is NOT in the batch (e.g. the abort was
+          registered but the uid never actually forwarded because a prior
+          error rebuilt the batch) is silently dropped. The scheduler's
+          existing invariants guarantee any Req not in ``last_data.batch.reqs``
+          was already removed from the schedulable containers by
+          ``_process_one_msg`` at abort time, so nothing else needs freeing.
+        * ``deferred_abort_uids`` is fully cleared before returning. The
+          fence caller in ``overlap_loop`` also resets ``inflight_uids``
+          immediately after this call.
+
+        A ``None`` ``last_data`` (first overlap tick) is a no-op; nothing
+        could have been marked deferred yet in that state.
+        """
+        if last_data is None or not self.deferred_abort_uids:
+            self.deferred_abort_uids.clear()
+            return
+        batch = last_data[0].batch
+        freed_ids: Set[int] = set()
+        for req in batch.reqs:
+            if req.uid not in self.deferred_abort_uids:
+                continue
+            if id(req) in freed_ids:
+                continue
+            freed_ids.add(id(req))
+            # ChunkedReq lives in pending_list; if such a uid ever ended up
+            # inside last_data.batch.reqs (which requires PrefillAdder to have
+            # already advanced it into a chunked-prefill slot), the message
+            # handler has already removed it from prefill_manager.pending_list
+            # — no additional container removal is needed here. The physical
+            # free path is identical: table slot + KV pages.
+            self._free_req_resources(req)
+        self.deferred_abort_uids.clear()
+
     def _process_one_msg(self, msg: BaseBackendMsg) -> None:
         if isinstance(msg, BatchBackendMsg):
             for msg in msg.data:
@@ -300,6 +380,30 @@ class Scheduler(SchedulerIOMixin):
             self.prefill_manager.add_one_req(msg)
         elif isinstance(msg, AbortBackendMsg):
             logger.debug_rank0("Aborting request %d", msg.uid)
+            # Gate 2.3e: overlap-loop abort fence. If the uid is in the batch
+            # whose CPU-side results have not yet been processed (inflight_uids
+            # is only populated inside overlap_loop, and only for last_data's
+            # reqs), we cannot free its resources here — _process_last_data
+            # still needs to read req.can_decode and its device-side sampled
+            # token buffer. Instead: yank it out of any schedulable container
+            # so it cannot re-enter the next batch, mark it deferred, and let
+            # _apply_deferred_aborts perform the single, idempotent free after
+            # _process_last_data has consumed everything it needs.
+            #
+            # For normal_loop (which never populates inflight_uids) and for any
+            # abort whose uid is NOT inflight, this branch is a strict no-op
+            # and the existing immediate-free path runs unchanged.
+            if msg.uid in self.inflight_uids:
+                # Removing from decode_manager here means the req cannot enter
+                # _schedule_next_batch on the CURRENT tick, and removing from
+                # prefill_manager covers the (rare) case where the same uid
+                # was chunked-prefilled last tick and requeued as pending
+                # this tick before the abort arrived. Both calls are safe
+                # no-ops when the container doesn't hold the uid.
+                self.decode_manager.abort_req(msg.uid)
+                self.prefill_manager.abort_req(msg.uid)
+                self.deferred_abort_uids.add(msg.uid)
+                return
             req_to_free = self.prefill_manager.abort_req(msg.uid)
             req_to_free = req_to_free or self.decode_manager.abort_req(msg.uid)
             if req_to_free is not None:

--- a/python/minisgl/scheduler/scheduler.py
+++ b/python/minisgl/scheduler/scheduler.py
@@ -13,7 +13,7 @@ from minisgl.message import (
     ExitMsg,
     UserMsg,
 )
-from minisgl.utils import init_logger, load_tokenizer
+from minisgl.utils import div_ceil, init_logger, load_tokenizer
 from minisgl.utils.device_runtime import (
     create_stream,
     current_stream,
@@ -145,7 +145,98 @@ class Scheduler(SchedulerIOMixin):
     def shutdown(self) -> None:
         synchronize_device(self.device_type)
         self.sync_all_ranks()
+        # Gate 2.3d: proactively drain pending + running requests BEFORE
+        # engine.shutdown() so the allocator/table_manager are restored to
+        # baseline. Engine shutdown itself only tears down comm groups and
+        # graph capture — it does not walk the scheduler's queues.
+        self._drain_requests()
         self.engine.shutdown()
+
+    def _drain_requests(self) -> None:
+        """Release every request currently owned by this scheduler.
+
+        Called from ``shutdown()`` between the device/rank sync and the
+        engine teardown. Guarantees on return:
+
+        * ``prefill_manager.pending_list`` is empty.
+        * ``decode_manager.running_reqs`` is empty.
+        * Every ``table_idx`` those requests held is back on
+          ``table_manager._free_slots``.
+        * Every non-cached KV page those requests owned is back on
+          ``cache_manager.free_slots`` (via ``cache_req(..., finished=True)``).
+        * ``cache_manager.check_integrity()`` passes.
+
+        Idempotent: calling twice is a no-op — the second call finds both
+        containers already empty and returns without touching the
+        allocators.
+
+        Deliberately out of scope (per Gate 2.3d):
+          * No abort ack, no final DetokenizeMsg emission.
+          * No handling of overlap-loop in-flight batches (those are
+            drained by the earlier ``synchronize_device`` call).
+        """
+        # Dedup by object identity so a Req referenced from multiple
+        # containers (e.g. the pending list's ChunkedReq AND the running
+        # set, if bookkeeping ever drifts) is freed exactly once. Uid is
+        # user-controlled and not guaranteed unique across the lifetime
+        # of a scheduler; id() is.
+        freed_ids: Set[int] = set()
+
+        def _free_once(req: Req) -> None:
+            if id(req) in freed_ids:
+                return
+            freed_ids.add(id(req))
+            # Standard release path frees pages in [0, req.cached_len). For
+            # mid-flight requests (chunked prefill that never advanced,
+            # decode reqs stopped between forward and post-processing) the
+            # region [cached_len, device_len) also holds physical KV pages
+            # that allocate_paged wrote — those would otherwise leak. Mirror
+            # allocate_paged's page math (round cached_len UP, device_len UP)
+            # so we only touch page-aligned regions the allocator itself
+            # produced. If they coincide (nothing was ever page-allocated for
+            # this req beyond the prefix), the slice is empty and _free is a
+            # no-op.
+            first_page = div_ceil(req.cached_len, self.cache_manager.page_size)
+            last_page = div_ceil(req.device_len, self.cache_manager.page_size)
+            if last_page > first_page:
+                first_pos = first_page * self.cache_manager.page_size
+                last_pos = last_page * self.cache_manager.page_size
+                tail_slots = self.cache_manager.page_table[
+                    req.table_idx, first_pos:last_pos
+                ]
+                self.cache_manager._free(tail_slots)
+            self._free_req_resources(req)
+
+        # -- pending -----------------------------------------------------------
+        # PendingReq is a lightweight envelope carrying user_ids /
+        # sampling_params. If `.chunked_req is None`, no Req was ever built
+        # for it — no table_idx, no KV pages — so dropping the entry is the
+        # entire cleanup. If `.chunked_req is not None`, a real Req was
+        # allocated (in PrefillAdder) with a table slot and possibly KV
+        # pages; that one needs _free_req_resources exactly once.
+        pending_list = self.prefill_manager.pending_list
+        for pending in pending_list:
+            chunked = pending.chunked_req
+            if chunked is not None:
+                _free_once(chunked)
+        pending_list.clear()
+
+        # -- running -----------------------------------------------------------
+        # Snapshot to a list to iterate deterministically — a Set's iteration
+        # order is nondeterministic across Python runs, and any future
+        # dependency between free ordering and page reuse would silently
+        # regress. Sorting by uid gives a stable, reviewable order.
+        running_snapshot = sorted(self.decode_manager.running_reqs, key=lambda r: r.uid)
+        for req in running_snapshot:
+            _free_once(req)
+        self.decode_manager.running_reqs.clear()
+
+        # -- finished bookkeeping ---------------------------------------------
+        # The overlap-scheduling second-free guard tracks recently-finished
+        # reqs so a repeated free is a no-op. Once drained, that guard is
+        # irrelevant — dump the set so a subsequent drain call cannot see a
+        # phantom "already freed" mask.
+        self.finished_reqs = set()
 
     def _process_last_data(self, last_data: ForwardData | None) -> None:
         if last_data is None:

--- a/python/minisgl/scheduler/scheduler.py
+++ b/python/minisgl/scheduler/scheduler.py
@@ -6,8 +6,10 @@ import torch
 from minisgl.core import Batch, Req
 from minisgl.env import ENV
 from minisgl.message import (
+    AbortAckMsg,
     AbortBackendMsg,
     BaseBackendMsg,
+    BaseTokenizerMsg,
     BatchBackendMsg,
     DetokenizeMsg,
     ExitMsg,
@@ -81,6 +83,16 @@ class Scheduler(SchedulerIOMixin):
         # Gate 2.3e: overlap-loop abort fence state. See _apply_deferred_aborts.
         self.inflight_uids: Set[int] = set()
         self.deferred_abort_uids: Set[int] = set()
+        # Gate 2.3f: abort ack queue. Every _process_one_msg AbortBackendMsg
+        # entry — non-inflight free, inflight-deferred (post-apply), and
+        # unknown-uid idempotent — appends the uid here; the flush at each
+        # loop tail sends AbortAckMsg to the tokenizer in one batched call.
+        # Deliberately a list (not a set) so a Scheduler-side duplicate
+        # would produce a duplicate ack — but the guard in _process_one_msg
+        # ensures each abort msg produces exactly one entry, so ordering is
+        # stable and duplicates only arise if a duplicate AbortBackendMsg is
+        # received (the Frontend must tolerate that per Gate 2.3f spec).
+        self._pending_abort_acks: List[int] = []
         self.tokenizer = load_tokenizer(config.model_path)
         self.eos_token_id = self.tokenizer.eos_token_id
         self.token_pool = self.table_manager.token_pool
@@ -132,6 +144,12 @@ class Scheduler(SchedulerIOMixin):
         # of every deferred-abort req in that batch. Runs BEFORE we clear
         # inflight_uids so the apply helper can trust the batch identity.
         self._apply_deferred_aborts(last_data)
+        # Gate 2.3f: flush AbortAckMsg AFTER the deferred frees so the ack
+        # invariant ("resources released by the time the ack lands") holds
+        # end-to-end. Non-inflight aborts appended their acks earlier in
+        # _process_one_msg — they are also drained here so all aborts of
+        # the tick coalesce into a single tokenizer round-trip.
+        self._flush_pending_acks()
         # Fence lifetime ends here — the next overlap_loop tick will re-populate
         # inflight_uids from its own last_data, and abort msgs arriving between
         # loop ticks (i.e. while no batch is inflight) must take the immediate
@@ -150,6 +168,12 @@ class Scheduler(SchedulerIOMixin):
             ongoing_data = (forward_input, self._forward(forward_input))
 
         self._process_last_data(ongoing_data)
+        # Gate 2.3f: same rationale as overlap_loop's flush — every abort msg
+        # in normal_loop takes the immediate-free path in _process_one_msg (no
+        # inflight fence exists here), so this is purely the wire-out step.
+        # Called AFTER _process_last_data so UserReplies precede AbortAckMsgs
+        # on the tokenizer channel.
+        self._flush_pending_acks()
 
     @torch.inference_mode()
     def run_forever(self) -> NoReturn:
@@ -355,7 +379,42 @@ class Scheduler(SchedulerIOMixin):
             # — no additional container removal is needed here. The physical
             # free path is identical: table slot + KV pages.
             self._free_req_resources(req)
+            # Gate 2.3f: ack must be emitted AFTER _free_req_resources so
+            # the tokenizer/frontend can rely on the invariant "AbortAckMsg
+            # arrives only once every allocator slot for that uid has been
+            # returned". The append is one-per-freed-Req (never per abort
+            # msg): duplicate abort msgs that landed on an already-deferred
+            # uid do NOT produce a duplicate ack because the id()-dedup
+            # above collapses them into a single free + a single append.
+            self._pending_abort_acks.append(req.uid)
         self.deferred_abort_uids.clear()
+
+    def _flush_pending_acks(self) -> None:
+        """Drain ``self._pending_abort_acks`` onto the tokenizer channel.
+
+        Gate 2.3f loop-tail helper. Called from ``overlap_loop`` (after
+        ``_apply_deferred_aborts``) and ``normal_loop`` (after
+        ``_process_last_data``). Both call sites are AFTER the tick's normal
+        ``send_result`` — one AbortAckMsg batch per tick keeps the wire
+        ordering deterministic: any UserReply produced by this tick is
+        flushed first, the acks follow.
+
+        Invariants:
+          * The list is cleared exactly when the acks are handed to
+            ``send_result`` — so a second call on an empty list is a strict
+            no-op, and a partial delivery (should ``send_result`` raise)
+            leaves the acks unshipped for the next tick to retry.
+          * Non-primary ranks share the same code path; ``send_result`` on
+            those ranks is ``_reply_tokenizer_rank1`` which is a no-op. No
+            rank-guard is needed here.
+        """
+        if not self._pending_abort_acks:
+            return
+        acks: List[BaseTokenizerMsg] = [
+            AbortAckMsg(uid=uid) for uid in self._pending_abort_acks
+        ]
+        self._pending_abort_acks.clear()
+        self.send_result(acks)
 
     def _process_one_msg(self, msg: BaseBackendMsg) -> None:
         if isinstance(msg, BatchBackendMsg):
@@ -402,12 +461,22 @@ class Scheduler(SchedulerIOMixin):
                 # no-ops when the container doesn't hold the uid.
                 self.decode_manager.abort_req(msg.uid)
                 self.prefill_manager.abort_req(msg.uid)
+                # Gate 2.3f: a duplicate abort for a uid already deferred adds
+                # nothing to the set (idempotent) and MUST NOT enqueue a
+                # second ack — _apply_deferred_aborts emits exactly one ack
+                # per uid it frees.
                 self.deferred_abort_uids.add(msg.uid)
                 return
+            # Gate 2.3f: non-inflight path. Every branch below terminates in
+            # exactly one appended ack — even the "uid not found anywhere"
+            # branch — so the Frontend's abort-pending state machine cannot
+            # get stuck waiting on a Scheduler that never saw the uid (e.g.
+            # already-finished, never-existed, or already-aborted-and-freed).
             req_to_free = self.prefill_manager.abort_req(msg.uid)
             req_to_free = req_to_free or self.decode_manager.abort_req(msg.uid)
             if req_to_free is not None:
                 self._free_req_resources(req_to_free)
+            self._pending_abort_acks.append(msg.uid)
         else:
             logger.error(f"Unknown message type: {type(msg)}")
             raise NotImplementedError

--- a/python/minisgl/scheduler/scheduler.py
+++ b/python/minisgl/scheduler/scheduler.py
@@ -222,16 +222,33 @@ class Scheduler(SchedulerIOMixin):
         self.cache_manager.cache_req(req, finished=True)
 
     def _prepare_batch(self, batch: Batch) -> ForwardInput:
+        # Gate 2.3b: transactional page-table allocation. Everything from
+        # ``allocate_paged`` onward mutates scratch state on ``batch``; any
+        # raise before we return must undo *only* what this call added — new
+        # physical pages and page_table slice overwrites — without touching
+        # prefix pages, cache handles, or the running/pending sets.
         self.engine.graph_runner.pad_batch(batch)
-        self.cache_manager.allocate_paged(batch.reqs)
-        batch.positions = _make_positions(batch, self.device)
-        input_mapping = _make_input_tuple(batch, self.device)
-        write_mapping = _make_write_tuple(batch, self.device)
-        batch.out_loc = self.engine.page_table[input_mapping]
-        self.engine.attn_backend.prepare_metadata(batch)
+        token = self.cache_manager.allocate_paged(batch.reqs)
+        try:
+            batch.positions = _make_positions(batch, self.device)
+            input_mapping = _make_input_tuple(batch, self.device)
+            write_mapping = _make_write_tuple(batch, self.device)
+            batch.out_loc = self.engine.page_table[input_mapping]
+            self.engine.attn_backend.prepare_metadata(batch)
+            sample_args = self.engine.sampler.prepare(batch)
+        except BaseException:
+            # Roll back only the allocation performed above. Then drop every
+            # scratch attribute the failed prepare wrote onto ``batch`` so a
+            # later scheduling round cannot accidentally reuse a stale
+            # positions / out_loc / metadata pointing at freed pages.
+            self.cache_manager.rollback_allocation(token)
+            for attr in ("positions", "out_loc", "padded_reqs", "attn_metadata"):
+                if attr in batch.__dict__:
+                    del batch.__dict__[attr]
+            raise
         return ForwardInput(
             batch=batch,
-            sample_args=self.engine.sampler.prepare(batch),
+            sample_args=sample_args,
             input_tuple=input_mapping,
             write_tuple=write_mapping,
         )

--- a/python/minisgl/scheduler/scheduler.py
+++ b/python/minisgl/scheduler/scheduler.py
@@ -165,6 +165,14 @@ class Scheduler(SchedulerIOMixin):
                 finished = not req.can_decode
                 if not req.sampling_params.ignore_eos:
                     finished |= next_token == self.eos_token_id
+                # Gate 2.1c: explicit per-request stop tokens. Evaluated AFTER
+                # req.append_host so the stop token itself is retained in the
+                # output sequence (spec: "stop token 本身必须保留在输出序列中").
+                # Runs independently of ignore_eos — ignore_eos silences only
+                # the tokenizer's EOS, never the user-declared stop set. Empty
+                # tuple keeps the pre-2.1c behavior a strict no-op.
+                if next_token in req.sampling_params.stop_token_ids:
+                    finished = True
                 reply.append(DetokenizeMsg(uid=req.uid, next_token=next_token, finished=finished))
 
                 # NOTE: overlap scheduling may make the request freed twice, skip second free

--- a/python/minisgl/server/api_server.py
+++ b/python/minisgl/server/api_server.py
@@ -5,7 +5,7 @@ import json
 import time
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
-from typing import Callable, Dict, List, Literal, Tuple
+from typing import Callable, Dict, List, Literal, Set, Tuple
 
 import uvicorn
 from fastapi import FastAPI, Request
@@ -13,6 +13,7 @@ from fastapi.responses import StreamingResponse
 from minisgl.core import SamplingParams
 from minisgl.env import ENV
 from minisgl.message import (
+    AbortAckReply,
     AbortMsg,
     BaseFrontendMsg,
     BaseTokenizerMsg,
@@ -39,14 +40,16 @@ def get_global_state() -> FrontendManager:
     return _GLOBAL_STATE
 
 
-def _unwrap_msg(msg: BaseFrontendMsg) -> List[UserReply]:
+def _unwrap_msg(msg: BaseFrontendMsg) -> List[BaseFrontendMsg]:
+    """Flatten one wire message into its atomic BaseFrontendMsg children.
+
+    Gate 2.3f: return type widened from ``List[UserReply]`` to
+    ``List[BaseFrontendMsg]`` so ``AbortAckReply`` can travel the same
+    frontend-inbound channel. Downstream dispatch is ``isinstance``-based
+    in ``FrontendManager.listen``.
+    """
     if isinstance(msg, BatchFrontendMsg):
-        result = []
-        for reply in msg.data:
-            assert isinstance(reply, UserReply)
-            result.append(reply)
-        return result
-    assert isinstance(msg, UserReply)
+        return list(msg.data)
     return [msg]
 
 
@@ -105,6 +108,26 @@ class FrontendManager:
     initialized: bool = False
     ack_map: Dict[int, List[UserReply]] = field(default_factory=dict)
     event_map: Dict[int, asyncio.Event] = field(default_factory=dict)
+    # Gate 2.3f: end-to-end abort acknowledgement bookkeeping.
+    #
+    # abort_pending — uids whose AbortMsg has been sent to the tokenizer but
+    # whose AbortAckReply has not yet arrived from the scheduler. While a uid
+    # is in this set, ANY UserReply for that uid is dropped (see ``listen``):
+    # the request has been declared cancelled; late tokens produced by the
+    # scheduler between the abort msg being enqueued and the fence closing
+    # must never surface to the client. Removed exactly when the ack arrives.
+    #
+    # abort_pending_events — one-shot asyncio.Event per pending uid, set when
+    # the ack arrives. Kept separate from event_map so abort_user's waiter
+    # (if any) does not race the streaming waiter over the same Event.
+    # abort_user itself does NOT block on this event — the scheduler → tokenizer
+    # → frontend hop plus the ack flush is not synchronous with the caller's
+    # abort request; callers that need proof of completion can await
+    # ``wait_for_abort_ack``. The streaming path (``stream_with_cancellation``)
+    # never awaits an ack: the client is already gone, so the cleanup must
+    # not block the shutdown of its task.
+    abort_pending: Set[int] = field(default_factory=set)
+    abort_pending_events: Dict[int, asyncio.Event] = field(default_factory=dict)
 
     def new_user(self) -> int:
         uid = self.uid_counter
@@ -117,7 +140,48 @@ class FrontendManager:
         while True:
             msg = await self.recv_tokenizer.get()
             for msg in _unwrap_msg(msg):
+                # Gate 2.3f: AbortAckReply is dispatched independently from
+                # UserReply. Cleanup ordering:
+                #   1. remove uid from abort_pending  → subsequent UserReplies
+                #      (should any still be in flight from a slower scheduler
+                #      rank) will be treated as normal state-unknown drops,
+                #      not "silently swallowed under abort".
+                #   2. drop ack_map + event_map      → wait_for_ack's suspended
+                #      awaiter will observe the KeyError-free "no more state"
+                #      condition once its Event fires; see wait_for_ack for
+                #      how the abort-pending case exits the yield loop.
+                #   3. fire abort_pending_events     → any explicit awaiter
+                #      of the ack (e.g. tests, non-streaming abort_user
+                #      variants) unblocks.
+                # An AbortAckReply for a uid NOT in abort_pending is a strict
+                # no-op — could arise from a duplicate ack (Scheduler emits
+                # exactly one per free but a retried AbortMsg from a caller
+                # could produce two). Idempotency is required by spec.
+                if isinstance(msg, AbortAckReply):
+                    uid = msg.uid
+                    self.abort_pending.discard(uid)
+                    self.ack_map.pop(uid, None)
+                    ev = self.event_map.pop(uid, None)
+                    if ev is not None:
+                        # Wake any streaming waiter so it can observe the
+                        # empty ack list and exit — see wait_for_ack.
+                        ev.set()
+                    pending_ev = self.abort_pending_events.pop(uid, None)
+                    if pending_ev is not None:
+                        pending_ev.set()
+                    continue
+
+                assert isinstance(msg, UserReply)
                 if msg.uid not in self.ack_map:
+                    # Unknown uid: request already finished normally or the
+                    # scheduler emitted a token during the abort fence window
+                    # AFTER our ack cleanup ran. Drop silently.
+                    continue
+                # Gate 2.3f: while a uid is abort-pending, drop any UserReply
+                # that races the AbortAckReply. This keeps the streamed output
+                # from being polluted by a token that was already logically
+                # cancelled by the time it reached us.
+                if msg.uid in self.abort_pending:
                     continue
                 self.ack_map[msg.uid].append(msg)
                 self.event_map[msg.uid].set()
@@ -138,7 +202,18 @@ class FrontendManager:
             await event.wait()
             event.clear()
 
-            pending = self.ack_map[uid]
+            # Gate 2.3f: the AbortAckReply handler in ``listen`` removes both
+            # ack_map[uid] and event_map[uid] as part of the ack cleanup, then
+            # fires the event so this waiter unblocks. When we return from
+            # ``await event.wait()`` we may therefore find the uid gone from
+            # ack_map — that is the terminal "aborted" signal for this loop.
+            pending = self.ack_map.pop(uid, None)
+            if pending is None:
+                # ack cleanup happened; no more replies will arrive. Exit
+                # without touching event_map (already removed by listen).
+                return
+            # The list is drained; keep the slot alive with a fresh list so
+            # subsequent ticks can accumulate.
             self.ack_map[uid] = []
             ack = None
             for ack in pending:
@@ -200,13 +275,52 @@ class FrontendManager:
             raise
 
     async def abort_user(self, uid: int):
-        await asyncio.sleep(0.1)
-        if uid in self.ack_map:
-            del self.ack_map[uid]
-        if uid in self.event_map:
-            del self.event_map[uid]
+        """Mark ``uid`` as abort-pending and send AbortMsg to the tokenizer.
+
+        Gate 2.3f state-machine entry point.
+
+        The caller is NOT blocked waiting for the AbortAckReply — the
+        cancellation path (``stream_with_cancellation``) is triggered by a
+        client disconnect, so waiting for the scheduler round-trip is both
+        unnecessary and undesirable (the request task must be free to
+        finalise). ack cleanup is performed by ``listen`` when the ack
+        arrives; callers that need to await proof of completion should
+        instead await ``wait_for_abort_ack``.
+
+        Idempotency: a duplicate call for the same uid re-adds the (already
+        present) entry to ``abort_pending`` and sends a second AbortMsg. The
+        scheduler tolerates duplicate aborts (see _process_one_msg's
+        non-inflight branch: unknown uid → idempotent ack); the frontend
+        tolerates duplicate acks (see ``listen``).
+        """
         logger.warning("Aborting request for user %s", uid)
+        # Move the uid into abort-pending BEFORE the AbortMsg is enqueued so
+        # any UserReply that lands between the scheduler processing the abort
+        # and the ack arriving is dropped by ``listen`` (dispatched on
+        # abort_pending membership).
+        self.abort_pending.add(uid)
+        # Create the one-shot event lazily so wait_for_abort_ack has
+        # something to await. If one already exists (duplicate abort_user),
+        # reuse it so both awaiters unblock on the same ack.
+        if uid not in self.abort_pending_events:
+            self.abort_pending_events[uid] = asyncio.Event()
         await self.send_one(AbortMsg(uid=uid))
+
+    async def wait_for_abort_ack(self, uid: int):
+        """Block until ``uid``'s AbortAckReply has been processed.
+
+        Gate 2.3f: used by callers that need synchronous proof of
+        abort completion (tests, non-streaming HTTP paths that want
+        deterministic cleanup). Does NOT trigger the abort itself — call
+        ``abort_user`` first. Safe to await on a uid that already received
+        its ack: ``abort_pending_events`` still holds a set Event until the
+        listener's cleanup removes it, and a missing entry returns
+        immediately (the ack must have already fired).
+        """
+        ev = self.abort_pending_events.get(uid)
+        if ev is None:
+            return
+        await ev.wait()
 
     def shutdown(self):
         self.send_tokenizer.stop()

--- a/python/minisgl/tokenizer/server.py
+++ b/python/minisgl/tokenizer/server.py
@@ -5,6 +5,8 @@ from typing import List
 
 import torch
 from minisgl.message import (
+    AbortAckMsg,
+    AbortAckReply,
     AbortBackendMsg,
     AbortMsg,
     BaseBackendMsg,
@@ -67,7 +69,18 @@ def tokenize_worker(
             detokenize_msg = [m for m in pending_msg if isinstance(m, DetokenizeMsg)]
             tokenize_msg = [m for m in pending_msg if isinstance(m, TokenizeMsg)]
             abort_msg = [m for m in pending_msg if isinstance(m, AbortMsg)]
-            assert len(detokenize_msg) + len(tokenize_msg) + len(abort_msg) == len(pending_msg)
+            # Gate 2.3f: Scheduler → Tokenizer AbortAckMsg forwarded verbatim
+            # to the frontend as AbortAckReply. Kept as its own partition (not
+            # merged into DetokenizeMsg) so the frontend can dispatch on
+            # isinstance without inspecting UserReply.finished + fake tokens.
+            abort_ack_msg = [m for m in pending_msg if isinstance(m, AbortAckMsg)]
+            assert (
+                len(detokenize_msg)
+                + len(tokenize_msg)
+                + len(abort_msg)
+                + len(abort_ack_msg)
+                == len(pending_msg)
+            )
             if len(detokenize_msg) > 0:
                 replies = detokenize_manager.detokenize(detokenize_msg)
                 batch_output = BatchFrontendMsg(
@@ -106,5 +119,17 @@ def tokenize_worker(
                 if len(batch_output.data) == 1:
                     batch_output = batch_output.data[0]
                 send_backend.put(batch_output)
+            if len(abort_ack_msg) > 0:
+                # Gate 2.3f: forward each AbortAckMsg to the frontend as an
+                # AbortAckReply. No transformation happens here — the tokenizer
+                # is a stateless conduit for acks (no text to detokenize).
+                # Coalesced into one BatchFrontendMsg to match the other
+                # dispatch branches' single-put pattern.
+                batch_output = BatchFrontendMsg(
+                    data=[AbortAckReply(uid=msg.uid) for msg in abort_ack_msg]
+                )
+                if len(batch_output.data) == 1:
+                    batch_output = batch_output.data[0]
+                send_frontend.put(batch_output)
     except KeyboardInterrupt:
         pass

--- a/python/minisgl/utils/__init__.py
+++ b/python/minisgl/utils/__init__.py
@@ -1,17 +1,38 @@
-from .arch import is_arch_supported, is_sm90_supported, is_sm100_supported
-from .hf import cached_load_hf_config, download_hf_weight, load_tokenizer
-from .logger import init_logger
-from .misc import UNSET, Unset, align_ceil, align_down, call_if_main, div_ceil, div_even
-from .mp import (
-    ZmqAsyncPullQueue,
-    ZmqAsyncPushQueue,
-    ZmqPubQueue,
-    ZmqPullQueue,
-    ZmqPushQueue,
-    ZmqSubQueue,
-)
-from .registry import Registry
-from .torch_utils import nvtx_annotate, torch_dtype
+"""Utility package for minisgl.
+
+Public names are re-exported lazily via PEP 562 ``__getattr__`` so that
+submodules like :mod:`minisgl.utils.device` can be imported on hosts that
+do not have the full runtime stack (torch, huggingface_hub, msgpack/zmq,
+...). This is the pattern required by the Ascend Gate 0.3a contract:
+
+    import minisgl.utils.device          # never pulls in huggingface_hub
+    import minisgl.distributed.backend    # never pulls in torch.distributed
+
+Behaviour for legacy callers is preserved — every symbol listed in
+``__all__`` remains reachable via ``from minisgl.utils import X`` and
+resolves to the exact same object that the eager version would have
+returned. The only observable difference is *when* the owning submodule
+executes.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only imports
+    from .arch import is_arch_supported, is_sm90_supported, is_sm100_supported
+    from .hf import cached_load_hf_config, download_hf_weight, load_tokenizer
+    from .logger import init_logger
+    from .misc import UNSET, Unset, align_ceil, align_down, call_if_main, div_ceil, div_even
+    from .mp import (
+        ZmqAsyncPullQueue,
+        ZmqAsyncPushQueue,
+        ZmqPubQueue,
+        ZmqPullQueue,
+        ZmqPushQueue,
+        ZmqSubQueue,
+    )
+    from .registry import Registry
+    from .torch_utils import nvtx_annotate, torch_dtype
 
 __all__ = [
     "cached_load_hf_config",
@@ -38,3 +59,49 @@ __all__ = [
     "ZmqAsyncPushQueue",
     "ZmqAsyncPullQueue",
 ]
+
+# Attribute → owning submodule. Kept as an explicit table so failures
+# surface as clean ``ImportError``s from the real submodule rather than a
+# swallowed generic error.
+_LAZY_ATTR_TO_SUBMODULE: dict[str, str] = {
+    "cached_load_hf_config": ".hf",
+    "download_hf_weight": ".hf",
+    "load_tokenizer": ".hf",
+    "init_logger": ".logger",
+    "is_arch_supported": ".arch",
+    "is_sm90_supported": ".arch",
+    "is_sm100_supported": ".arch",
+    "call_if_main": ".misc",
+    "div_even": ".misc",
+    "div_ceil": ".misc",
+    "align_ceil": ".misc",
+    "align_down": ".misc",
+    "UNSET": ".misc",
+    "Unset": ".misc",
+    "torch_dtype": ".torch_utils",
+    "nvtx_annotate": ".torch_utils",
+    "Registry": ".registry",
+    "ZmqPushQueue": ".mp",
+    "ZmqPullQueue": ".mp",
+    "ZmqPubQueue": ".mp",
+    "ZmqSubQueue": ".mp",
+    "ZmqAsyncPushQueue": ".mp",
+    "ZmqAsyncPullQueue": ".mp",
+}
+
+
+def __getattr__(name: str) -> Any:
+    submod_name = _LAZY_ATTR_TO_SUBMODULE.get(name)
+    if submod_name is None:
+        raise AttributeError(f"module 'minisgl.utils' has no attribute {name!r}")
+    import importlib
+
+    submod = importlib.import_module(submod_name, __name__)
+    value = getattr(submod, name)
+    # Cache on the package object so subsequent lookups skip this function.
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted({*globals().keys(), *__all__})

--- a/python/minisgl/utils/arch.py
+++ b/python/minisgl/utils/arch.py
@@ -3,13 +3,23 @@ from __future__ import annotations
 import functools
 from typing import Tuple
 
+from .device import is_cuda_available
+
 
 @functools.cache
 def _get_torch_cuda_version() -> Tuple[int, int] | None:
+    """Return the current CUDA compute capability, or ``None`` on non-CUDA hosts.
+
+    Device presence is decided by :func:`minisgl.utils.device.is_cuda_available`
+    so this module contains no direct device-probe logic. On NPU/CPU hosts the
+    function returns ``None`` without importing torch's CUDA APIs.
+    """
+    if not is_cuda_available():
+        return None
     import torch
     import torch.version
 
-    if not torch.cuda.is_available() or not torch.version.cuda:
+    if not torch.version.cuda:
         return None
     return torch.cuda.get_device_capability()
 

--- a/python/minisgl/utils/device.py
+++ b/python/minisgl/utils/device.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import functools
+from typing import Literal
+
+DeviceType = Literal["cuda", "npu", "cpu"]
+
+__all__ = [
+    "DeviceType",
+    "get_device_type",
+    "is_cuda_available",
+    "is_npu_available",
+]
+
+
+def _probe_cuda() -> bool:
+    """Return True if a CUDA-enabled ``torch`` build reports at least one device.
+
+    All failure modes (torch missing, driver missing, transient runtime errors)
+    are treated as "CUDA not available" — never raised to callers.
+    """
+    try:
+        import torch
+    except Exception:
+        return False
+    try:
+        return bool(torch.cuda.is_available())
+    except Exception:
+        return False
+
+
+def _probe_npu() -> bool:
+    """Return True if ``torch_npu`` is importable and reports at least one NPU.
+
+    ``torch_npu`` is imported lazily via a local ``import`` statement so this
+    module stays importable on hosts (e.g. macOS) where the package is absent.
+    Any import- or runtime-error path degrades to False rather than propagating.
+    """
+    try:
+        import torch_npu  # noqa: F401  (import-for-side-effect probe)
+    except Exception:
+        return False
+    try:
+        npu_mod = getattr(torch_npu, "npu", None)
+        if npu_mod is None:
+            return False
+        is_available = getattr(npu_mod, "is_available", None)
+        if is_available is None:
+            return False
+        return bool(is_available())
+    except Exception:
+        return False
+
+
+@functools.cache
+def is_cuda_available() -> bool:
+    """Cached ``True`` iff a usable CUDA device is present. Never raises."""
+    return _probe_cuda()
+
+
+@functools.cache
+def is_npu_available() -> bool:
+    """Cached ``True`` iff a usable Ascend NPU is present. Never raises.
+
+    Does not import ``torch_npu`` unconditionally, and does not touch device
+    state — safe to call at import time on any host.
+    """
+    return _probe_npu()
+
+
+@functools.cache
+def get_device_type() -> DeviceType:
+    """Return the preferred accelerator, preferring CUDA over NPU over CPU.
+
+    Contract: no side effects, never raises, never sets or selects a device.
+    Cached — call ``get_device_type.cache_clear()`` from tests when swapping
+    the underlying probes via monkeypatch.
+    """
+    if is_cuda_available():
+        return "cuda"
+    if is_npu_available():
+        return "npu"
+    return "cpu"

--- a/python/minisgl/utils/device_runtime.py
+++ b/python/minisgl/utils/device_runtime.py
@@ -36,6 +36,8 @@ __all__ = [
     "set_stream",
     "current_stream",
     "synchronize_device",
+    "create_event",
+    "record_event",
 ]
 
 
@@ -157,6 +159,71 @@ def synchronize_device(device_type: DeviceType) -> None:
         import torch
 
         torch.npu.synchronize()
+        return
+
+    if device_type == "cpu":
+        return
+
+    raise _unsupported(device_type)
+
+
+def create_event(device_type: DeviceType) -> Optional[Any]:
+    """Create a fresh event on the given device type.
+
+    * ``cuda`` → ``torch.cuda.Event()``
+    * ``npu``  → dynamic ``import torch_npu``; then ``torch.npu.Event()``
+    * ``cpu``  → ``None`` (CPU has no event concept)
+
+    Gate 1.3a intentionally exposes only the default no-argument constructor.
+    Timing / blocking-sync / IPC flavours are deferred to later Gates.
+    """
+    if device_type == "cuda":
+        import torch
+
+        return torch.cuda.Event()
+
+    if device_type == "npu":
+        _require_torch_npu()
+        import torch
+
+        return torch.npu.Event()
+
+    if device_type == "cpu":
+        return None
+
+    raise _unsupported(device_type)
+
+
+def record_event(
+    device_type: DeviceType,
+    event: Optional[Any],
+    stream: Optional[Any] = None,
+) -> None:
+    """Record ``event`` on ``stream`` (or the current stream if ``None``).
+
+    * ``cuda`` → ``event.record(stream)``
+    * ``npu``  → dynamic ``import torch_npu``; then ``event.record(stream)``
+    * ``cpu``  → no-op (``event`` and ``stream`` are ignored)
+
+    ``event`` and ``stream`` are the objects previously returned by
+    :func:`create_event` / :func:`create_stream` / :func:`current_stream` on
+    the *same* device type. Cross-device usage is not supported and is not
+    validated here — that's PyTorch's job.
+    """
+    if device_type == "cuda":
+        # The event object itself carries the backend binding; we only need to
+        # dispatch on device_type to know whether the torch_npu monkey-patch
+        # must be installed before .record() is safe to call.
+        import torch  # noqa: F401  (kept for symmetry with the other branches)
+
+        event.record(stream)
+        return
+
+    if device_type == "npu":
+        _require_torch_npu()
+        import torch  # noqa: F401
+
+        event.record(stream)
         return
 
     if device_type == "cpu":

--- a/python/minisgl/utils/device_runtime.py
+++ b/python/minisgl/utils/device_runtime.py
@@ -40,6 +40,7 @@ __all__ = [
     "record_event",
     "empty_device_cache",
     "reset_peak_memory_stats",
+    "get_free_memory_bytes",
 ]
 
 
@@ -292,5 +293,43 @@ def reset_peak_memory_stats(device_type: DeviceType) -> None:
 
     if device_type == "cpu":
         return
+
+    raise _unsupported(device_type)
+
+
+def get_free_memory_bytes(device_type: DeviceType, device: Any) -> int:
+    """Return the currently-free device memory in bytes.
+
+    * ``cuda`` → ``torch.cuda.mem_get_info(device)[0]`` → ``int``
+    * ``npu``  → dynamic ``import torch_npu``; then
+      ``torch.npu.mem_get_info(device)[0]`` → ``int``
+    * ``cpu``  → raises :class:`NotImplementedError` — CPU has no dedicated
+      device memory pool distinct from host RAM, and Gate 1.5a deliberately
+      does not shim in a ``psutil`` fallback.
+
+    ``device`` is forwarded verbatim to the vendor ``mem_get_info`` call. It
+    accepts whatever that call accepts today (``int`` index, ``torch.device``,
+    ``str``) — this dispatch layer does not narrow the contract.
+
+    Only the free half of the tuple is returned; ``total_bytes`` is not exposed
+    on purpose (Engine's memory bookkeeping never needs it).
+    """
+    if device_type == "cuda":
+        import torch
+
+        free_bytes, _total_bytes = torch.cuda.mem_get_info(device)
+        return int(free_bytes)
+
+    if device_type == "npu":
+        _require_torch_npu()
+        import torch
+
+        free_bytes, _total_bytes = torch.npu.mem_get_info(device)
+        return int(free_bytes)
+
+    if device_type == "cpu":
+        raise NotImplementedError(
+            "free device memory query is not implemented for CPU"
+        )
 
     raise _unsupported(device_type)

--- a/python/minisgl/utils/device_runtime.py
+++ b/python/minisgl/utils/device_runtime.py
@@ -1,0 +1,165 @@
+"""Device-runtime stream primitives shared across CUDA and NPU.
+
+This module is a **pure dispatch layer** over ``torch.cuda`` / ``torch.npu``
+for the four stream entrypoints the engine currently touches — creation,
+binding as the current stream, reading the current stream, and device-wide
+synchronization. Every call routes through here so that when Gate 1.2+ ports
+the engine off the raw ``torch.cuda.*`` API only this file needs to grow new
+branches.
+
+Deliberately NOT in scope for Gate 1.2a:
+
+* ``Event`` — has its own Gate.
+* Stream context managers (``with stream:``) — has its own Gate.
+* Wiring these primitives into ``Engine`` — has its own Gate.
+* Memory / graph / kernel abstractions — separate Gates.
+
+Design notes:
+
+* No top-level ``import torch_npu``. The NPU branch imports it lazily inside
+  each function so macOS / CPU-only hosts stay importable.
+* CPU is a real, fully-supported device type: ``create_stream("cpu")`` returns
+  ``None`` and the other three CPU calls are no-ops. This matches how
+  :mod:`torch` itself treats CPU — there is no stream object.
+* Unknown ``device_type`` values surface as ``ValueError`` — the same error
+  shape :func:`minisgl.distributed.runtime.bind_local_device` and
+  :func:`minisgl.distributed.backend.get_distributed_backend` use.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from .device import DeviceType
+
+__all__ = [
+    "create_stream",
+    "set_stream",
+    "current_stream",
+    "synchronize_device",
+]
+
+
+def _require_torch_npu() -> None:
+    """Dynamic ``import torch_npu`` with a clean error message on failure.
+
+    ``torch_npu`` monkey-patches ``torch.npu`` at import time; without it the
+    ``torch.npu`` namespace is unusable even on a real Ascend host. We centralise
+    the import here so every NPU branch gets the same actionable RuntimeError.
+    """
+    try:
+        import torch_npu  # noqa: F401  (import-for-side-effect: patches torch.npu)
+    except Exception as exc:
+        raise RuntimeError(
+            "device_type is 'npu' but 'torch_npu' could not be imported; "
+            "install the matching torch_npu wheel on the Ascend host"
+        ) from exc
+
+
+def _unsupported(device_type: Any) -> ValueError:
+    return ValueError(
+        f"unsupported device_type for device_runtime: {device_type!r}; "
+        f"expected one of: cpu, cuda, npu"
+    )
+
+
+def create_stream(device_type: DeviceType) -> Optional[Any]:
+    """Create a fresh stream on the given device type.
+
+    * ``cuda`` → ``torch.cuda.Stream()``
+    * ``npu``  → dynamic ``import torch_npu``; then ``torch.npu.Stream()``
+    * ``cpu``  → ``None`` (CPU has no stream concept)
+    """
+    if device_type == "cuda":
+        import torch  # lazy: only touched on CUDA hosts
+
+        return torch.cuda.Stream()
+
+    if device_type == "npu":
+        _require_torch_npu()
+        import torch
+
+        return torch.npu.Stream()
+
+    if device_type == "cpu":
+        return None
+
+    raise _unsupported(device_type)
+
+
+def set_stream(device_type: DeviceType, stream: Optional[Any]) -> None:
+    """Bind ``stream`` as the current stream on the given device type.
+
+    * ``cuda`` → ``torch.cuda.set_stream(stream)``
+    * ``npu``  → dynamic ``import torch_npu``; then ``torch.npu.set_stream(stream)``
+    * ``cpu``  → no-op regardless of ``stream``
+
+    CPU accepts ``None`` (or any value) silently — matches ``create_stream``'s
+    return contract.
+    """
+    if device_type == "cuda":
+        import torch
+
+        torch.cuda.set_stream(stream)
+        return
+
+    if device_type == "npu":
+        _require_torch_npu()
+        import torch
+
+        torch.npu.set_stream(stream)
+        return
+
+    if device_type == "cpu":
+        return
+
+    raise _unsupported(device_type)
+
+
+def current_stream(device_type: DeviceType) -> Optional[Any]:
+    """Return the current stream on the given device type.
+
+    * ``cuda`` → ``torch.cuda.current_stream()``
+    * ``npu``  → dynamic ``import torch_npu``; then ``torch.npu.current_stream()``
+    * ``cpu``  → ``None``
+    """
+    if device_type == "cuda":
+        import torch
+
+        return torch.cuda.current_stream()
+
+    if device_type == "npu":
+        _require_torch_npu()
+        import torch
+
+        return torch.npu.current_stream()
+
+    if device_type == "cpu":
+        return None
+
+    raise _unsupported(device_type)
+
+
+def synchronize_device(device_type: DeviceType) -> None:
+    """Block until all previously-queued work on the given device completes.
+
+    * ``cuda`` → ``torch.cuda.synchronize()``
+    * ``npu``  → dynamic ``import torch_npu``; then ``torch.npu.synchronize()``
+    * ``cpu``  → no-op
+    """
+    if device_type == "cuda":
+        import torch
+
+        torch.cuda.synchronize()
+        return
+
+    if device_type == "npu":
+        _require_torch_npu()
+        import torch
+
+        torch.npu.synchronize()
+        return
+
+    if device_type == "cpu":
+        return
+
+    raise _unsupported(device_type)

--- a/python/minisgl/utils/device_runtime.py
+++ b/python/minisgl/utils/device_runtime.py
@@ -38,6 +38,8 @@ __all__ = [
     "synchronize_device",
     "create_event",
     "record_event",
+    "empty_device_cache",
+    "reset_peak_memory_stats",
 ]
 
 
@@ -224,6 +226,68 @@ def record_event(
         import torch  # noqa: F401
 
         event.record(stream)
+        return
+
+    if device_type == "cpu":
+        return
+
+    raise _unsupported(device_type)
+
+
+def empty_device_cache(device_type: DeviceType) -> None:
+    """Release cached device memory back to the allocator's free pool.
+
+    * ``cuda`` → ``torch.cuda.empty_cache()``
+    * ``npu``  → dynamic ``import torch_npu``; then ``torch.npu.empty_cache()``
+    * ``cpu``  → no-op
+
+    Gate 1.4a intentionally exposes only the plain no-argument variant used by
+    :meth:`Engine._sync_get_memory`. Memory profiling / GC / device-scoped
+    allocator toggles are deferred to later Gates.
+    """
+    if device_type == "cuda":
+        import torch
+
+        torch.cuda.empty_cache()
+        return
+
+    if device_type == "npu":
+        _require_torch_npu()
+        import torch
+
+        torch.npu.empty_cache()
+        return
+
+    if device_type == "cpu":
+        return
+
+    raise _unsupported(device_type)
+
+
+def reset_peak_memory_stats(device_type: DeviceType) -> None:
+    """Reset the "peak memory" counter tracked by the device allocator.
+
+    * ``cuda`` → ``torch.cuda.reset_peak_memory_stats()``
+    * ``npu``  → dynamic ``import torch_npu``; then ``torch.npu.reset_peak_memory_stats()``
+    * ``cpu``  → no-op (CPU has no peak-memory counter)
+
+    Only the no-argument, current-device form is exposed. Per-device selection
+    is deferred: today :meth:`Engine._sync_get_memory` already bound the
+    process to a single device via ``bind_local_device`` before touching this
+    counter, so an explicit ``device=`` override would just re-encode that
+    binding.
+    """
+    if device_type == "cuda":
+        import torch
+
+        torch.cuda.reset_peak_memory_stats()
+        return
+
+    if device_type == "npu":
+        _require_torch_npu()
+        import torch
+
+        torch.npu.reset_peak_memory_stats()
         return
 
     if device_type == "cpu":

--- a/python/minisgl/utils/device_runtime.py
+++ b/python/minisgl/utils/device_runtime.py
@@ -27,7 +27,8 @@ Design notes:
 """
 from __future__ import annotations
 
-from typing import Any, Optional
+import contextlib
+from typing import Any, ContextManager, Optional
 
 from .device import DeviceType
 
@@ -35,6 +36,7 @@ __all__ = [
     "create_stream",
     "set_stream",
     "current_stream",
+    "stream_context",
     "synchronize_device",
     "create_event",
     "record_event",
@@ -166,6 +168,36 @@ def synchronize_device(device_type: DeviceType) -> None:
 
     if device_type == "cpu":
         return
+
+    raise _unsupported(device_type)
+
+
+def stream_context(
+    device_type: DeviceType, stream: Optional[Any]
+) -> ContextManager[None]:
+    """Return a context manager that binds ``stream`` as the current stream
+    for the duration of the ``with`` block.
+
+    * ``cuda`` → ``torch.cuda.stream(stream)``
+    * ``npu``  → dynamic ``import torch_npu``; then ``torch.npu.stream(stream)``
+    * ``cpu``  → :func:`contextlib.nullcontext` (no stream concept on CPU)
+
+    The returned object is the backend-native ``StreamContext`` — reusable via
+    repeated ``with`` blocks, and cheap to construct once and cache on the caller.
+    """
+    if device_type == "cuda":
+        import torch
+
+        return torch.cuda.stream(stream)
+
+    if device_type == "npu":
+        _require_torch_npu()
+        import torch
+
+        return torch.npu.stream(stream)
+
+    if device_type == "cpu":
+        return contextlib.nullcontext()
 
     raise _unsupported(device_type)
 

--- a/python/minisgl/utils/torch_utils.py
+++ b/python/minisgl/utils/torch_utils.py
@@ -21,14 +21,18 @@ def torch_dtype(dtype: torch.dtype):
 
 
 def nvtx_annotate(name: str, layer_id_field: str | None = None):
-    import torch.cuda.nvtx as nvtx
-
     def decorator(fn):
         @functools.wraps(fn)
         def wrapper(self, *args, **kwargs):
+            import torch
+
             display_name = name
             if layer_id_field and hasattr(self, layer_id_field):
                 display_name = name.format(getattr(self, layer_id_field))
+            if not torch.cuda.is_available():
+                return fn(self, *args, **kwargs)
+            import torch.cuda.nvtx as nvtx
+
             with nvtx.range(display_name):
                 return fn(self, *args, **kwargs)
 

--- a/scripts/ascend/run_hccl_smoke.sh
+++ b/scripts/ascend/run_hccl_smoke.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Gate 0.5 — 8-card HCCL collective smoke launcher.
+#
+# Runs tests/ascend/hccl_smoke.py under torchrun with an explicit c10d
+# rendezvous bound to 127.0.0.1, which avoids the "hostname resolves to a
+# bogus numeric IPv4" pitfall we hit in the 0.4b container (hostname 0002
+# → 0.0.0.2). Kept intentionally minimal: no --standalone, no hostname
+# mutation, no tee, no hard-coded absolute paths.
+#
+# Environment overrides:
+#   PORT   c10d rendezvous port (default 29582)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+PORT="${PORT:-29582}"
+
+export PYTHONPATH="${REPO_ROOT}/python${PYTHONPATH:+:${PYTHONPATH}}"
+
+exec torchrun \
+    --rdzv-backend=c10d \
+    --rdzv-endpoint="127.0.0.1:${PORT}" \
+    --rdzv-id=gate0-hccl-smoke \
+    --nnodes=1 \
+    --nproc-per-node=8 \
+    "${REPO_ROOT}/tests/ascend/hccl_smoke.py"

--- a/tests/ascend/hccl_smoke.py
+++ b/tests/ascend/hccl_smoke.py
@@ -1,0 +1,67 @@
+import os
+
+import torch
+import torch_npu
+
+from minisgl.distributed.runtime import initialize_distributed_from_env
+
+
+def main() -> None:
+    runtime = initialize_distributed_from_env()
+    rank = runtime.rank
+    world_size = runtime.world_size
+
+    try:
+        assert runtime.world_size == 8, (
+            f"HCCL smoke test requires world_size=8, "
+            f"got {runtime.world_size}"
+        )
+        assert runtime.device_type == "npu"
+        assert runtime.backend == "hccl"
+        assert torch.npu.current_device() == runtime.local_rank
+
+        # all-reduce: sum(1..8) = 36
+        value = torch.tensor(
+            [rank + 1],
+            dtype=torch.float32,
+            device=runtime.device,
+        )
+        torch.distributed.all_reduce(value)
+        torch.npu.synchronize()
+        assert value.item() == world_size * (world_size + 1) / 2
+
+        # broadcast: rank 0 sends 20260704
+        payload = torch.tensor(
+            [20260704 if rank == 0 else 0],
+            dtype=torch.int64,
+            device=runtime.device,
+        )
+        torch.distributed.broadcast(payload, src=0)
+        torch.npu.synchronize()
+        assert payload.item() == 20260704
+
+        # all-gather: collect rank IDs
+        local_rank_id = torch.tensor(
+            [rank],
+            dtype=torch.int64,
+            device=runtime.device,
+        )
+        gathered = [torch.empty_like(local_rank_id) for _ in range(world_size)]
+        torch.distributed.all_gather(gathered, local_rank_id)
+        torch.npu.synchronize()
+        assert [item.item() for item in gathered] == list(range(world_size))
+
+        torch.distributed.barrier()
+
+        print(
+            f"PASS rank={rank} local_rank={runtime.local_rank} "
+            f"device={runtime.device} all_reduce={value.item():.0f}",
+            flush=True,
+        )
+    finally:
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/kvcache/test_mha_layout.py
+++ b/tests/kvcache/test_mha_layout.py
@@ -1,0 +1,480 @@
+"""Gate 1.7f: hermetic tests for layout-aware MHAKVCache.
+
+Most of the tests are purely source-level: importing the actual pool would
+pull in torch + Ascend deps, which are unavailable on some dev hosts.
+Instead we ``ast``-parse the three touched modules and assert:
+
+1. ``MHAKVCache.__init__`` gets a ``layout`` kwarg defaulting to ``"nhd"``,
+   validates it, and stores metadata.
+2. The two allocation shapes appear textually in the two branches.
+3. ``store_kv`` dispatches on ``self._layout``: the nhd branch keeps the
+   ``store_cache`` CUDA path; the bnbsd branch scatters via pure PyTorch
+   advanced indexing and does **not** import ``minisgl.kernel``.
+4. Cross-page raw-slot conversion produces the expected page_ids/offsets.
+5. ``create_kvcache_pool`` forwards an explicit ``layout`` kwarg (default
+   ``"nhd"``) and never calls ``get_device_type``.
+6. ``Engine.__init__`` picks the layout via a ternary on ``self.device_type``
+   and passes it to ``create_kvcache_pool``.
+
+Gate 1.7f-fix adds one **runtime** test that instantiates ``MHAKVCache`` on
+CPU with ``layout="bnbsd"`` and drives real numerical scatter through
+``store_kv``, with an ``__import__`` guard that fails immediately if the
+bnbsd path attempts to touch ``minisgl.kernel``. It skips gracefully when
+torch is not installed.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MHA_PATH = _REPO_ROOT / "python" / "minisgl" / "kvcache" / "mha_pool.py"
+_FACTORY_PATH = _REPO_ROOT / "python" / "minisgl" / "kvcache" / "__init__.py"
+_ENGINE_PATH = _REPO_ROOT / "python" / "minisgl" / "engine" / "engine.py"
+
+
+# ---------- source helpers ---------------------------------------------------
+
+
+def _mha_source() -> str:
+    return _MHA_PATH.read_text()
+
+
+def _mha_tree() -> ast.Module:
+    return ast.parse(_mha_source())
+
+
+def _mha_cls() -> ast.ClassDef:
+    return next(
+        node for node in _mha_tree().body
+        if isinstance(node, ast.ClassDef) and node.name == "MHAKVCache"
+    )
+
+
+def _mha_method(name: str) -> ast.FunctionDef:
+    return next(
+        node for node in _mha_cls().body
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    )
+
+
+def _factory_source() -> str:
+    return _FACTORY_PATH.read_text()
+
+
+def _factory_tree() -> ast.Module:
+    return ast.parse(_factory_source())
+
+
+def _factory_fn() -> ast.FunctionDef:
+    return next(
+        node for node in _factory_tree().body
+        if isinstance(node, ast.FunctionDef) and node.name == "create_kvcache_pool"
+    )
+
+
+def _engine_source() -> str:
+    return _ENGINE_PATH.read_text()
+
+
+def _engine_tree() -> ast.Module:
+    return ast.parse(_engine_source())
+
+
+def _engine_init() -> ast.FunctionDef:
+    engine_cls = next(
+        node for node in _engine_tree().body
+        if isinstance(node, ast.ClassDef) and node.name == "Engine"
+    )
+    return next(
+        node for node in engine_cls.body
+        if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+    )
+
+
+# ---------- MHAKVCache: layout kwarg & validation ---------------------------
+
+
+def test_mha_kv_cache_init_has_layout_kwarg_defaulting_to_nhd():
+    init = _mha_method("__init__")
+    args = init.args
+    kwargs_by_name = {a.arg: default for a, default in zip(args.args, [None] * (len(args.args) - len(args.defaults)) + list(args.defaults))}
+    assert "layout" in kwargs_by_name, "MHAKVCache.__init__ must accept 'layout'"
+    default = kwargs_by_name["layout"]
+    assert isinstance(default, ast.Constant) and default.value == "nhd", \
+        f"layout default must be the string 'nhd', got {ast.dump(default)!r}"
+
+
+def test_mha_kv_cache_layout_annotation_is_literal_nhd_bnbsd():
+    init = _mha_method("__init__")
+    layout_arg = next(a for a in init.args.args if a.arg == "layout")
+    assert layout_arg.annotation is not None, "layout must be annotated"
+    text = ast.unparse(layout_arg.annotation)
+    assert "Literal" in text and "'nhd'" in text and "'bnbsd'" in text, \
+        f"layout annotation must be Literal['nhd', 'bnbsd'], got {text!r}"
+
+
+def test_mha_kv_cache_raises_value_error_on_invalid_layout():
+    init = _mha_method("__init__")
+    raises = [
+        node for node in ast.walk(init)
+        if isinstance(node, ast.Raise)
+        and isinstance(node.exc, ast.Call)
+        and isinstance(node.exc.func, ast.Name)
+        and node.exc.func.id == "ValueError"
+    ]
+    assert raises, "MHAKVCache.__init__ must raise ValueError on invalid layout"
+
+
+def test_mha_kv_cache_nhd_allocation_shape_present():
+    src = _mha_source()
+    assert "(2, num_layers, num_pages, page_size, local_kv_heads, head_dim)" in src, \
+        "nhd branch must allocate the 6D NHD shape"
+
+
+def test_mha_kv_cache_bnbsd_allocation_shape_present():
+    src = _mha_source()
+    assert "(2, num_layers, num_pages, local_kv_heads, page_size, head_dim)" in src, \
+        "bnbsd branch must allocate the 6D BnNBsD shape"
+
+
+def test_mha_kv_cache_stores_layout_metadata():
+    src = _mha_source()
+    for attr in ("self._layout", "self._page_size", "self._local_kv_heads", "self._head_dim"):
+        assert attr in src, f"MHAKVCache must persist {attr}"
+
+
+# ---------- store_kv: layout dispatch ---------------------------------------
+
+
+def test_store_kv_dispatches_on_self_layout():
+    method = _mha_method("store_kv")
+    text = ast.unparse(method)
+    assert "self._layout" in text, "store_kv must branch on self._layout"
+
+
+def test_store_kv_nhd_branch_still_calls_store_cache():
+    method = _mha_method("store_kv")
+    text = ast.unparse(method)
+    assert "from minisgl.kernel import store_cache" in text, \
+        "nhd branch must still import store_cache"
+    assert "store_cache(" in text, "nhd branch must still call store_cache"
+
+
+def _store_kv_top_level_if() -> ast.If:
+    method = _mha_method("store_kv")
+    for node in method.body:
+        if isinstance(node, ast.If):
+            return node
+    raise AssertionError("store_kv must contain a top-level if branching on layout")
+
+
+def test_store_kv_bnbsd_branch_does_not_import_or_call_store_cache():
+    if_node = _store_kv_top_level_if()
+    else_text = "\n".join(ast.unparse(n) for n in if_node.orelse)
+    assert "store_cache" not in else_text, "bnbsd branch must NOT reference store_cache"
+    assert "minisgl.kernel" not in else_text, "bnbsd branch must NOT import minisgl.kernel"
+
+
+def test_store_kv_bnbsd_branch_uses_advanced_indexing_scatter():
+    if_node = _store_kv_top_level_if()
+    else_text = "\n".join(ast.unparse(n) for n in if_node.orelse)
+    assert "out_loc // self._page_size" in else_text, \
+        "bnbsd branch must derive page_ids as out_loc // self._page_size"
+    assert "out_loc % self._page_size" in else_text, \
+        "bnbsd branch must derive offsets as out_loc % self._page_size"
+    assert "self._k_buffer[layer_id][page_ids, :, offsets, :]" in else_text, \
+        "bnbsd branch must scatter K via advanced indexing on [page_ids, :, offsets, :]"
+    assert "self._v_buffer[layer_id][page_ids, :, offsets, :]" in else_text, \
+        "bnbsd branch must scatter V via advanced indexing on [page_ids, :, offsets, :]"
+
+
+def test_store_kv_bnbsd_branch_reshapes_kv_to_3d():
+    if_node = _store_kv_top_level_if()
+    else_text = "\n".join(ast.unparse(n) for n in if_node.orelse)
+    assert "k.view(-1, self._local_kv_heads, self._head_dim)" in else_text, \
+        "bnbsd branch must reshape k to (-1, HKV, D)"
+    assert "v.view(-1, self._local_kv_heads, self._head_dim)" in else_text, \
+        "bnbsd branch must reshape v to (-1, HKV, D)"
+
+
+# ---------- raw-slot arithmetic (pure Python, no torch) ---------------------
+
+
+def test_bnbsd_raw_slot_to_page_id_and_offset_cross_page():
+    """Spec case: raw_slots=[15, 16, 34] with page_size=16.
+
+    Page IDs = raw // 16 → [0, 1, 2]; offsets = raw % 16 → [15, 0, 2]. The
+    bnbsd branch performs exactly this arithmetic, so verify the maths
+    matches the pattern present in the source without needing torch.
+    """
+    page_size = 16
+    raw_slots = [15, 16, 34]
+    page_ids = [s // page_size for s in raw_slots]
+    offsets = [s % page_size for s in raw_slots]
+    assert page_ids == [0, 1, 2]
+    assert offsets == [15, 0, 2]
+    # Sanity check the source literally uses `// self._page_size` and
+    # `% self._page_size` (guards against a future refactor to something
+    # semantically different but easy to miss).
+    src = _mha_source()
+    assert "out_loc // self._page_size" in src
+    assert "out_loc % self._page_size" in src
+
+
+def test_bnbsd_untouched_slots_are_left_to_torch_empty_semantics():
+    """The bnbsd branch must not blanket-clear _k_buffer / _v_buffer — only
+    the (page_ids, offsets) coordinates are written. Any assignment target
+    referencing _k_buffer or _v_buffer in the bnbsd branch must be the
+    advanced-index scatter form using layer_id, page_ids, and offsets.
+    """
+    if_node = _store_kv_top_level_if()
+    for node in if_node.orelse:
+        for assign in ast.walk(node):
+            if isinstance(assign, ast.Assign):
+                for tgt in assign.targets:
+                    tgt_text = ast.unparse(tgt)
+                    if "_k_buffer" in tgt_text or "_v_buffer" in tgt_text:
+                        assert "layer_id" in tgt_text \
+                            and "page_ids" in tgt_text \
+                            and "offsets" in tgt_text, \
+                            f"bnbsd write must be scoped to [layer_id][page_ids, :, offsets, :], got {tgt_text!r}"
+
+
+# ---------- factory: layout param & no device inference ---------------------
+
+
+def test_create_kvcache_pool_has_layout_kwarg_defaulting_to_nhd():
+    fn = _factory_fn()
+    args = fn.args
+    kwargs_by_name = {a.arg: default for a, default in zip(args.args, [None] * (len(args.args) - len(args.defaults)) + list(args.defaults))}
+    assert "layout" in kwargs_by_name, "create_kvcache_pool must accept 'layout'"
+    default = kwargs_by_name["layout"]
+    assert isinstance(default, ast.Constant) and default.value == "nhd", \
+        f"factory layout default must be 'nhd', got {ast.dump(default)!r}"
+
+
+def test_create_kvcache_pool_forwards_layout_to_mha_kv_cache():
+    fn = _factory_fn()
+    calls = [
+        node for node in ast.walk(fn)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "MHAKVCache"
+    ]
+    assert calls, "factory must instantiate MHAKVCache"
+    kw_names = {kw.arg for kw in calls[0].keywords}
+    assert "layout" in kw_names, "MHAKVCache must be called with layout=..."
+    # And the argument value must be the local layout variable, not a
+    # hard-coded constant, so device selection genuinely flows through.
+    layout_kw = next(kw for kw in calls[0].keywords if kw.arg == "layout")
+    assert isinstance(layout_kw.value, ast.Name) and layout_kw.value.id == "layout", \
+        f"factory must forward layout=layout, got {ast.unparse(layout_kw.value)!r}"
+
+
+def test_create_kvcache_pool_does_not_call_get_device_type():
+    src = ast.unparse(_factory_fn())
+    assert "get_device_type" not in src, \
+        "factory must NOT infer layout via get_device_type()"
+
+
+# ---------- Engine: layout selection & wiring -------------------------------
+
+
+def _engine_layout_ifexp() -> ast.IfExp:
+    """Find the ternary that selects 'bnbsd' vs 'nhd' in Engine.__init__."""
+    init = _engine_init()
+    for node in ast.walk(init):
+        if isinstance(node, ast.IfExp) \
+                and isinstance(node.body, ast.Constant) and node.body.value == "bnbsd" \
+                and isinstance(node.orelse, ast.Constant) and node.orelse.value == "nhd":
+            return node
+    raise AssertionError(
+        "Engine.__init__ must contain a ternary "
+        "'bnbsd' if self.device_type == 'npu' else 'nhd'"
+    )
+
+
+def test_engine_selects_layout_via_device_type_ternary():
+    ifexp = _engine_layout_ifexp()
+    test_text = ast.unparse(ifexp.test)
+    # Accept either ordering: `self.device_type == "npu"` or `"npu" == self.device_type`.
+    assert "self.device_type" in test_text and '"npu"' in test_text.replace("'", '"'), \
+        f"ternary test must compare self.device_type to 'npu', got {test_text!r}"
+
+
+def test_engine_passes_layout_kwarg_to_create_kvcache_pool():
+    init = _engine_init()
+    calls = [
+        node for node in ast.walk(init)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "create_kvcache_pool"
+    ]
+    assert calls, "Engine.__init__ must call create_kvcache_pool"
+    kw_names = {kw.arg for kw in calls[0].keywords}
+    assert "layout" in kw_names, \
+        "create_kvcache_pool must be called with layout=..."
+
+
+def test_engine_layout_kwarg_is_variable_not_literal():
+    """Guards against a regression like ``layout="nhd"`` — the Engine must
+    always forward the ternary result so npu → bnbsd, cuda/cpu → nhd."""
+    init = _engine_init()
+    call = next(
+        node for node in ast.walk(init)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "create_kvcache_pool"
+    )
+    layout_kw = next(kw for kw in call.keywords if kw.arg == "layout")
+    assert isinstance(layout_kw.value, ast.Name), \
+        f"Engine must forward a variable to layout, got {ast.unparse(layout_kw.value)!r}"
+
+
+# =========================================================================
+# Gate 1.7f-fix: real CPU numerical test of the bnbsd store_kv path.
+#
+# Skipped when torch is not installed so the AST-only tests above still run
+# on hosts without torch.
+# =========================================================================
+
+
+@pytest.fixture(scope="module")
+def _tp_info_set():
+    """Ensure DistributedInfo is initialised exactly once for the module.
+
+    Skips gracefully when ``minisgl`` (i.e. the source tree isn't on
+    ``PYTHONPATH``) or its transitive dependencies cannot be imported.
+    """
+    try:
+        from minisgl.distributed import set_tp_info, try_get_tp_info
+    except ImportError as exc:
+        pytest.skip(f"minisgl not importable: {exc}")
+
+    if try_get_tp_info() is None:
+        set_tp_info(0, 1)
+    yield
+
+
+def test_bnbsd_store_kv_real_scatter_on_cpu(_tp_info_set):
+    """Instantiate MHAKVCache(layout='bnbsd') on CPU and drive real scatter
+    through store_kv. Verify:
+
+    * three cross-page writes land at the correct (page, offset) coordinates;
+    * sentinel-filled untouched slots survive;
+    * per-layer view is contiguous and has BnNBsD shape ``(P, HKV, S, D)``;
+    * the bnbsd branch does not import ``minisgl.kernel`` — enforced with an
+      active ``__import__`` guard, not just AST inspection.
+    """
+    torch = pytest.importorskip("torch")
+
+    try:
+        from minisgl.kvcache.mha_pool import MHAKVCache
+    except ImportError as exc:
+        pytest.skip(f"minisgl.kvcache.mha_pool not importable: {exc}")
+
+    num_pages, page_size, kv_heads, head_dim = 4, 16, 2, 4
+    cache = MHAKVCache(
+        num_kv_heads=kv_heads,
+        num_layers=2,
+        head_dim=head_dim,
+        num_pages=num_pages,
+        page_size=page_size,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+        layout="bnbsd",
+    )
+
+    # Fill entire KV buffer with a distinctive sentinel so we can detect
+    # exactly which coordinates the scatter touches.
+    cache._kv_buffer.fill_(-999.0)
+
+    # Given test vectors from the spec.
+    out_loc = torch.tensor([15, 16, 34], dtype=torch.int64)
+    k = torch.arange(3 * 2 * 4, dtype=torch.float32).view(3, 2, 4)
+    v = (1000 + torch.arange(3 * 2 * 4, dtype=torch.float32)).view(3, 8)
+
+    # ---- Active import guard: fail fast if bnbsd store_kv touches minisgl.kernel.
+    import builtins
+
+    _orig_import = builtins.__import__
+    forbidden_names = []
+
+    def _forbid_kernel_import(name, *args, **kwargs):
+        if name == "minisgl.kernel" or name.startswith("minisgl.kernel."):
+            forbidden_names.append(name)
+            raise AssertionError(
+                f"bnbsd store_kv must NOT import {name!r}; the CUDA kernel "
+                "path is nhd-only."
+            )
+        return _orig_import(name, *args, **kwargs)
+
+    builtins.__import__ = _forbid_kernel_import
+    try:
+        cache.store_kv(k, v, out_loc, layer_id=1)
+    finally:
+        builtins.__import__ = _orig_import
+    assert forbidden_names == [], \
+        f"bnbsd path illegally imported: {forbidden_names!r}"
+
+    # ---- Layer-1 view shape / contiguity.
+    k_view_1 = cache.k_cache(1)
+    v_view_1 = cache.v_cache(1)
+    assert tuple(k_view_1.shape) == (num_pages, kv_heads, page_size, head_dim), \
+        f"k_cache(1) shape mismatch: {tuple(k_view_1.shape)}"
+    assert tuple(v_view_1.shape) == (num_pages, kv_heads, page_size, head_dim), \
+        f"v_cache(1) shape mismatch: {tuple(v_view_1.shape)}"
+    assert k_view_1.is_contiguous(), "k_cache(1) must be contiguous"
+    assert v_view_1.is_contiguous(), "v_cache(1) must be contiguous"
+
+    # ---- Written slots match input tensors.
+    # loc 15 → page 0, offset 15
+    # loc 16 → page 1, offset 0
+    # loc 34 → page 2, offset 2
+    expected = [(0, 15, 0), (1, 0, 1), (2, 2, 2)]
+    for page, offset, token in expected:
+        written_k = k_view_1[page, :, offset, :]
+        written_v = v_view_1[page, :, offset, :]
+        assert torch.equal(written_k, k[token]), (
+            f"k mismatch at page={page}, offset={offset}: "
+            f"got {written_k.tolist()} vs expected {k[token].tolist()}"
+        )
+        assert torch.equal(written_v, v[token].view(kv_heads, head_dim)), (
+            f"v mismatch at page={page}, offset={offset}: "
+            f"got {written_v.tolist()} vs expected "
+            f"{v[token].view(kv_heads, head_dim).tolist()}"
+        )
+        # And the written values must NOT be the sentinel.
+        assert not torch.any(written_k == -999.0)
+        assert not torch.any(written_v == -999.0)
+
+    # ---- Sentinel-untouched positions on layer 1 stay at -999.0.
+    sentinel = torch.full((kv_heads, head_dim), -999.0, dtype=torch.float32)
+    for page, offset in [(0, 0), (1, 1), (2, 1)]:
+        assert torch.equal(k_view_1[page, :, offset, :], sentinel), \
+            f"layer 1 page {page} offset {offset} K unexpectedly touched"
+        assert torch.equal(v_view_1[page, :, offset, :], sentinel), \
+            f"layer 1 page {page} offset {offset} V unexpectedly touched"
+
+    # Entire page 3 on layer 1 must remain untouched.
+    layer1_page3_sentinel = torch.full(
+        (kv_heads, page_size, head_dim), -999.0, dtype=torch.float32
+    )
+    assert torch.equal(k_view_1[3], layer1_page3_sentinel), \
+        "layer 1 page 3 K was unexpectedly written to"
+    assert torch.equal(v_view_1[3], layer1_page3_sentinel), \
+        "layer 1 page 3 V was unexpectedly written to"
+
+    # ---- Layer 0 must be completely untouched — every K and V slot is -999.0.
+    layer0_sentinel = torch.full(
+        (num_pages, kv_heads, page_size, head_dim),
+        -999.0,
+        dtype=torch.float32,
+    )
+    assert torch.equal(cache.k_cache(0), layer0_sentinel), \
+        "layer 0 K cache was unexpectedly written to"
+    assert torch.equal(cache.v_cache(0), layer0_sentinel), \
+        "layer 0 V cache was unexpectedly written to"

--- a/tests/layers/test_activation.py
+++ b/tests/layers/test_activation.py
@@ -1,0 +1,428 @@
+"""Gate 1.9o hermetic tests for silu_and_mul CUDA/NPU/CPU dispatch.
+
+Neither real CUDA nor real NPU are required. The CUDA and NPU branches are
+exercised via fake device tensors and fake modules injected into sys.modules
+so we can assert dispatch behavior deterministically on a CPU host.
+"""
+from __future__ import annotations
+
+import ast
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest import mock
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+
+MODULE_PATH = "minisgl.layers.activation"
+SOURCE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "python"
+    / "minisgl"
+    / "layers"
+    / "activation.py"
+)
+
+
+@pytest.fixture()
+def activation_mod():
+    mod = importlib.import_module(MODULE_PATH)
+    return mod
+
+
+# =================================================================== helpers
+def _cpu_reference(x: torch.Tensor) -> torch.Tensor:
+    gate, up = x.float().chunk(2, dim=-1)
+    return (F.silu(gate) * up).to(x.dtype)
+
+
+class _FakeDevice:
+    """Fake device that looks like an NPU or CUDA tensor's .device."""
+
+    def __init__(self, type_: str, index: int = 0):
+        self.type = type_
+        self.index = index
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, _FakeDevice)
+            and self.type == other.type
+            and self.index == other.index
+        )
+
+    def __hash__(self):
+        return hash((self.type, self.index))
+
+    def __repr__(self):
+        return f"_FakeDevice(type={self.type!r}, index={self.index})"
+
+
+class _FakeTensor:
+    """Minimal tensor stand-in exposing the attributes silu_and_mul touches."""
+
+    def __init__(
+        self,
+        shape,
+        dtype=torch.float16,
+        device_type: str = "npu",
+        device_index: int = 0,
+    ):
+        self.shape = torch.Size(shape)
+        self.dtype = dtype
+        self.device = _FakeDevice(device_type, device_index)
+        # side-effect counters
+        self.contiguous_calls = 0
+        self.float_calls = 0
+        self.long_calls = 0
+        self.chunk_calls = 0
+
+    def contiguous(self):
+        self.contiguous_calls += 1
+        return self
+
+    def float(self):
+        self.float_calls += 1
+        return self
+
+    def long(self):
+        self.long_calls += 1
+        return self
+
+    def chunk(self, n, dim=-1):
+        self.chunk_calls += 1
+        raise AssertionError("chunk should not be called on NPU/CUDA dispatch branches")
+
+
+# ================================================================== 1. import
+def test_import_does_not_pull_flashinfer_or_torch_npu():
+    for name in list(sys.modules):
+        if name == MODULE_PATH:
+            del sys.modules[name]
+    for name in ("flashinfer", "torch_npu"):
+        sys.modules.pop(name, None)
+
+    importlib.import_module(MODULE_PATH)
+
+    assert "flashinfer" not in sys.modules
+    assert "torch_npu" not in sys.modules
+
+
+# =============================================================== 2/3/4/5 CPU
+def test_cpu_contiguous_matches_reference(activation_mod):
+    torch.manual_seed(1701)
+    x = torch.randn(4, 8, dtype=torch.float32)
+    y = activation_mod.silu_and_mul(x)
+    assert torch.equal(y, _cpu_reference(x))
+
+
+def test_cpu_non_contiguous_matches_reference(activation_mod):
+    torch.manual_seed(1702)
+    packed = torch.randn(4, 16, dtype=torch.float32)
+    x = packed[:, 4:12]
+    assert not x.is_contiguous()
+    y = activation_mod.silu_and_mul(x)
+    assert torch.equal(y, _cpu_reference(x))
+
+
+def test_cpu_input_not_mutated(activation_mod):
+    torch.manual_seed(1703)
+    x = torch.randn(3, 6, dtype=torch.float32)
+    snap = x.detach().clone()
+    ptr = x.data_ptr()
+    _ = activation_mod.silu_and_mul(x)
+    assert torch.equal(x, snap)
+    assert x.data_ptr() == ptr
+
+
+def test_cpu_returns_new_tensor(activation_mod):
+    torch.manual_seed(1704)
+    x = torch.randn(2, 4, dtype=torch.float32)
+    y = activation_mod.silu_and_mul(x)
+    assert y.data_ptr() != x.data_ptr()
+
+
+# ================================================================== 6. CPU out
+def test_cpu_out_returns_same_object_and_correct_values(activation_mod):
+    torch.manual_seed(1705)
+    x = torch.randn(3, 8, dtype=torch.float32)
+    out = torch.empty(3, 4, dtype=torch.float32)
+    out_ptr = out.data_ptr()
+
+    result = activation_mod.silu_and_mul(x, out=out)
+
+    assert result is out
+    assert result.data_ptr() == out_ptr
+    assert torch.equal(result, _cpu_reference(x))
+
+
+def test_cpu_out_none_returns_new_tensor(activation_mod):
+    torch.manual_seed(1706)
+    x = torch.randn(2, 4, dtype=torch.float32)
+    y = activation_mod.silu_and_mul(x, out=None)
+    assert torch.equal(y, _cpu_reference(x))
+    assert y.data_ptr() != x.data_ptr()
+
+
+# ==================================================================== 7-10 NPU
+def _install_fake_torch_npu(swiglu_impl):
+    fake = ModuleType("torch_npu")
+    fake.npu_swiglu = swiglu_impl
+    sys.modules["torch_npu"] = fake
+    return fake
+
+
+def test_fake_npu_calls_npu_swiglu_once_with_dim_neg1(activation_mod):
+    calls = []
+
+    def _swiglu(x, dim=-999):
+        calls.append({"x": x, "dim": dim, "kw_dim_used": dim})
+        return torch.zeros(*x.shape[:-1], x.shape[-1] // 2, dtype=x.dtype)
+
+    x = _FakeTensor((3, 8), dtype=torch.float16, device_type="npu")
+
+    real_zeros = torch.zeros
+
+    def _swiglu_returning_tensor(x_, dim=-999):
+        calls.append({"dim": dim})
+        return real_zeros(3, 4, dtype=torch.float16)
+
+    try:
+        _install_fake_torch_npu(_swiglu_returning_tensor)
+        y = activation_mod.silu_and_mul(x)
+    finally:
+        sys.modules.pop("torch_npu", None)
+
+    assert len(calls) == 1
+    assert calls[0]["dim"] == -1
+    assert isinstance(y, torch.Tensor)
+    assert tuple(y.shape) == (3, 4)
+
+
+def test_fake_npu_does_not_call_contiguous_or_cast(activation_mod):
+    x = _FakeTensor((2, 6), dtype=torch.float16, device_type="npu")
+
+    def _swiglu(x_, dim=-1):
+        # x_ is the same FakeTensor — mutating internal counters proves identity
+        assert x_ is x
+        return torch.zeros(2, 3, dtype=torch.float16)
+
+    try:
+        _install_fake_torch_npu(_swiglu)
+        activation_mod.silu_and_mul(x)
+    finally:
+        sys.modules.pop("torch_npu", None)
+
+    assert x.contiguous_calls == 0
+    assert x.float_calls == 0
+    assert x.long_calls == 0
+    assert x.chunk_calls == 0
+
+
+def test_fake_npu_input_not_mutated(activation_mod):
+    # Use a real CPU tensor spoofed as NPU via mock on .device
+    real = torch.randn(2, 4, dtype=torch.float16)
+    snap = real.detach().clone()
+
+    class _Spoofed:
+        def __init__(self, t):
+            self._t = t
+            self.shape = t.shape
+            self.dtype = t.dtype
+            self.device = _FakeDevice("npu", 0)
+
+    spoofed = _Spoofed(real)
+
+    def _swiglu(x_, dim=-1):
+        # simulate NPU op that does not modify input
+        return torch.empty(2, 2, dtype=torch.float16)
+
+    try:
+        _install_fake_torch_npu(_swiglu)
+        activation_mod.silu_and_mul(spoofed)
+    finally:
+        sys.modules.pop("torch_npu", None)
+
+    assert torch.equal(real, snap)
+
+
+def test_fake_npu_out_semantics(activation_mod):
+    x = _FakeTensor((2, 4), dtype=torch.float16, device_type="npu")
+
+    filled = torch.arange(4, dtype=torch.float16).reshape(2, 2)
+
+    class _OutSpy:
+        def __init__(self):
+            self.shape = torch.Size((2, 2))
+            self.dtype = torch.float16
+            self.device = _FakeDevice("npu", 0)
+            self.copied_from = None
+
+        def copy_(self, src):
+            self.copied_from = src
+            return self
+
+    out = _OutSpy()
+
+    def _swiglu(x_, dim=-1):
+        return filled
+
+    try:
+        _install_fake_torch_npu(_swiglu)
+        result = activation_mod.silu_and_mul(x, out=out)
+    finally:
+        sys.modules.pop("torch_npu", None)
+
+    assert result is out
+    assert out.copied_from is filled
+
+
+# ==================================================================== 11 CUDA
+def test_fake_cuda_preserves_flashinfer_args_and_return(activation_mod):
+    seen = {}
+
+    def _fake_flashinfer_silu_and_mul(x, out=None):
+        seen["x"] = x
+        seen["out"] = out
+        seen["called"] = seen.get("called", 0) + 1
+        return "SENTINEL_RETURN"
+
+    fake_fi = ModuleType("flashinfer")
+    fake_fi.silu_and_mul = _fake_flashinfer_silu_and_mul
+
+    class _CudaTensor:
+        def __init__(self, shape, dtype=torch.float16):
+            self.shape = torch.Size(shape)
+            self.dtype = dtype
+            self.device = _FakeDevice("cuda", 0)
+
+    x = _CudaTensor((2, 8))
+    out_obj = _CudaTensor((2, 4))
+
+    try:
+        sys.modules["flashinfer"] = fake_fi
+        r_none = activation_mod.silu_and_mul(x, out=None)
+        r_out = activation_mod.silu_and_mul(x, out=out_obj)
+    finally:
+        sys.modules.pop("flashinfer", None)
+
+    assert r_none == "SENTINEL_RETURN"
+    assert r_out == "SENTINEL_RETURN"
+    assert seen["called"] == 2
+    assert seen["x"] is x
+    assert seen["out"] is out_obj
+
+
+# ============================================================ 12 missing deps
+def test_missing_torch_npu_raises_clear_runtimeerror(activation_mod):
+    x = _FakeTensor((2, 4), dtype=torch.float16, device_type="npu")
+
+    # Prevent any real torch_npu from resolving
+    sys.modules.pop("torch_npu", None)
+    with mock.patch.dict(sys.modules, {"torch_npu": None}):
+        with pytest.raises(RuntimeError, match="torch_npu"):
+            activation_mod.silu_and_mul(x)
+
+
+def test_missing_flashinfer_raises_clear_runtimeerror(activation_mod):
+    class _CudaTensor:
+        shape = torch.Size((2, 4))
+        dtype = torch.float16
+        device = _FakeDevice("cuda", 0)
+
+    sys.modules.pop("flashinfer", None)
+    with mock.patch.dict(sys.modules, {"flashinfer": None}):
+        with pytest.raises(RuntimeError, match="flashinfer"):
+            activation_mod.silu_and_mul(_CudaTensor())
+
+
+# ============================================================ 13 odd last dim
+def test_odd_last_dim_rejected(activation_mod):
+    x = torch.randn(2, 5, dtype=torch.float32)
+    with pytest.raises(ValueError, match="even last dimension"):
+        activation_mod.silu_and_mul(x)
+
+
+# ============================================================ 14 out mismatches
+def test_out_shape_mismatch_rejected(activation_mod):
+    x = torch.randn(2, 8, dtype=torch.float32)
+    bad = torch.empty(2, 3, dtype=torch.float32)
+    with pytest.raises(ValueError, match="shape"):
+        activation_mod.silu_and_mul(x, out=bad)
+
+
+def test_out_dtype_mismatch_rejected(activation_mod):
+    x = torch.randn(2, 8, dtype=torch.float32)
+    bad = torch.empty(2, 4, dtype=torch.float16)
+    with pytest.raises(ValueError, match="dtype"):
+        activation_mod.silu_and_mul(x, out=bad)
+
+
+def test_out_device_mismatch_rejected(activation_mod):
+    # Use FakeTensor to spoof device without needing a second real device.
+    class _RealShaped:
+        def __init__(self):
+            self.shape = torch.Size((2, 8))
+            self.dtype = torch.float32
+            self.device = _FakeDevice("cpu", 0)
+
+    class _WrongDev:
+        def __init__(self):
+            self.shape = torch.Size((2, 4))
+            self.dtype = torch.float32
+            self.device = _FakeDevice("cuda", 0)
+
+    with pytest.raises(ValueError, match="device"):
+        activation_mod.silu_and_mul(_RealShaped(), out=_WrongDev())
+
+
+# ============================================================ 15 gelu unchanged
+def test_gelu_and_mul_source_unchanged():
+    src = SOURCE_PATH.read_text()
+    tree = ast.parse(src)
+    gelu_defs = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "gelu_and_mul"
+    ]
+    assert len(gelu_defs) == 1
+    fn = gelu_defs[0]
+    # Body must be: from flashinfer import gelu_and_mul ; return gelu_and_mul(x, out=out)
+    assert len(fn.body) == 2
+    stmt0 = fn.body[0]
+    assert isinstance(stmt0, ast.ImportFrom)
+    assert stmt0.module == "flashinfer"
+    assert [a.name for a in stmt0.names] == ["gelu_and_mul"]
+    stmt1 = fn.body[1]
+    assert isinstance(stmt1, ast.Return)
+    assert isinstance(stmt1.value, ast.Call)
+    assert isinstance(stmt1.value.func, ast.Name)
+    assert stmt1.value.func.id == "gelu_and_mul"
+
+
+def test_gelu_and_mul_still_delegates_to_flashinfer(activation_mod):
+    seen = {}
+
+    def _fake_gelu(x, out=None):
+        seen["x"] = x
+        seen["out"] = out
+        return "GELU_SENTINEL"
+
+    fake = ModuleType("flashinfer")
+    fake.gelu_and_mul = _fake_gelu
+
+    sentinel_x = object()
+    sentinel_out = object()
+
+    try:
+        sys.modules["flashinfer"] = fake
+        result = activation_mod.gelu_and_mul(sentinel_x, out=sentinel_out)
+    finally:
+        sys.modules.pop("flashinfer", None)
+
+    assert result == "GELU_SENTINEL"
+    assert seen["x"] is sentinel_x
+    assert seen["out"] is sentinel_out

--- a/tests/layers/test_attention.py
+++ b/tests/layers/test_attention.py
@@ -1,0 +1,536 @@
+"""Hermetic tests for ``python/minisgl/layers/attention.py`` AttentionLayer.
+
+No CUDA / NPU hardware and no real ``flashinfer`` / ``torch_npu`` are required.
+
+The tests build a real ``AttentionLayer`` on CPU, then replace ``.rotary`` with
+a fake identity callable so we can drive the Q/K/V handoff contract without
+depending on the platform RoPE op. RMSNorm and the attention backend are also
+fake, purely to record what shapes each stage received.
+"""
+from __future__ import annotations
+
+import ast
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+import torch
+
+
+MODULE_PATH = "minisgl.layers.attention"
+SOURCE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "python"
+    / "minisgl"
+    / "layers"
+    / "attention.py"
+)
+
+
+# ============================================================ constants
+# ``RotaryEmbedding`` asserts head_size in {64, 128, 256, 512}. We pick 64 so
+# the surrounding tests stay small while still constructing a real rotary.
+Hq = 4
+Hk = 2
+D = 64
+QKV_LAST = (Hq + 2 * Hk) * D  # 512
+
+
+# ============================================================ helpers
+class _FakeRotary:
+    """Records inputs and returns them unchanged (identity)."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def forward(self, positions, query, key):
+        self.calls.append(
+            {
+                "positions_id": id(positions),
+                "positions_shape": tuple(positions.shape),
+                "positions_dtype": positions.dtype,
+                "query_shape": tuple(query.shape),
+                "query_dtype": query.dtype,
+                "query_contig": query.is_contiguous(),
+                "key_shape": tuple(key.shape),
+                "key_dtype": key.dtype,
+                "key_contig": key.is_contiguous(),
+            }
+        )
+        return query, key
+
+
+class _FakeNorm:
+    """Records incoming shapes, no-op forward_inplace."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def forward_inplace(self, x):
+        self.calls.append(
+            {
+                "shape": tuple(x.shape),
+                "dtype": x.dtype,
+                "contig": x.is_contiguous(),
+                "data_ptr": x.data_ptr(),
+            }
+        )
+        return x
+
+
+class _CaptureBackend:
+    def __init__(self, return_shape=None):
+        self.calls = 0
+        self.args: dict[str, Any] | None = None
+        self._return_shape = return_shape
+
+    def forward(self, q, k, v, layer_id, batch):
+        self.calls += 1
+        self.args = {
+            "q_shape": tuple(q.shape),
+            "q_stride": q.stride(),
+            "q_dtype": q.dtype,
+            "q_data_ptr": q.data_ptr(),
+            "k_shape": tuple(k.shape),
+            "k_stride": k.stride(),
+            "k_dtype": k.dtype,
+            "k_data_ptr": k.data_ptr(),
+            "v_shape": tuple(v.shape),
+            "v_stride": v.stride(),
+            "v_dtype": v.dtype,
+            "v_data_ptr": v.data_ptr(),
+            "layer_id": layer_id,
+            "batch_id": id(batch),
+            "positions_id": id(batch.positions),
+        }
+        shape = self._return_shape or tuple(q.shape)
+        return torch.zeros(shape, dtype=q.dtype)
+
+
+# ============================================================ fixtures
+@pytest.fixture()
+def clean_tp():
+    """Reset TP info so ``set_tp_info(rank=0, size=1)`` succeeds each test."""
+    import minisgl.distributed.info as info_mod
+
+    saved = info_mod._TP_INFO
+    info_mod._TP_INFO = None
+    from minisgl.distributed import set_tp_info
+
+    set_tp_info(rank=0, size=1)
+    yield
+    info_mod._TP_INFO = saved
+
+
+@pytest.fixture()
+def clean_ctx():
+    import minisgl.core as core_mod
+
+    saved = core_mod._GLOBAL_CTX
+    core_mod._GLOBAL_CTX = None
+    yield
+    core_mod._GLOBAL_CTX = saved
+
+
+@pytest.fixture()
+def attn_factory(clean_tp, clean_ctx):
+    """Return a factory that builds an AttentionLayer with fake sub-modules."""
+    from minisgl.layers.attention import AttentionLayer
+    from minisgl.models.config import RotaryConfig
+    from minisgl.layers.rotary import set_rope_device
+
+    # RotaryEmbedding's ctor allocates a cos/sin cache on the current default
+    # device; the CI host defaults to CPU which is fine, but we make it
+    # explicit and small.
+    set_rope_device(torch.device("cpu"))
+
+    def _make(*, q_norm=None, k_norm=None):
+        rotary_config = RotaryConfig(
+            head_dim=D,
+            rotary_dim=D,
+            max_position=64,
+            base=10000.0,
+            scaling=None,
+        )
+        layer = AttentionLayer(
+            layer_id=7,
+            num_qo_heads=Hq,
+            num_kv_heads=Hk,
+            head_dim=D,
+            rotary_config=rotary_config,
+            q_norm=q_norm,
+            k_norm=k_norm,
+        )
+        return layer
+
+    return _make
+
+
+def _install_ctx(backend, positions):
+    from minisgl.core import Context, Batch, set_global_ctx
+
+    ctx = Context(page_size=1)
+    ctx.attn_backend = backend
+    set_global_ctx(ctx)
+    batch = Batch(reqs=[], phase="prefill")
+    batch.positions = positions
+    return ctx, batch
+
+
+# ============================================================ 1. shape flow
+@pytest.mark.parametrize("T", [1, 6])
+def test_qkv_reshape_and_backend_shapes(attn_factory, T):
+    q_norm = _FakeNorm()
+    k_norm = _FakeNorm()
+    layer = attn_factory(q_norm=q_norm, k_norm=k_norm)
+    fake_rotary = _FakeRotary()
+    layer.rotary = fake_rotary
+
+    backend = _CaptureBackend()
+    positions = torch.arange(T, dtype=torch.int32)
+    ctx, batch = _install_ctx(backend, positions)
+
+    torch.manual_seed(101)
+    qkv = torch.randn(T, QKV_LAST, dtype=torch.float32)
+
+    with torch.inference_mode():
+        with ctx.forward_batch(batch):
+            out = layer.forward(qkv)
+
+    assert tuple(out.shape) == (T, Hq * D)
+
+    # q_norm and k_norm each received the 3D reshape
+    assert len(q_norm.calls) == 1
+    assert q_norm.calls[0]["shape"] == (T, Hq, D)
+    assert len(k_norm.calls) == 1
+    assert k_norm.calls[0]["shape"] == (T, Hk, D)
+
+    # rotary got 3D q/k
+    assert len(fake_rotary.calls) == 1
+    rc = fake_rotary.calls[0]
+    assert rc["query_shape"] == (T, Hq, D)
+    assert rc["key_shape"] == (T, Hk, D)
+    assert rc["positions_id"] == id(positions)
+
+    # backend got 3D q/k/v with correct head splits
+    assert backend.calls == 1
+    assert backend.args is not None
+    assert backend.args["q_shape"] == (T, Hq, D)
+    assert backend.args["k_shape"] == (T, Hk, D)
+    assert backend.args["v_shape"] == (T, Hk, D)
+    assert backend.args["layer_id"] == 7
+    assert backend.args["batch_id"] == id(batch)
+    assert backend.args["positions_id"] == id(positions)
+
+
+# ============================================================ 2. no-copy reshape
+@pytest.mark.parametrize("T", [1, 6])
+def test_reshape_does_not_copy(attn_factory, T):
+    q_norm = _FakeNorm()
+    k_norm = _FakeNorm()
+    layer = attn_factory(q_norm=q_norm, k_norm=k_norm)
+    fake_rotary = _FakeRotary()
+    layer.rotary = fake_rotary
+    backend = _CaptureBackend()
+    positions = torch.arange(T, dtype=torch.int32)
+    ctx, batch = _install_ctx(backend, positions)
+
+    torch.manual_seed(102)
+    qkv = torch.randn(T, QKV_LAST, dtype=torch.float32)
+    qkv_ptr = qkv.data_ptr()
+
+    with torch.inference_mode():
+        with ctx.forward_batch(batch):
+            layer.forward(qkv)
+
+    # data_ptr of the tensors passed to norms and backend must all fall inside
+    # qkv's storage — the split+view chain is a pure view.
+    q_ptr = q_norm.calls[0]["data_ptr"]
+    k_ptr = k_norm.calls[0]["data_ptr"]
+    b_v_ptr = backend.args["v_data_ptr"]
+
+    element_bytes = qkv.element_size()
+    q_offset = (q_ptr - qkv_ptr) // element_bytes
+    k_offset = (k_ptr - qkv_ptr) // element_bytes
+    v_offset = (b_v_ptr - qkv_ptr) // element_bytes
+
+    # Q starts at qkv[..., 0], K at qkv[..., Hq*D], V at qkv[..., (Hq+Hk)*D]
+    assert q_offset == 0
+    assert k_offset == Hq * D
+    assert v_offset == (Hq + Hk) * D
+
+
+# ============================================================ 3. numerical Q/K/V vs slice-reshape reference
+@pytest.mark.parametrize("T", [1, 6])
+def test_qkv_values_match_slice_reshape(attn_factory, T):
+    layer = attn_factory(q_norm=None, k_norm=None)
+    fake_rotary = _FakeRotary()
+
+    captured = {}
+
+    def rotary_capture(positions, q, k):
+        captured["q_in"] = q.detach().clone()
+        captured["k_in"] = k.detach().clone()
+        return q, k
+
+    class _Rot:
+        def forward(self, positions, q, k):
+            return rotary_capture(positions, q, k)
+
+    layer.rotary = _Rot()
+
+    backend = _CaptureBackend()
+
+    def _bf(q, k, v, layer_id, batch):
+        captured["backend_q"] = q.detach().clone()
+        captured["backend_k"] = k.detach().clone()
+        captured["backend_v"] = v.detach().clone()
+        return _CaptureBackend.forward(backend, q, k, v, layer_id, batch)
+
+    backend.forward = _bf  # type: ignore[assignment]
+
+    positions = torch.arange(T, dtype=torch.int32)
+    ctx, batch = _install_ctx(backend, positions)
+
+    torch.manual_seed(203)
+    qkv = torch.randn(T, QKV_LAST, dtype=torch.float32)
+
+    # Reference: pure slice + reshape on qkv.
+    ref_q = qkv[:, : Hq * D].contiguous().view(T, Hq, D)
+    ref_k = qkv[:, Hq * D : (Hq + Hk) * D].contiguous().view(T, Hk, D)
+    ref_v = qkv[:, (Hq + Hk) * D :].contiguous().view(T, Hk, D)
+
+    with torch.inference_mode():
+        with ctx.forward_batch(batch):
+            layer.forward(qkv)
+
+    assert torch.equal(captured["q_in"], ref_q)
+    assert torch.equal(captured["k_in"], ref_k)
+    assert torch.equal(captured["backend_v"], ref_v)
+
+
+# ============================================================ 4. V ordering: catch silent gate/order swaps
+def test_v_slice_is_the_last_third(attn_factory):
+    """Sentinel test: fill each split with a distinct constant and verify that
+    V corresponds to the LAST slice, not Q or K.
+    """
+    layer = attn_factory(q_norm=None, k_norm=None)
+    layer.rotary = _FakeRotary()
+    backend = _CaptureBackend()
+
+    captured = {}
+
+    def _bf(q, k, v, layer_id, batch):
+        captured["q"] = q.detach().clone()
+        captured["k"] = k.detach().clone()
+        captured["v"] = v.detach().clone()
+        return torch.zeros_like(q)
+
+    backend.forward = _bf  # type: ignore[assignment]
+
+    T = 3
+    positions = torch.arange(T, dtype=torch.int32)
+    ctx, batch = _install_ctx(backend, positions)
+
+    qkv = torch.empty(T, QKV_LAST, dtype=torch.float32)
+    qkv[:, : Hq * D] = 1.0
+    qkv[:, Hq * D : (Hq + Hk) * D] = 2.0
+    qkv[:, (Hq + Hk) * D :] = 3.0
+
+    with torch.inference_mode():
+        with ctx.forward_batch(batch):
+            layer.forward(qkv)
+
+    assert torch.all(captured["q"] == 1.0)
+    assert torch.all(captured["k"] == 2.0)
+    assert torch.all(captured["v"] == 3.0)
+
+
+# ============================================================ 5. no q/k norm branch
+@pytest.mark.parametrize("T", [1, 6])
+def test_forward_without_norms(attn_factory, T):
+    layer = attn_factory(q_norm=None, k_norm=None)
+    fake_rotary = _FakeRotary()
+    layer.rotary = fake_rotary
+    backend = _CaptureBackend()
+    positions = torch.arange(T, dtype=torch.int32)
+    ctx, batch = _install_ctx(backend, positions)
+
+    torch.manual_seed(303)
+    qkv = torch.randn(T, QKV_LAST, dtype=torch.float32)
+
+    with torch.inference_mode():
+        with ctx.forward_batch(batch):
+            out = layer.forward(qkv)
+
+    assert tuple(out.shape) == (T, Hq * D)
+    assert len(fake_rotary.calls) == 1
+    assert fake_rotary.calls[0]["query_shape"] == (T, Hq, D)
+    assert fake_rotary.calls[0]["key_shape"] == (T, Hk, D)
+    assert backend.calls == 1
+
+
+# ============================================================ 6. positions and batch passthrough
+def test_positions_and_batch_passthrough(attn_factory):
+    layer = attn_factory(q_norm=_FakeNorm(), k_norm=_FakeNorm())
+    fake_rotary = _FakeRotary()
+    layer.rotary = fake_rotary
+    backend = _CaptureBackend()
+    positions = torch.arange(4, dtype=torch.int64)  # deliberately int64
+    ctx, batch = _install_ctx(backend, positions)
+
+    qkv = torch.randn(4, QKV_LAST, dtype=torch.float32)
+    with torch.inference_mode():
+        with ctx.forward_batch(batch):
+            layer.forward(qkv)
+
+    # rotary saw the same positions object
+    assert fake_rotary.calls[0]["positions_id"] == id(positions)
+    assert fake_rotary.calls[0]["positions_dtype"] == torch.int64
+    # backend saw the same batch object
+    assert backend.args["batch_id"] == id(batch)
+    # backend saw the same positions via batch
+    assert backend.args["positions_id"] == id(positions)
+
+
+# ============================================================ 7. layer_id passthrough
+def test_layer_id_passthrough(attn_factory):
+    layer = attn_factory()
+    layer.rotary = _FakeRotary()
+    backend = _CaptureBackend()
+    positions = torch.arange(2, dtype=torch.int32)
+    ctx, batch = _install_ctx(backend, positions)
+
+    qkv = torch.randn(2, QKV_LAST, dtype=torch.float32)
+    with torch.inference_mode():
+        with ctx.forward_batch(batch):
+            layer.forward(qkv)
+
+    assert backend.args["layer_id"] == 7  # set in the factory
+
+
+# ============================================================ 8. call counts
+def test_call_counts(attn_factory):
+    q_norm = _FakeNorm()
+    k_norm = _FakeNorm()
+    layer = attn_factory(q_norm=q_norm, k_norm=k_norm)
+    fake_rotary = _FakeRotary()
+    layer.rotary = fake_rotary
+    backend = _CaptureBackend()
+    positions = torch.arange(5, dtype=torch.int32)
+    ctx, batch = _install_ctx(backend, positions)
+
+    qkv = torch.randn(5, QKV_LAST, dtype=torch.float32)
+    with torch.inference_mode():
+        with ctx.forward_batch(batch):
+            layer.forward(qkv)
+
+    assert len(q_norm.calls) == 1
+    assert len(k_norm.calls) == 1
+    assert len(fake_rotary.calls) == 1
+    assert backend.calls == 1
+
+
+# ============================================================ 9. no .contiguous() call in source
+def test_no_contiguous_call_in_forward():
+    src = SOURCE_PATH.read_text()
+    tree = ast.parse(src)
+    fn = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "forward":
+            fn = node
+            break
+    assert fn is not None
+    for sub in ast.walk(fn):
+        if isinstance(sub, ast.Attribute) and sub.attr == "contiguous":
+            raise AssertionError(
+                "AttentionLayer.forward must not call .contiguous() on Q/K/V"
+            )
+
+
+# ============================================================ 10. bad qkv last dim raises
+def test_bad_qkv_last_dim_raises(attn_factory):
+    layer = attn_factory()
+    layer.rotary = _FakeRotary()
+    backend = _CaptureBackend()
+    positions = torch.arange(2, dtype=torch.int32)
+    ctx, batch = _install_ctx(backend, positions)
+
+    bad = torch.randn(2, QKV_LAST + 1, dtype=torch.float32)
+    with torch.inference_mode():
+        with ctx.forward_batch(batch):
+            with pytest.raises((RuntimeError, ValueError)):
+                layer.forward(bad)
+
+
+# ============================================================ 11. import guard
+def test_module_import_does_not_pull_flashinfer_torch_npu_or_kernel():
+    # Fresh import to observe what the module drags in.
+    for name in list(sys.modules):
+        if name == MODULE_PATH:
+            del sys.modules[name]
+    for name in ("flashinfer", "torch_npu"):
+        sys.modules.pop(name, None)
+
+    importlib.import_module(MODULE_PATH)
+
+    assert "flashinfer" not in sys.modules
+    assert "torch_npu" not in sys.modules
+    for name in list(sys.modules):
+        assert not name.startswith("minisgl.kernel"), (
+            f"AttentionLayer import pulled minisgl.kernel: {name}"
+        )
+
+
+# ============================================================ 12. grad-mode characterization
+def test_grad_mode_characterization(attn_factory):
+    """Characterization: outside ``inference_mode``, ``forward_inplace`` on a
+    view returned by ``torch.split`` may raise. Production runs under
+    ``torch.inference_mode()`` (scheduler / server / tokenizer_server) so we
+    only record this behaviour here; failure is expected and not asserted.
+    """
+    q_norm = _FakeNorm()
+    k_norm = _FakeNorm()
+
+    # Give the fake norm a real inplace copy_ so grad-mode restriction bites.
+    def fi_with_copy(x):
+        y = x + 0
+        x.copy_(y)
+        return x
+
+    q_norm.forward_inplace = fi_with_copy  # type: ignore[assignment]
+    k_norm.forward_inplace = fi_with_copy  # type: ignore[assignment]
+
+    layer = attn_factory(q_norm=q_norm, k_norm=k_norm)
+    layer.rotary = _FakeRotary()
+    backend = _CaptureBackend()
+    positions = torch.arange(1, dtype=torch.int32)
+    ctx, batch = _install_ctx(backend, positions)
+
+    qkv = torch.randn(1, QKV_LAST, dtype=torch.float32)
+
+    # Grad mode: torch may or may not reject the copy_ on a split-view. Both
+    # outcomes are informational; do not assert.
+    grad_mode_ok = None
+    grad_mode_err = None
+    try:
+        with ctx.forward_batch(batch):
+            layer.forward(qkv)
+        grad_mode_ok = True
+    except RuntimeError as exc:
+        grad_mode_ok = False
+        grad_mode_err = str(exc)
+
+    # Inference mode must succeed regardless (this is the production contract).
+    inf_ok = False
+    with torch.inference_mode():
+        with ctx.forward_batch(batch):
+            layer.forward(qkv)
+        inf_ok = True
+    assert inf_ok
+
+    # Emit for record; keep test always green.
+    print(f"[gate1.9t] grad_mode_ok={grad_mode_ok}  err={grad_mode_err!r}")

--- a/tests/layers/test_embedding.py
+++ b/tests/layers/test_embedding.py
@@ -1,0 +1,544 @@
+"""Gate 1.9l: hermetic tests for VocabParallelEmbedding CUDA/NPU/CPU dispatch.
+
+Verifies:
+  * import + construction do not touch minisgl.kernel
+  * CPU/NPU TP=1 uses F.embedding directly, no dtype coercion
+  * CPU/NPU TP>1 masked-gather + zero-fill + all_reduce
+  * CUDA branch still calls the lazy minisgl.kernel.indexing with
+    vocab_range=(start,length) for TP>1
+  * ParallelLMHead tied path is unaffected
+  * source does not contain .long() / .to(torch.int64)
+"""
+from __future__ import annotations
+
+import ast
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest import mock
+
+import pytest
+import torch
+
+
+REPO = Path(__file__).resolve().parents[2]
+EMB_SRC = REPO / "python" / "minisgl" / "layers" / "embedding.py"
+
+
+# ------------------------------------------------------------------ fixtures
+def _reset_tp_info():
+    """Reset the module-global TP info singleton so tests can set it fresh."""
+    import minisgl.distributed.info as info_mod
+    info_mod._TP_INFO = None
+
+
+def _set_tp(rank, size):
+    _reset_tp_info()
+    from minisgl.distributed import set_tp_info
+    set_tp_info(rank=rank, size=size)
+
+
+@pytest.fixture(autouse=True)
+def _tp_reset():
+    _reset_tp_info()
+    yield
+    _reset_tp_info()
+
+
+@pytest.fixture()
+def _tp1():
+    _set_tp(0, 1)
+    yield
+
+
+@pytest.fixture()
+def _clean_kernel(monkeypatch):
+    """Remove any stale minisgl.kernel entries so we can observe fresh imports."""
+    for m in list(sys.modules):
+        if m == "minisgl.kernel" or m.startswith("minisgl.kernel."):
+            monkeypatch.delitem(sys.modules, m, raising=False)
+    yield
+
+
+class _FakeComm:
+    """Fake DistributedCommunicator recording all_reduce/all_gather invocations."""
+
+    def __init__(self):
+        self.all_reduce_calls = 0
+        self.all_gather_calls = 0
+
+    def all_reduce(self, x):
+        self.all_reduce_calls += 1
+        # In tests we simulate the sum by returning x unchanged;
+        # dedicated TP>1 tests do the manual per-rank sum.
+        return x
+
+    def all_gather(self, x):
+        self.all_gather_calls += 1
+        return x
+
+
+def _make_emb(vocab, hidden, *, tp_rank=0, tp_size=1, weight=None, seed=1234):
+    """Construct a fresh VocabParallelEmbedding with a real weight tensor."""
+    from minisgl.layers.embedding import VocabParallelEmbedding
+    _set_tp(tp_rank, tp_size)
+    emb = VocabParallelEmbedding(num_embeddings=vocab, embedding_dim=hidden)
+    if weight is None:
+        g = torch.Generator().manual_seed(seed)
+        weight = torch.randn(emb.num_embeddings_tp, hidden, generator=g)
+    else:
+        assert tuple(weight.shape) == (emb.num_embeddings_tp, hidden)
+    emb.weight = torch.nn.Parameter(weight)
+    return emb
+
+
+# ================================================================ 1. import
+def test_import_does_not_load_minisgl_kernel(_clean_kernel):
+    """Fresh import of the module must not pull minisgl.kernel."""
+    sys.modules.pop("minisgl.layers.embedding", None)
+    importlib.import_module("minisgl.layers.embedding")
+    hits = [m for m in sys.modules if m == "minisgl.kernel" or m.startswith("minisgl.kernel.")]
+    assert hits == [], f"unexpected kernel imports on module load: {hits}"
+
+
+def test_construction_does_not_load_minisgl_kernel(_clean_kernel, _tp1):
+    from minisgl.layers.embedding import VocabParallelEmbedding
+    for m in list(sys.modules):
+        if m == "minisgl.kernel" or m.startswith("minisgl.kernel."):
+            sys.modules.pop(m, None)
+    _ = VocabParallelEmbedding(num_embeddings=32, embedding_dim=16)
+    hits = [m for m in sys.modules if m == "minisgl.kernel" or m.startswith("minisgl.kernel.")]
+    assert hits == [], f"construction loaded kernel: {hits}"
+
+
+# ================================================================ 2-6. CPU TP=1
+@pytest.mark.parametrize("dtype", [torch.int32, torch.int64])
+def test_cpu_tp1_native_embedding(_tp1, dtype):
+    torch.manual_seed(101)
+    W = torch.randn(32, 16)
+    emb = _make_emb(vocab=32, hidden=16, weight=W)
+    ids = torch.tensor([3, 0, 17, 8, 31, 1, 15, 25, 12, 4], dtype=dtype)
+    ids_before = ids.detach().clone()
+    y = emb.forward(ids)
+    assert tuple(y.shape) == (10, 16)
+    assert y.dtype == W.dtype
+    assert torch.equal(y, torch.nn.functional.embedding(ids, W))
+    # inputs untouched, dtype preserved
+    assert ids.dtype == dtype
+    assert torch.equal(ids, ids_before)
+
+
+def test_cpu_tp1_1d_shape(_tp1):
+    W = torch.randn(32, 16)
+    emb = _make_emb(vocab=32, hidden=16, weight=W)
+    ids = torch.tensor([0, 5, 31], dtype=torch.int32)
+    y = emb.forward(ids)
+    assert tuple(y.shape) == (3, 16)
+
+
+def test_cpu_tp1_2d_shape(_tp1):
+    W = torch.randn(32, 16)
+    emb = _make_emb(vocab=32, hidden=16, weight=W)
+    ids = torch.tensor([[3, 0, 17, 8, 31], [1, 15, 25, 12, 4]], dtype=torch.int64)
+    y = emb.forward(ids)
+    assert tuple(y.shape) == (2, 5, 16)
+    assert torch.equal(y, torch.nn.functional.embedding(ids, W))
+
+
+def test_cpu_tp1_no_kernel_import(_tp1, _clean_kernel):
+    W = torch.randn(32, 16)
+    emb = _make_emb(vocab=32, hidden=16, weight=W)
+    for m in list(sys.modules):
+        if m == "minisgl.kernel" or m.startswith("minisgl.kernel."):
+            sys.modules.pop(m, None)
+    ids = torch.tensor([0, 1, 2], dtype=torch.int32)
+    emb.forward(ids)
+    hits = [m for m in sys.modules if m == "minisgl.kernel" or m.startswith("minisgl.kernel.")]
+    assert hits == [], f"NPU/CPU TP=1 forward loaded kernel: {hits}"
+
+
+# ================================================================ 7-11. TP>1
+def _tp2_setup(vocab=10, hidden=4, ids=None):
+    torch.manual_seed(2002)
+    W_full = torch.randn(vocab, hidden)
+    if ids is None:
+        ids = torch.tensor([0, 4, 5, 9], dtype=torch.int64)
+    return W_full, ids
+
+
+def _shard(W_full, tp_size, rank, num_embeddings_tp):
+    start = num_embeddings_tp * rank
+    finish = min(start + num_embeddings_tp, W_full.shape[0])
+    W_r = torch.zeros(num_embeddings_tp, W_full.shape[1])
+    length = finish - start
+    W_r[:length] = W_full[start:finish]
+    return W_r
+
+
+def test_tp2_rank0_masked_gather(_clean_kernel):
+    from minisgl.layers.embedding import VocabParallelEmbedding
+    W_full, ids = _tp2_setup(vocab=10, hidden=4)
+    _set_tp(0, 2)
+    with mock.patch(
+        "minisgl.layers.embedding.DistributedCommunicator", new=_FakeComm
+    ):
+        emb = VocabParallelEmbedding(num_embeddings=10, embedding_dim=4)
+    emb.weight = torch.nn.Parameter(_shard(W_full, 2, 0, emb.num_embeddings_tp))
+    assert emb.vocab_range == (0, 5)
+    y = emb.forward(ids)
+    # rank 0 owns [0,5); ids [0,4,5,9] → only positions 0,1 valid
+    assert tuple(y.shape) == (4, 4)
+    assert torch.equal(y[0], W_full[0])
+    assert torch.equal(y[1], W_full[4])
+    assert torch.equal(y[2], torch.zeros(4))
+    assert torch.equal(y[3], torch.zeros(4))
+    assert emb._comm.all_reduce_calls == 1
+
+
+def test_tp2_rank1_masked_gather(_clean_kernel):
+    from minisgl.layers.embedding import VocabParallelEmbedding
+    W_full, ids = _tp2_setup(vocab=10, hidden=4)
+    _set_tp(1, 2)
+    with mock.patch(
+        "minisgl.layers.embedding.DistributedCommunicator", new=_FakeComm
+    ):
+        emb = VocabParallelEmbedding(num_embeddings=10, embedding_dim=4)
+    emb.weight = torch.nn.Parameter(_shard(W_full, 2, 1, emb.num_embeddings_tp))
+    assert emb.vocab_range == (5, 5)
+    y = emb.forward(ids)
+    # rank 1 owns [5,10); only positions 2,3 valid
+    assert torch.equal(y[0], torch.zeros(4))
+    assert torch.equal(y[1], torch.zeros(4))
+    assert torch.equal(y[2], W_full[5])
+    assert torch.equal(y[3], W_full[9])
+    assert emb._comm.all_reduce_calls == 1
+
+
+def test_tp2_sum_matches_full_embedding(_clean_kernel):
+    from minisgl.layers.embedding import VocabParallelEmbedding
+    W_full, ids = _tp2_setup(vocab=10, hidden=4)
+    outs = []
+    for r in range(2):
+        _set_tp(r, 2)
+        with mock.patch(
+            "minisgl.layers.embedding.DistributedCommunicator", new=_FakeComm
+        ):
+            emb = VocabParallelEmbedding(num_embeddings=10, embedding_dim=4)
+        emb.weight = torch.nn.Parameter(_shard(W_full, 2, r, emb.num_embeddings_tp))
+        outs.append(emb.forward(ids))
+    total = outs[0] + outs[1]
+    ref = W_full[ids]
+    assert torch.equal(total, ref)
+
+
+def test_tp2_vocab_range_start_length_contract(_clean_kernel):
+    from minisgl.layers.embedding import VocabParallelEmbedding
+    # vocab=10, tp=3 → num_embeddings_tp=4 → ranges (0,4),(4,4),(8,2)
+    for r, expected in enumerate([(0, 4), (4, 4), (8, 2)]):
+        _set_tp(r, 3)
+        emb = VocabParallelEmbedding(num_embeddings=10, embedding_dim=4)
+        assert emb.vocab_range == expected, f"rank {r}: {emb.vocab_range} != {expected}"
+
+
+def test_tp2_out_of_range_zero_before_all_reduce(_clean_kernel):
+    """The value fed to all_reduce must have zeros on out-of-range positions."""
+    from minisgl.layers.embedding import VocabParallelEmbedding
+
+    captured = {}
+
+    class _CapturingComm:
+        def all_reduce(self, x):
+            captured["y"] = x.detach().clone()
+            return x
+        def all_gather(self, x):
+            return x
+
+    W_full, ids = _tp2_setup(vocab=10, hidden=4)
+    _set_tp(0, 2)
+    with mock.patch(
+        "minisgl.layers.embedding.DistributedCommunicator", new=_CapturingComm
+    ):
+        emb = VocabParallelEmbedding(num_embeddings=10, embedding_dim=4)
+    emb.weight = torch.nn.Parameter(_shard(W_full, 2, 0, emb.num_embeddings_tp))
+    emb.forward(ids)
+    y = captured["y"]
+    # ids [0,4,5,9] on rank 0 → 5 and 9 are out of range; must be exactly zero
+    assert torch.equal(y[2], torch.zeros(4))
+    assert torch.equal(y[3], torch.zeros(4))
+    # in-range unchanged
+    assert torch.equal(y[0], W_full[0])
+    assert torch.equal(y[1], W_full[4])
+
+
+# ================================================================ 12. all_reduce only TP>1
+def test_all_reduce_not_called_at_tp1(_tp1):
+    from minisgl.layers.embedding import VocabParallelEmbedding
+    with mock.patch(
+        "minisgl.layers.embedding.DistributedCommunicator", new=_FakeComm
+    ):
+        emb = VocabParallelEmbedding(num_embeddings=32, embedding_dim=16)
+    emb.weight = torch.nn.Parameter(torch.randn(32, 16))
+    emb.forward(torch.tensor([0, 1, 2], dtype=torch.int32))
+    assert emb._comm.all_reduce_calls == 0
+
+
+# ================================================================ 13-14. CUDA
+def _fake_cuda_int_tensor(list_):
+    """Make a real CPU tensor but claim device.type == 'cuda' via a subclass wrap."""
+    t = torch.tensor(list_, dtype=torch.int32)
+
+    class _CudaFake(torch.Tensor):
+        @property
+        def device(self):
+            return torch.device("cuda:0")
+
+    return t.as_subclass(_CudaFake)
+
+
+def test_cuda_branch_calls_lazy_indexing_tp1(_tp1):
+    """CUDA path: minisgl.kernel.indexing is imported inside forward and called."""
+    from minisgl.layers.embedding import VocabParallelEmbedding
+    with mock.patch(
+        "minisgl.layers.embedding.DistributedCommunicator", new=_FakeComm
+    ):
+        emb = VocabParallelEmbedding(num_embeddings=32, embedding_dim=16)
+    emb.weight = torch.nn.Parameter(torch.randn(32, 16))
+
+    calls = []
+
+    def _fake_indexing(*, weights, indices, vocab_range):
+        calls.append({"weights_shape": tuple(weights.shape),
+                      "indices_dtype": indices.dtype,
+                      "vocab_range": vocab_range})
+        return weights.new_zeros(indices.shape + (weights.shape[1],))
+
+    fake_kernel = ModuleType("minisgl.kernel")
+    fake_kernel.indexing = _fake_indexing
+    with mock.patch.dict(sys.modules, {"minisgl.kernel": fake_kernel}):
+        ids = _fake_cuda_int_tensor([0, 1, 2, 3])
+        emb.forward(ids)
+
+    assert len(calls) == 1
+    assert calls[0]["vocab_range"] is None    # TP=1
+    assert calls[0]["indices_dtype"] == torch.int32
+
+
+def test_cuda_branch_passes_start_length_vocab_range_tp2():
+    from minisgl.layers.embedding import VocabParallelEmbedding
+    _set_tp(1, 2)
+    with mock.patch(
+        "minisgl.layers.embedding.DistributedCommunicator", new=_FakeComm
+    ):
+        emb = VocabParallelEmbedding(num_embeddings=10, embedding_dim=4)
+    emb.weight = torch.nn.Parameter(torch.zeros(emb.num_embeddings_tp, 4))
+
+    seen = []
+
+    def _fake_indexing(*, weights, indices, vocab_range):
+        seen.append(vocab_range)
+        return weights.new_zeros(indices.shape + (weights.shape[1],))
+
+    fake_kernel = ModuleType("minisgl.kernel")
+    fake_kernel.indexing = _fake_indexing
+    with mock.patch.dict(sys.modules, {"minisgl.kernel": fake_kernel}):
+        ids = _fake_cuda_int_tensor([0, 4, 5, 9])
+        emb.forward(ids)
+
+    # rank=1, size=2, vocab=10, num_embeddings_tp=5 → (5,5)
+    assert seen == [(5, 5)]
+
+
+# ================================================================ 15. NPU CPU no import
+def test_npu_cpu_path_never_imports_kernel(_clean_kernel):
+    """Repeatedly exercise CPU forward (TP=1 and TP>1) — kernel stays out."""
+    from minisgl.layers.embedding import VocabParallelEmbedding
+
+    for m in list(sys.modules):
+        if m == "minisgl.kernel" or m.startswith("minisgl.kernel."):
+            sys.modules.pop(m, None)
+
+    _set_tp(0, 1)
+    emb1 = VocabParallelEmbedding(num_embeddings=32, embedding_dim=16)
+    emb1.weight = torch.nn.Parameter(torch.randn(32, 16))
+    emb1.forward(torch.tensor([0, 1], dtype=torch.int32))
+    emb1.forward(torch.tensor([2, 3], dtype=torch.int64))
+
+    with mock.patch(
+        "minisgl.layers.embedding.DistributedCommunicator", new=_FakeComm
+    ):
+        _set_tp(0, 2)
+        emb2 = VocabParallelEmbedding(num_embeddings=10, embedding_dim=4)
+    emb2.weight = torch.nn.Parameter(torch.randn(emb2.num_embeddings_tp, 4))
+    emb2.forward(torch.tensor([0, 4, 5, 9], dtype=torch.int64))
+
+    hits = [m for m in sys.modules if m == "minisgl.kernel" or m.startswith("minisgl.kernel.")]
+    assert hits == [], f"NPU/CPU path leaked kernel import: {hits}"
+
+
+# ================================================================ 16. source hygiene
+def test_source_has_no_long_or_int64_coercion():
+    src = EMB_SRC.read_text()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr == "long":
+            pytest.fail(f".long attribute reference at line {node.lineno}")
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr == "to":
+                for a in node.args:
+                    if isinstance(a, ast.Attribute) and a.attr == "int64":
+                        pytest.fail(f".to(torch.int64) at line {node.lineno}")
+    assert ".long(" not in src
+    assert "torch.int64" not in src
+
+
+# ================================================================ 17. LMHead tied path unaffected
+def test_parallel_lmhead_tied_state_dict_and_load(_tp1):
+    from minisgl.layers.embedding import ParallelLMHead, VocabParallelEmbedding
+    tied = VocabParallelEmbedding(num_embeddings=32, embedding_dim=16)
+    tied.weight = torch.nn.Parameter(torch.randn(32, 16))
+    head = ParallelLMHead(
+        num_embeddings=32,
+        embedding_dim=16,
+        tie_word_embeddings=True,
+        tied_embedding=tied,
+    )
+    # tied state_dict returns empty
+    assert head.state_dict(prefix="lm_head") == {}
+
+    # tied load pops lm_head.weight and .bias if present, otherwise no-op
+    sd = {"lm_head.weight": torch.zeros(32, 16), "lm_head.bias": torch.zeros(32)}
+    head.load_state_dict(sd, prefix="lm_head")
+    assert "lm_head.weight" not in sd
+    assert "lm_head.bias" not in sd
+
+    # tied module still references the original weights
+    assert head.tied_embedding is tied
+    assert torch.equal(tied.weight, tied.weight)   # unchanged type
+
+
+# ================================================================ 18. Gate 1.9l-fix
+# The real DistributedCommunicator.all_reduce is *in-place* on the tensor; both
+# TorchDistributedImpl (impl.py:26-31) and PyNCCLDistributedImpl (impl.py:48-50)
+# return the same object they received. But the pynccl primitive itself is
+# declared '-> None' (kernel/pynccl.py:18). To prove embedding never depends on
+# the wrapper *returning* the tensor, we exercise it with a communicator that
+# mutates in place and returns None.
+class InplaceNoneCommunicator:
+    """all_reduce mutates the tensor in place and returns None.
+
+    This is the strictest form of the distributed-primitive contract: only the
+    side effect on the argument is observable. Any embedding code that does
+    ``return self._comm.all_reduce(y)`` breaks against this backend.
+    """
+
+    def __init__(self, factor=2.0):
+        self.factor = factor
+        self.all_reduce_calls = 0
+        self.last_arg_id = None
+        self.all_gather_calls = 0
+
+    def all_reduce(self, tensor):
+        self.all_reduce_calls += 1
+        self.last_arg_id = id(tensor)
+        tensor.mul_(self.factor)                 # in-place mutation, sentinel
+        return None                              # explicit None contract
+
+    def all_gather(self, tensor):
+        self.all_gather_calls += 1
+        return tensor
+
+
+def test_tp2_forward_returns_tensor_not_none_under_inplace_none_comm(_clean_kernel):
+    """Gate 1.9l-fix: TP>1 forward must NOT return whatever all_reduce returns.
+
+    With a communicator whose all_reduce returns None, embedding must still
+    return the tensor y that was passed to all_reduce.
+    """
+    from minisgl.layers.embedding import VocabParallelEmbedding
+    W_full, ids = _tp2_setup(vocab=10, hidden=4)
+    _set_tp(0, 2)
+    with mock.patch(
+        "minisgl.layers.embedding.DistributedCommunicator",
+        new=InplaceNoneCommunicator,
+    ):
+        emb = VocabParallelEmbedding(num_embeddings=10, embedding_dim=4)
+    emb.weight = torch.nn.Parameter(_shard(W_full, 2, 0, emb.num_embeddings_tp))
+    y = emb.forward(ids)
+    assert y is not None
+    assert isinstance(y, torch.Tensor)
+    assert emb._comm.all_reduce_calls == 1
+
+
+def test_tp2_forward_returns_same_object_as_all_reduce_arg(_clean_kernel):
+    """The returned tensor must BE the tensor that was passed to all_reduce
+    (so the caller sees the in-place mutation)."""
+    from minisgl.layers.embedding import VocabParallelEmbedding
+    W_full, ids = _tp2_setup(vocab=10, hidden=4)
+    _set_tp(0, 2)
+    with mock.patch(
+        "minisgl.layers.embedding.DistributedCommunicator",
+        new=InplaceNoneCommunicator,
+    ):
+        emb = VocabParallelEmbedding(num_embeddings=10, embedding_dim=4)
+    emb.weight = torch.nn.Parameter(_shard(W_full, 2, 0, emb.num_embeddings_tp))
+    y = emb.forward(ids)
+    assert id(y) == emb._comm.last_arg_id
+
+
+def test_tp2_inplace_mutation_by_all_reduce_visible_in_output(_clean_kernel):
+    """The multiplication done inside all_reduce must be visible on the
+    returned tensor — verifying the side effect propagates."""
+    from minisgl.layers.embedding import VocabParallelEmbedding
+    W_full, ids = _tp2_setup(vocab=10, hidden=4)
+    _set_tp(0, 2)
+    with mock.patch(
+        "minisgl.layers.embedding.DistributedCommunicator",
+        new=InplaceNoneCommunicator,
+    ):
+        emb = VocabParallelEmbedding(num_embeddings=10, embedding_dim=4)
+    emb.weight = torch.nn.Parameter(_shard(W_full, 2, 0, emb.num_embeddings_tp))
+    y = emb.forward(ids)
+    # rank 0 owns [0,5) → ids [0,4,5,9] give rows W_full[0], W_full[4], 0, 0
+    # then InplaceNoneCommunicator multiplied everything by factor=2.0.
+    expected = torch.stack(
+        [W_full[0] * 2.0, W_full[4] * 2.0, torch.zeros(4), torch.zeros(4)]
+    )
+    assert torch.equal(y, expected)
+
+
+def test_tp1_does_not_call_all_reduce_under_inplace_none_comm(_clean_kernel, _tp1):
+    """TP=1 must never touch all_reduce, even with a None-returning backend."""
+    from minisgl.layers.embedding import VocabParallelEmbedding
+    with mock.patch(
+        "minisgl.layers.embedding.DistributedCommunicator",
+        new=InplaceNoneCommunicator,
+    ):
+        emb = VocabParallelEmbedding(num_embeddings=32, embedding_dim=16)
+    emb.weight = torch.nn.Parameter(torch.randn(32, 16))
+    y = emb.forward(torch.tensor([0, 1, 2], dtype=torch.int32))
+    assert y is not None
+    assert emb._comm.all_reduce_calls == 0
+
+
+def test_tp2_sum_matches_full_embedding_under_inplace_none_comm(_clean_kernel):
+    """End-to-end sanity: with the in-place/None backend, do a manual per-rank
+    sum and confirm we still recover W_full[ids] (factor=1.0 so mutation is
+    a no-op equivalent to identity)."""
+    from minisgl.layers.embedding import VocabParallelEmbedding
+    W_full, ids = _tp2_setup(vocab=10, hidden=4)
+    outs = []
+    for r in range(2):
+        _set_tp(r, 2)
+        with mock.patch(
+            "minisgl.layers.embedding.DistributedCommunicator",
+            new=lambda: InplaceNoneCommunicator(factor=1.0),
+        ):
+            emb = VocabParallelEmbedding(num_embeddings=10, embedding_dim=4)
+        emb.weight = torch.nn.Parameter(_shard(W_full, 2, r, emb.num_embeddings_tp))
+        y = emb.forward(ids)
+        assert y is not None
+        outs.append(y)
+    total = outs[0] + outs[1]
+    assert torch.equal(total, W_full[ids])
+

--- a/tests/layers/test_norm.py
+++ b/tests/layers/test_norm.py
@@ -1,0 +1,413 @@
+"""Hermetic tests for ``python/minisgl/layers/norm.py`` device dispatch.
+
+The tests never touch CUDA or NPU hardware. Fake ``flashinfer`` and
+``torch_npu`` modules are injected via ``monkeypatch`` and a fake tensor
+wrapper carries a controlled ``device.type`` string through the dispatch.
+"""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+import torch
+
+
+# ============================================================ fixtures
+@pytest.fixture
+def clean_optional_deps(monkeypatch):
+    """Drop any previously-cached flashinfer / torch_npu from sys.modules."""
+    for name in list(sys.modules):
+        head = name.split(".", 1)[0]
+        if head in {"flashinfer", "torch_npu"}:
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+
+@pytest.fixture
+def fresh_norm(clean_optional_deps):
+    """Re-import ``minisgl.layers.norm`` on a clean slate."""
+    monkeypatch_targets = [
+        "minisgl.layers.norm",
+    ]
+    for name in monkeypatch_targets:
+        if name in sys.modules:
+            del sys.modules[name]
+    import minisgl.layers.norm as norm
+    return norm
+
+
+class _BlockingFinder:
+    """Meta-path finder that raises ImportError for a fixed set of top names."""
+
+    def __init__(self, *blocked: str) -> None:
+        self._blocked = set(blocked)
+
+    def find_spec(self, name, path=None, target=None):
+        head = name.split(".", 1)[0]
+        if head in self._blocked:
+            raise ImportError(f"blocked by test finder: {name}")
+        return None
+
+
+@pytest.fixture
+def block_flashinfer(monkeypatch):
+    for name in list(sys.modules):
+        if name.split(".", 1)[0] == "flashinfer":
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    finder = _BlockingFinder("flashinfer")
+    monkeypatch.setattr(sys, "meta_path", [finder] + list(sys.meta_path))
+
+
+@pytest.fixture
+def block_torch_npu(monkeypatch):
+    for name in list(sys.modules):
+        if name.split(".", 1)[0] == "torch_npu":
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    finder = _BlockingFinder("torch_npu")
+    monkeypatch.setattr(sys, "meta_path", [finder] + list(sys.meta_path))
+
+
+# ============================================================ helpers
+class _FakeDevice:
+    def __init__(self, t: str) -> None:
+        self.type = t
+
+    def __repr__(self) -> str:
+        return f"_FakeDevice(type={self.type!r})"
+
+
+class _FakeTensor:
+    """Minimal tensor stand-in.
+
+    The dispatch code only reads ``x.device.type`` and, on the inplace path,
+    calls ``x.copy_(y)``. Everything else is forwarded to the underlying real
+    tensor when needed.
+    """
+
+    def __init__(self, real: torch.Tensor, device_type: str) -> None:
+        self._real = real
+        self.device = _FakeDevice(device_type)
+        self.copy_calls: list = []
+
+    def copy_(self, other):
+        self.copy_calls.append(other)
+        payload = other._real if isinstance(other, _FakeTensor) else other
+        if isinstance(payload, torch.Tensor):
+            self._real.copy_(payload)
+        return self
+
+
+def _cpu_reference(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    x_f = x.float()
+    variance = x_f.pow(2).mean(dim=-1, keepdim=True)
+    return (x_f * torch.rsqrt(variance + eps) * weight.float()).to(x.dtype)
+
+
+def _install_fake_torch_npu(monkeypatch, rms_norm_impl=None, add_rms_norm_impl=None):
+    fake = types.ModuleType("torch_npu")
+    if rms_norm_impl is not None:
+        fake.npu_rms_norm = rms_norm_impl
+    if add_rms_norm_impl is not None:
+        fake.npu_add_rms_norm = add_rms_norm_impl
+    monkeypatch.setitem(sys.modules, "torch_npu", fake)
+
+
+def _install_fake_flashinfer(monkeypatch, rmsnorm_impl=None, fused_add_impl=None):
+    fake = types.ModuleType("flashinfer")
+    if rmsnorm_impl is not None:
+        fake.rmsnorm = rmsnorm_impl
+    if fused_add_impl is not None:
+        fake.fused_add_rmsnorm = fused_add_impl
+    monkeypatch.setitem(sys.modules, "flashinfer", fake)
+
+
+# ================================================================ #1
+def test_import_norm_does_not_trigger_optional_deps(fresh_norm):
+    assert "flashinfer" not in sys.modules
+    assert "torch_npu" not in sys.modules
+
+
+# ================================================================ #2
+def test_construct_classes_does_not_import_optional_deps(fresh_norm):
+    _ = fresh_norm.RMSNorm(16, 1e-6)
+    _ = fresh_norm.RMSNormFused(16, 1e-6)
+    assert "flashinfer" not in sys.modules
+    assert "torch_npu" not in sys.modules
+
+
+# ================================================================ #3
+def test_cpu_rmsnorm_forward_matches_reference(fresh_norm):
+    torch.manual_seed(0)
+    norm = fresh_norm.RMSNorm(64, 1e-6)
+    norm.weight = torch.randn(64)
+    x = torch.randn(3, 5, 64)
+
+    y = norm.forward(x)
+    ref = _cpu_reference(x, norm.weight, norm.eps)
+
+    assert y.shape == x.shape
+    assert y.dtype == x.dtype
+    assert torch.allclose(y, ref, atol=1e-6)
+
+
+# ================================================================ #4
+def test_cpu_rmsnorm_forward_inplace_mutates_and_returns_none(fresh_norm):
+    torch.manual_seed(1)
+    norm = fresh_norm.RMSNorm(32, 1e-6)
+    norm.weight = torch.randn(32)
+    x = torch.randn(4, 32)
+    x_orig = x.clone()
+    x_id = id(x)
+    ptr = x.data_ptr()
+
+    ret = norm.forward_inplace(x)
+
+    assert ret is None
+    assert id(x) == x_id
+    assert x.data_ptr() == ptr
+    ref = _cpu_reference(x_orig, norm.weight, norm.eps)
+    assert torch.allclose(x, ref, atol=1e-6)
+
+
+# ================================================================ #5
+def test_cpu_fused_residual_none_passes_original_x(fresh_norm):
+    torch.manual_seed(2)
+    norm = fresh_norm.RMSNormFused(32, 1e-6)
+    norm.weight = torch.randn(32)
+    x = torch.randn(3, 32)
+    x_orig = x.clone()
+
+    normalized, passthrough = norm.forward(x, residual=None)
+
+    assert passthrough is x
+    assert torch.equal(x, x_orig)
+    ref = _cpu_reference(x_orig, norm.weight, norm.eps)
+    assert torch.allclose(normalized, ref, atol=1e-6)
+
+
+# ================================================================ #6
+def test_cpu_fused_with_residual(fresh_norm):
+    torch.manual_seed(3)
+    norm = fresh_norm.RMSNormFused(64, 1e-6)
+    norm.weight = torch.randn(64)
+    x = torch.randn(2, 64)
+    residual = torch.randn(2, 64)
+    x_orig = x.clone()
+    residual_orig = residual.clone()
+
+    normalized, summed = norm.forward(x, residual)
+
+    # CPU + NPU mirror the "no in-place on inputs" contract.
+    assert torch.equal(x, x_orig)
+    assert torch.equal(residual, residual_orig)
+
+    sum_ref = x_orig + residual_orig
+    assert torch.allclose(summed, sum_ref, atol=1e-6)
+    norm_ref = _cpu_reference(sum_ref, norm.weight, norm.eps)
+    assert torch.allclose(normalized, norm_ref, atol=1e-6)
+
+
+# ================================================================ #7
+def test_npu_rmsnorm_forward_returns_first_of_tuple(fresh_norm, monkeypatch):
+    sentinel_out = torch.randn(2, 8)
+    sentinel_rstd = torch.randn(2, 1)
+    call_log = []
+
+    def fake_rms_norm(x, weight, eps):
+        call_log.append(("rms", x, weight, eps))
+        return sentinel_out, sentinel_rstd
+
+    _install_fake_torch_npu(monkeypatch, rms_norm_impl=fake_rms_norm)
+
+    norm = fresh_norm.RMSNorm(8, 3e-6)
+    norm.weight = torch.randn(8)
+
+    fake_x = _FakeTensor(torch.randn(2, 8), "npu")
+    y = norm.forward(fake_x)
+
+    assert len(call_log) == 1
+    assert call_log[0][0] == "rms"
+    assert call_log[0][1] is fake_x
+    assert call_log[0][2] is norm.weight
+    assert call_log[0][3] == 3e-6
+    assert y is sentinel_out  # tuple[1] discarded
+
+
+# ================================================================ #8
+def test_npu_rmsnorm_forward_inplace_calls_copy_(fresh_norm, monkeypatch):
+    sentinel_out = torch.randn(3, 16)
+    sentinel_rstd = torch.randn(3, 1)
+
+    def fake_rms_norm(x, weight, eps):
+        return sentinel_out, sentinel_rstd
+
+    _install_fake_torch_npu(monkeypatch, rms_norm_impl=fake_rms_norm)
+
+    norm = fresh_norm.RMSNorm(16, 1e-6)
+    norm.weight = torch.randn(16)
+
+    fake_x = _FakeTensor(torch.randn(3, 16), "npu")
+    ret = norm.forward_inplace(fake_x)
+
+    assert ret is None
+    assert len(fake_x.copy_calls) == 1
+    assert fake_x.copy_calls[0] is sentinel_out
+
+
+# ================================================================ #9
+def test_npu_fused_maps_first_and_third(fresh_norm, monkeypatch):
+    normalized = torch.randn(4, 32)
+    rstd = torch.randn(4, 1)
+    summed = torch.randn(4, 32)
+    call_log = []
+
+    def fake_add_rms_norm(x, residual, weight, eps):
+        call_log.append((x, residual, weight, eps))
+        return normalized, rstd, summed
+
+    _install_fake_torch_npu(monkeypatch, add_rms_norm_impl=fake_add_rms_norm)
+
+    norm = fresh_norm.RMSNormFused(32, 5e-6)
+    norm.weight = torch.randn(32)
+
+    fake_x = _FakeTensor(torch.randn(4, 32), "npu")
+    fake_residual = _FakeTensor(torch.randn(4, 32), "npu")
+
+    out0, out1 = norm.forward(fake_x, fake_residual)
+
+    assert len(call_log) == 1
+    x_arg, res_arg, w_arg, eps_arg = call_log[0]
+    assert x_arg is fake_x
+    assert res_arg is fake_residual
+    assert w_arg is norm.weight
+    assert eps_arg == 5e-6
+    assert out0 is normalized       # tuple[0]
+    assert out1 is summed           # tuple[2] — rstd (tuple[1]) dropped
+
+
+# ================================================================ #10
+def test_npu_fused_does_not_mutate_inputs(fresh_norm, monkeypatch):
+    normalized = torch.randn(3, 16)
+    rstd = torch.randn(3, 1)
+    summed = torch.randn(3, 16)
+
+    def fake_add_rms_norm(x, residual, weight, eps):
+        # Explicitly do NOT touch x or residual.
+        return normalized, rstd, summed
+
+    _install_fake_torch_npu(monkeypatch, add_rms_norm_impl=fake_add_rms_norm)
+
+    norm = fresh_norm.RMSNormFused(16, 1e-6)
+    norm.weight = torch.randn(16)
+
+    real_x = torch.randn(3, 16)
+    real_residual = torch.randn(3, 16)
+    real_x_orig = real_x.clone()
+    real_residual_orig = real_residual.clone()
+
+    fake_x = _FakeTensor(real_x, "npu")
+    fake_residual = _FakeTensor(real_residual, "npu")
+    _ = norm.forward(fake_x, fake_residual)
+
+    assert torch.equal(real_x, real_x_orig)
+    assert torch.equal(real_residual, real_residual_orig)
+    assert fake_x.copy_calls == []
+    assert fake_residual.copy_calls == []
+
+
+# ================================================================ #11
+def test_cuda_paths_preserve_flashinfer_contracts(fresh_norm, monkeypatch):
+    rmsnorm_calls = []
+    fused_calls = []
+    sentinel_new = torch.randn(3, 8)
+
+    def fake_rmsnorm(x, weight, eps, out=None):
+        rmsnorm_calls.append({"x": x, "weight": weight, "eps": eps, "out": out})
+        return out if out is not None else sentinel_new
+
+    def fake_fused_add_rmsnorm(x, residual, weight, eps):
+        fused_calls.append({"x": x, "residual": residual, "weight": weight, "eps": eps})
+        return None
+
+    _install_fake_flashinfer(monkeypatch, fake_rmsnorm, fake_fused_add_rmsnorm)
+
+    norm = fresh_norm.RMSNorm(8, 1e-6)
+    norm.weight = torch.randn(8)
+
+    # RMSNorm.forward — no out= kwarg
+    fake_x = _FakeTensor(torch.randn(3, 8), "cuda")
+    y = norm.forward(fake_x)
+    assert y is sentinel_new
+    assert rmsnorm_calls[-1]["out"] is None
+    assert rmsnorm_calls[-1]["x"] is fake_x
+    assert rmsnorm_calls[-1]["weight"] is norm.weight
+
+    # RMSNorm.forward_inplace — out=x passthrough
+    fake_x2 = _FakeTensor(torch.randn(3, 8), "cuda")
+    ret = norm.forward_inplace(fake_x2)
+    assert ret is None
+    assert rmsnorm_calls[-1]["out"] is fake_x2
+    assert rmsnorm_calls[-1]["x"] is fake_x2
+
+    # RMSNormFused with residual — fused_add_rmsnorm invocation + identity return
+    fused_norm = fresh_norm.RMSNormFused(8, 2e-6)
+    fused_norm.weight = torch.randn(8)
+    fake_x3 = _FakeTensor(torch.randn(3, 8), "cuda")
+    fake_r = _FakeTensor(torch.randn(3, 8), "cuda")
+    out0, out1 = fused_norm.forward(fake_x3, fake_r)
+    assert out0 is fake_x3
+    assert out1 is fake_r
+    assert fused_calls[-1]["x"] is fake_x3
+    assert fused_calls[-1]["residual"] is fake_r
+    assert fused_calls[-1]["weight"] is fused_norm.weight
+    assert fused_calls[-1]["eps"] == 2e-6
+
+    # RMSNormFused residual=None — passthrough of x as second slot
+    fake_x4 = _FakeTensor(torch.randn(3, 8), "cuda")
+    o0, o1 = fused_norm.forward(fake_x4, None)
+    assert o1 is fake_x4
+
+
+# ================================================================ #12
+def test_weight_attribute_name_and_shape_preserved(fresh_norm):
+    norm1 = fresh_norm.RMSNorm(128, 1e-6)
+    norm2 = fresh_norm.RMSNormFused(64, 1e-6)
+
+    assert hasattr(norm1, "weight")
+    assert hasattr(norm2, "weight")
+    assert isinstance(norm1.weight, torch.Tensor)
+    assert isinstance(norm2.weight, torch.Tensor)
+    assert norm1.weight.shape == (128,)
+    assert norm2.weight.shape == (64,)
+    assert norm1.eps == 1e-6
+    assert norm2.eps == 1e-6
+
+    # BaseOP.state_dict serialization still surfaces exactly one "weight" key.
+    assert list(norm1.state_dict().keys()) == ["weight"]
+    assert list(norm2.state_dict().keys()) == ["weight"]
+
+
+# ================================================================ #13
+def test_missing_torch_npu_raises_runtime_error(fresh_norm, block_torch_npu):
+    norm = fresh_norm.RMSNorm(8, 1e-6)
+    norm.weight = torch.randn(8)
+    fake_x = _FakeTensor(torch.randn(1, 8), "npu")
+    with pytest.raises(RuntimeError, match="torch_npu"):
+        norm.forward(fake_x)
+
+
+def test_missing_flashinfer_raises_runtime_error(fresh_norm, block_flashinfer):
+    norm = fresh_norm.RMSNorm(8, 1e-6)
+    norm.weight = torch.randn(8)
+    fake_x = _FakeTensor(torch.randn(1, 8), "cuda")
+    with pytest.raises(RuntimeError, match="flashinfer"):
+        norm.forward(fake_x)
+
+
+def test_missing_flashinfer_fused_add_raises_runtime_error(fresh_norm, block_flashinfer):
+    norm = fresh_norm.RMSNormFused(8, 1e-6)
+    norm.weight = torch.randn(8)
+    fake_x = _FakeTensor(torch.randn(1, 8), "cuda")
+    fake_r = _FakeTensor(torch.randn(1, 8), "cuda")
+    with pytest.raises(RuntimeError, match="flashinfer"):
+        norm.forward(fake_x, fake_r)

--- a/tests/layers/test_rotary.py
+++ b/tests/layers/test_rotary.py
@@ -1,0 +1,580 @@
+"""Hermetic tests for ``python/minisgl/layers/rotary.py`` device dispatch.
+
+The tests never touch CUDA or NPU hardware. Fake ``flashinfer`` and
+``torch_npu`` modules are injected via ``monkeypatch`` and a fake tensor
+wrapper carries a controlled ``device.type`` string through the dispatch
+while forwarding ``.dtype`` / ``.shape`` / ``.view`` to a real underlying
+tensor.
+"""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+import torch
+
+
+# ============================================================ fixtures
+@pytest.fixture
+def clean_optional_deps(monkeypatch):
+    """Drop any previously-cached flashinfer / torch_npu from sys.modules."""
+    for name in list(sys.modules):
+        head = name.split(".", 1)[0]
+        if head in {"flashinfer", "torch_npu"}:
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+
+@pytest.fixture
+def fresh_rotary(clean_optional_deps):
+    """Re-import ``minisgl.layers.rotary`` on a clean slate."""
+    if "minisgl.layers.rotary" in sys.modules:
+        del sys.modules["minisgl.layers.rotary"]
+    import minisgl.layers.rotary as rotary
+    return rotary
+
+
+class _BlockingFinder:
+    """Meta-path finder that raises ImportError for a fixed set of top names."""
+
+    def __init__(self, *blocked: str) -> None:
+        self._blocked = set(blocked)
+
+    def find_spec(self, name, path=None, target=None):
+        head = name.split(".", 1)[0]
+        if head in self._blocked:
+            raise ImportError(f"blocked by test finder: {name}")
+        return None
+
+
+@pytest.fixture
+def block_flashinfer(monkeypatch):
+    for name in list(sys.modules):
+        if name.split(".", 1)[0] == "flashinfer":
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    finder = _BlockingFinder("flashinfer")
+    monkeypatch.setattr(sys, "meta_path", [finder] + list(sys.meta_path))
+
+
+@pytest.fixture
+def block_torch_npu(monkeypatch):
+    for name in list(sys.modules):
+        if name.split(".", 1)[0] == "torch_npu":
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    finder = _BlockingFinder("torch_npu")
+    monkeypatch.setattr(sys, "meta_path", [finder] + list(sys.meta_path))
+
+
+# ============================================================ helpers
+class _FakeDevice:
+    def __init__(self, t: str) -> None:
+        self.type = t
+
+    def __repr__(self) -> str:
+        return f"_FakeDevice(type={self.type!r})"
+
+
+class _FakeTensor:
+    """Minimal tensor stand-in.
+
+    The dispatch code reads ``.device.type`` for branching, ``.dtype`` for
+    the cos/sin cast, ``.shape`` for reshaping, and calls ``.view(...)`` to
+    build the 4-D BSND input for ``npu_rotary_mul``. The FlashInfer path
+    passes ``self`` through unchanged as the return value.
+    """
+
+    def __init__(self, real: torch.Tensor, device_type: str) -> None:
+        self._real = real
+        self.device = _FakeDevice(device_type)
+
+    @property
+    def dtype(self):
+        return self._real.dtype
+
+    @property
+    def shape(self):
+        return self._real.shape
+
+    def view(self, *args):
+        return self._real.view(*args)
+
+
+def _cpu_reference_rope(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    rotary_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Standalone NeoX rotate_half reference, computed in fp32.
+
+    Indexes ``cos_sin_cache`` with ``positions`` directly — no dtype
+    coercion, mirroring the production dispatch policy.
+    """
+    half = rotary_dim // 2
+    selected = cos_sin_cache[positions]
+    cos_half = selected[..., :half]
+    sin_half = selected[..., half:]
+    cos_full = torch.cat((cos_half, cos_half), dim=-1).unsqueeze(1)  # (T, 1, D)
+    sin_full = torch.cat((sin_half, sin_half), dim=-1).unsqueeze(1)
+
+    def _rotate(x: torch.Tensor) -> torch.Tensor:
+        x_f = x.float()
+        x1 = x_f[..., :half]
+        x2 = x_f[..., half:]
+        rotated = torch.cat((-x2, x1), dim=-1)
+        return (x_f * cos_full + rotated * sin_full).to(x.dtype)
+
+    return _rotate(query), _rotate(key)
+
+
+class _StrictPositions(torch.Tensor):
+    """torch.Tensor subclass whose dtype-coercion methods raise.
+
+    Any call to ``.to()``, ``.long()`` or ``.type()`` on an instance fails
+    the test loudly — the RoPE dispatch must accept the caller's positions
+    dtype (int32 or int64) verbatim and index ``_cos_sin_cache`` directly.
+
+    ``__torch_function__`` unwraps ``_StrictPositions`` args to plain
+    ``torch.Tensor`` before delegating to the real op, so downstream results
+    (``cache[positions]`` → ``cos_full`` → …) are plain tensors and don't
+    inherit the raising overrides. Only direct method calls on a positions
+    instance can trip the guard.
+    """
+
+    @classmethod
+    def __torch_function__(cls, func, types, args=(), kwargs=None):
+        if kwargs is None:
+            kwargs = {}
+        # Second line of defence: catch ``.to`` / ``.long`` / ``.type`` calls
+        # that arrive here rather than via Python-level method resolution.
+        fname = getattr(func, "__name__", "")
+        if fname in {"to", "long", "type"}:
+            for a in args:
+                if isinstance(a, _StrictPositions):
+                    raise AssertionError(
+                        f"positions.{fname}(...) reached via __torch_function__ "
+                        "— RoPE dispatch must not coerce positions dtype"
+                    )
+
+        # Disable subclass dispatch for the duration of unwrap + delegated
+        # call, so ``_make_subclass`` and the real op don't re-enter here.
+        with torch._C.DisableTorchFunctionSubclass():
+            def _unwrap(x):
+                if isinstance(x, _StrictPositions):
+                    return torch.Tensor._make_subclass(torch.Tensor, x)
+                return x
+
+            new_args = tuple(_unwrap(a) for a in args)
+            new_kwargs = {k: _unwrap(v) for k, v in kwargs.items()}
+            return func(*new_args, **new_kwargs)
+
+    def to(self, *args, **kwargs):
+        raise AssertionError(
+            f"positions.to({args!r}, {kwargs!r}) called — RoPE dispatch must "
+            "not coerce positions dtype"
+        )
+
+    def long(self, *args, **kwargs):
+        raise AssertionError(
+            "positions.long() called — RoPE dispatch must not coerce positions"
+        )
+
+    def type(self, *args, **kwargs):
+        raise AssertionError(
+            f"positions.type({args!r}) called — RoPE dispatch must not coerce"
+        )
+
+
+def _make_strict(values_or_tensor, dtype: torch.dtype | None = None) -> torch.Tensor:
+    if isinstance(values_or_tensor, torch.Tensor):
+        base = values_or_tensor
+    else:
+        base = torch.tensor(values_or_tensor, dtype=dtype)
+    # ``_make_subclass`` is a C-level factory that doesn't dispatch through
+    # ``__torch_function__``, avoiding infinite recursion during setup.
+    return torch.Tensor._make_subclass(_StrictPositions, base)
+
+
+def _install_fake_flashinfer(monkeypatch, apply_rope=None):
+    fake = types.ModuleType("flashinfer")
+    if apply_rope is not None:
+        fake.apply_rope_with_cos_sin_cache_inplace = apply_rope
+    monkeypatch.setitem(sys.modules, "flashinfer", fake)
+
+
+def _install_fake_torch_npu(monkeypatch, rotary_mul=None):
+    fake = types.ModuleType("torch_npu")
+    if rotary_mul is not None:
+        fake.npu_rotary_mul = rotary_mul
+    monkeypatch.setitem(sys.modules, "torch_npu", fake)
+
+
+# ================================================================ #1
+def test_import_rotary_does_not_trigger_optional_deps(fresh_rotary):
+    assert "flashinfer" not in sys.modules
+    assert "torch_npu" not in sys.modules
+
+
+# ================================================================ #2
+def test_construct_rotary_does_not_trigger_optional_deps(fresh_rotary):
+    _ = fresh_rotary.RotaryEmbedding(128, 128, 32, 10000.0)
+    assert "flashinfer" not in sys.modules
+    assert "torch_npu" not in sys.modules
+
+
+# ================================================================ #3
+def test_construct_preserves_params_and_cache_shape(fresh_rotary):
+    rope = fresh_rotary.RotaryEmbedding(128, 128, 64, 10000.0)
+    assert rope.head_size == 128
+    assert rope.rotary_dim == 128
+    assert rope._cos_sin_cache.shape == (64, 128)
+    assert rope._cos_sin_cache.dtype == torch.float32
+    # StateLessOP short-circuits state_dict to empty — cache must not leak.
+    assert rope.state_dict() == {}
+
+
+# ================================================================ #4
+def test_cpu_forward_matches_neox_reference_fp32(fresh_rotary):
+    torch.manual_seed(4001)
+    rope = fresh_rotary.RotaryEmbedding(128, 128, 32, 10000.0)
+    T, Hq, Hk, D = 6, 4, 2, 128
+    positions = torch.tensor([0, 1, 2, 5, 7, 9], dtype=torch.int64)
+    query = torch.randn(T, Hq, D, dtype=torch.float32)
+    key = torch.randn(T, Hk, D, dtype=torch.float32)
+
+    q_out, k_out = rope.forward(positions, query, key)
+
+    q_ref, k_ref = _cpu_reference_rope(query, key, positions, rope._cos_sin_cache, 128)
+    assert q_out.shape == query.shape
+    assert k_out.shape == key.shape
+    assert q_out.dtype == query.dtype
+    assert k_out.dtype == key.dtype
+    assert torch.allclose(q_out, q_ref, atol=1e-6)
+    assert torch.allclose(k_out, k_ref, atol=1e-6)
+
+
+# ================================================================ #5
+def test_cpu_forward_returns_new_tensors_and_inputs_untouched(fresh_rotary):
+    torch.manual_seed(4002)
+    rope = fresh_rotary.RotaryEmbedding(64, 64, 32, 10000.0)
+    T, Hq, Hk, D = 4, 3, 1, 64
+    positions = torch.tensor([1, 3, 5, 7], dtype=torch.int64)
+    query = torch.randn(T, Hq, D, dtype=torch.float32)
+    key = torch.randn(T, Hk, D, dtype=torch.float32)
+    q_orig = query.clone()
+    k_orig = key.clone()
+    q_ptr, k_ptr = query.data_ptr(), key.data_ptr()
+
+    q_out, k_out = rope.forward(positions, query, key)
+
+    assert torch.equal(query, q_orig)
+    assert torch.equal(key, k_orig)
+    assert q_out.data_ptr() != q_ptr
+    assert k_out.data_ptr() != k_ptr
+
+
+# ================================================================ #6
+def test_cpu_forward_accepts_non_contiguous_positions(fresh_rotary):
+    torch.manual_seed(4003)
+    rope = fresh_rotary.RotaryEmbedding(64, 64, 32, 10000.0)
+    T, Hq, Hk, D = 4, 2, 2, 64
+    # Non-contiguous slice — stride 2 view over an 8-element vector, wrapped
+    # as a _StrictPositions so any .to()/.long()/.type() from the dispatch
+    # would raise immediately.
+    base = torch.tensor([0, 99, 1, 99, 3, 99, 5, 99], dtype=torch.int64)
+    positions = _make_strict(base[::2])
+    assert not positions.is_contiguous()
+    assert positions.shape == (4,)
+    pos_id_pre = id(positions)
+    pos_dtype_pre = positions.dtype
+
+    query = torch.randn(T, Hq, D, dtype=torch.float32)
+    key = torch.randn(T, Hk, D, dtype=torch.float32)
+
+    q_out, k_out = rope.forward(positions, query, key)
+
+    # Same object, same dtype after the call.
+    assert id(positions) == pos_id_pre
+    assert positions.dtype == pos_dtype_pre == torch.int64
+
+    ref_positions = torch.tensor([0, 1, 3, 5], dtype=torch.int64)
+    q_ref, k_ref = _cpu_reference_rope(query, key, ref_positions, rope._cos_sin_cache, 64)
+    assert torch.allclose(q_out, q_ref, atol=1e-6)
+    assert torch.allclose(k_out, k_ref, atol=1e-6)
+
+
+# ================================================================ #7
+@pytest.mark.parametrize("pos_dtype", [torch.int32, torch.int64])
+def test_cpu_forward_accepts_int32_and_int64_positions(fresh_rotary, pos_dtype):
+    torch.manual_seed(4004)
+    rope = fresh_rotary.RotaryEmbedding(64, 64, 32, 10000.0)
+    T, Hq, Hk, D = 5, 2, 1, 64
+    values = [0, 1, 2, 4, 8]
+    positions = _make_strict(values, pos_dtype)
+    pos_id_pre = id(positions)
+    pos_dtype_pre = positions.dtype
+    query = torch.randn(T, Hq, D, dtype=torch.float32)
+    key = torch.randn(T, Hk, D, dtype=torch.float32)
+
+    q_out, k_out = rope.forward(positions, query, key)
+
+    # positions object identity + dtype preserved through the dispatch.
+    assert id(positions) == pos_id_pre
+    assert positions.dtype == pos_dtype_pre == pos_dtype
+
+    # Numerical correctness — compared against a plain-int64 reference.
+    ref_positions = torch.tensor(values, dtype=torch.int64)
+    q_ref, k_ref = _cpu_reference_rope(query, key, ref_positions, rope._cos_sin_cache, 64)
+    assert torch.allclose(q_out, q_ref, atol=1e-6)
+    assert torch.allclose(k_out, k_ref, atol=1e-6)
+
+
+# ================================================================ #7b
+def test_int32_and_int64_positions_produce_identical_outputs(fresh_rotary):
+    """Same position indices in int32 vs int64 must yield bit-identical output."""
+    torch.manual_seed(4009)
+    rope = fresh_rotary.RotaryEmbedding(128, 128, 32, 10000.0)
+    T, Hq, Hk, D = 4, 2, 1, 128
+    values = [0, 2, 5, 8]
+    query = torch.randn(T, Hq, D, dtype=torch.float32)
+    key = torch.randn(T, Hk, D, dtype=torch.float32)
+    q_clone = query.clone()
+    k_clone = key.clone()
+
+    positions_i32 = _make_strict(values, torch.int32)
+    q_i32, k_i32 = rope.forward(positions_i32, query, key)
+    assert positions_i32.dtype == torch.int32   # unchanged
+
+    positions_i64 = _make_strict(values, torch.int64)
+    q_i64, k_i64 = rope.forward(positions_i64, q_clone, k_clone)
+    assert positions_i64.dtype == torch.int64   # unchanged
+
+    assert torch.equal(q_i32, q_i64)
+    assert torch.equal(k_i32, k_i64)
+
+
+# ================================================================ #8
+def test_cpu_forward_supports_different_hq_hk_head_counts(fresh_rotary):
+    torch.manual_seed(4005)
+    rope = fresh_rotary.RotaryEmbedding(128, 128, 32, 10000.0)
+    T, D = 3, 128
+    Hq, Hk = 8, 1   # extreme GQA — 8 query heads, 1 KV head.
+    positions = torch.tensor([2, 4, 6], dtype=torch.int64)
+    query = torch.randn(T, Hq, D, dtype=torch.float32)
+    key = torch.randn(T, Hk, D, dtype=torch.float32)
+
+    q_out, k_out = rope.forward(positions, query, key)
+    assert q_out.shape == (T, Hq, D)
+    assert k_out.shape == (T, Hk, D)
+    q_ref, k_ref = _cpu_reference_rope(query, key, positions, rope._cos_sin_cache, 128)
+    assert torch.allclose(q_out, q_ref, atol=1e-6)
+    assert torch.allclose(k_out, k_ref, atol=1e-6)
+
+
+# ================================================================ #9
+def test_npu_forward_reshapes_qk_to_4d_bsnd(fresh_rotary, monkeypatch):
+    call_log = []
+
+    def fake_rotary_mul(x, r1, r2, rotary_mode):
+        call_log.append({"x_shape": tuple(x.shape), "r1_shape": tuple(r1.shape),
+                         "r2_shape": tuple(r2.shape), "rotary_mode": rotary_mode})
+        return torch.zeros_like(x)
+
+    _install_fake_torch_npu(monkeypatch, rotary_mul=fake_rotary_mul)
+
+    rope = fresh_rotary.RotaryEmbedding(128, 128, 32, 10000.0)
+    T, Hq, Hk, D = 5, 4, 2, 128
+    positions = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int64)
+    fake_q = _FakeTensor(torch.randn(T, Hq, D, dtype=torch.float16), "npu")
+    fake_k = _FakeTensor(torch.randn(T, Hk, D, dtype=torch.float16), "npu")
+
+    _ = rope.forward(positions, fake_q, fake_k)
+
+    assert len(call_log) == 2
+    # Query call
+    assert call_log[0]["x_shape"] == (1, T, Hq, D)
+    # Key call
+    assert call_log[1]["x_shape"] == (1, T, Hk, D)
+
+
+# ================================================================ #10
+def test_npu_forward_cos_sin_shape_is_1_T_1_D_neox_split(fresh_rotary, monkeypatch):
+    captured = []
+
+    def fake_rotary_mul(x, r1, r2, rotary_mode):
+        captured.append({"r1": r1.clone(), "r2": r2.clone()})
+        return torch.zeros_like(x)
+
+    _install_fake_torch_npu(monkeypatch, rotary_mul=fake_rotary_mul)
+
+    rope = fresh_rotary.RotaryEmbedding(128, 128, 32, 10000.0)
+    T, Hq, Hk, D = 3, 2, 1, 128
+    positions = torch.tensor([1, 2, 5], dtype=torch.int64)
+    fake_q = _FakeTensor(torch.randn(T, Hq, D, dtype=torch.float16), "npu")
+    fake_k = _FakeTensor(torch.randn(T, Hk, D, dtype=torch.float16), "npu")
+
+    _ = rope.forward(positions, fake_q, fake_k)
+
+    assert len(captured) == 2
+    for entry in captured:
+        assert entry["r1"].shape == (1, T, 1, D)
+        assert entry["r2"].shape == (1, T, 1, D)
+        assert entry["r1"].dtype == torch.float16
+        assert entry["r2"].dtype == torch.float16
+
+    # NeoX split correctness: cos_full == cat(cos_half, cos_half); the two
+    # halves of the last dim must be equal to each other.
+    r1 = captured[0]["r1"]
+    half = D // 2
+    assert torch.equal(r1[..., :half], r1[..., half:])
+    r2 = captured[0]["r2"]
+    assert torch.equal(r2[..., :half], r2[..., half:])
+
+    # And the halves must match what the shared cache actually stores.
+    selected = rope._cos_sin_cache[positions.long()]        # (T, D) fp32
+    cos_half_ref = selected[..., :half].to(torch.float16)   # (T, half)
+    sin_half_ref = selected[..., half:].to(torch.float16)
+    # r1 has shape (1, T, 1, D) — squeeze to (T, D) then take first half.
+    assert torch.equal(r1.view(T, D)[..., :half], cos_half_ref)
+    assert torch.equal(r2.view(T, D)[..., :half], sin_half_ref)
+
+
+# ================================================================ #11
+def test_npu_forward_calls_npu_rotary_mul_twice_with_rotary_mode_half(fresh_rotary, monkeypatch):
+    call_log = []
+
+    def fake_rotary_mul(x, r1, r2, rotary_mode):
+        call_log.append(rotary_mode)
+        return torch.zeros_like(x)
+
+    _install_fake_torch_npu(monkeypatch, rotary_mul=fake_rotary_mul)
+
+    rope = fresh_rotary.RotaryEmbedding(128, 128, 32, 10000.0)
+    T, Hq, Hk, D = 4, 3, 3, 128
+    positions = torch.tensor([0, 1, 2, 3], dtype=torch.int64)
+    fake_q = _FakeTensor(torch.randn(T, Hq, D, dtype=torch.float16), "npu")
+    fake_k = _FakeTensor(torch.randn(T, Hk, D, dtype=torch.float16), "npu")
+
+    _ = rope.forward(positions, fake_q, fake_k)
+
+    assert call_log == ["half", "half"]
+
+
+# ================================================================ #12
+def test_npu_forward_returns_new_tensors_no_copy_no_contiguous(fresh_rotary, monkeypatch):
+    sentinel_q_4d = torch.randn(1, 4, 3, 128, dtype=torch.float16)
+    sentinel_k_4d = torch.randn(1, 4, 1, 128, dtype=torch.float16)
+    seen = []
+
+    def fake_rotary_mul(x, r1, r2, rotary_mode):
+        seen.append(tuple(x.shape))
+        if x.shape[2] == 3:
+            return sentinel_q_4d
+        return sentinel_k_4d
+
+    _install_fake_torch_npu(monkeypatch, rotary_mul=fake_rotary_mul)
+
+    rope = fresh_rotary.RotaryEmbedding(128, 128, 32, 10000.0)
+    T, Hq, Hk, D = 4, 3, 1, 128
+    positions = torch.tensor([0, 1, 2, 3], dtype=torch.int64)
+    real_q = torch.randn(T, Hq, D, dtype=torch.float16)
+    real_k = torch.randn(T, Hk, D, dtype=torch.float16)
+    q_orig = real_q.clone()
+    k_orig = real_k.clone()
+    fake_q = _FakeTensor(real_q, "npu")
+    fake_k = _FakeTensor(real_k, "npu")
+
+    q_out, k_out = rope.forward(positions, fake_q, fake_k)
+
+    # Inputs never mutated (no copy_).
+    assert torch.equal(real_q, q_orig)
+    assert torch.equal(real_k, k_orig)
+    # Returned tensors are derived from the sentinels (no clone / contiguous
+    # inserted — .squeeze(0) is a view, so data_ptr matches the sentinels).
+    assert q_out.data_ptr() == sentinel_q_4d.data_ptr()
+    assert k_out.data_ptr() == sentinel_k_4d.data_ptr()
+    assert q_out.shape == (T, Hq, D)
+    assert k_out.shape == (T, Hk, D)
+
+
+# ================================================================ #13
+def test_cuda_forward_delegates_to_flashinfer_inplace_returns_identity(
+    fresh_rotary, monkeypatch,
+):
+    call_log = []
+
+    def fake_apply_rope(positions, query, key, head_size, cos_sin_cache):
+        call_log.append({
+            "positions": positions, "query": query, "key": key,
+            "head_size": head_size, "cos_sin_cache": cos_sin_cache,
+        })
+        return None
+
+    _install_fake_flashinfer(monkeypatch, apply_rope=fake_apply_rope)
+
+    rope = fresh_rotary.RotaryEmbedding(128, 128, 32, 10000.0)
+    positions = torch.tensor([0, 1, 2, 3], dtype=torch.int64)
+    fake_q = _FakeTensor(torch.randn(4, 8, 128), "cuda")
+    fake_k = _FakeTensor(torch.randn(4, 2, 128), "cuda")
+
+    q_out, k_out = rope.forward(positions, fake_q, fake_k)
+
+    # Identity return — FlashInfer mutates in-place; caller expects the same
+    # tensor objects back.
+    assert q_out is fake_q
+    assert k_out is fake_k
+    assert len(call_log) == 1
+    entry = call_log[0]
+    assert entry["positions"] is positions
+    assert entry["query"] is fake_q
+    assert entry["key"] is fake_k
+    assert entry["head_size"] == 128
+    assert entry["cos_sin_cache"] is rope._cos_sin_cache
+
+
+# ================================================================ #14
+def test_missing_optional_deps_raise_runtime_error(
+    fresh_rotary, block_flashinfer, block_torch_npu,
+):
+    rope = fresh_rotary.RotaryEmbedding(128, 128, 32, 10000.0)
+    positions = torch.tensor([0, 1], dtype=torch.int64)
+
+    fake_q_cuda = _FakeTensor(torch.randn(2, 2, 128), "cuda")
+    fake_k_cuda = _FakeTensor(torch.randn(2, 1, 128), "cuda")
+    with pytest.raises(RuntimeError, match="flashinfer"):
+        rope.forward(positions, fake_q_cuda, fake_k_cuda)
+
+    fake_q_npu = _FakeTensor(torch.randn(2, 2, 128, dtype=torch.float16), "npu")
+    fake_k_npu = _FakeTensor(torch.randn(2, 1, 128, dtype=torch.float16), "npu")
+    with pytest.raises(RuntimeError, match="torch_npu"):
+        rope.forward(positions, fake_q_npu, fake_k_npu)
+
+
+# ================================================================ #15
+def test_rotary_source_never_coerces_positions_dtype(fresh_rotary):
+    """AST guard: ``positions.to(...)`` / ``.long()`` / ``.type(...)`` must
+    not appear anywhere in ``rotary.py`` — the dispatch has to index the
+    cache with the caller's positions verbatim.
+    """
+    import ast
+    import inspect
+
+    src = inspect.getsource(fresh_rotary)
+    tree = ast.parse(src)
+    forbidden = {"to", "long", "type"}
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute):
+            continue
+        # Only flag ``positions.<name>(...)``.
+        if isinstance(func.value, ast.Name) and func.value.id == "positions":
+            if func.attr in forbidden:
+                offenders.append(f"positions.{func.attr}(...) at line {node.lineno}")
+    assert offenders == [], (
+        "rotary.py must not coerce ``positions`` dtype; found: "
+        + "; ".join(offenders)
+    )

--- a/tests/layers/test_rotary.py
+++ b/tests/layers/test_rotary.py
@@ -65,6 +65,79 @@ def block_torch_npu(monkeypatch):
     monkeypatch.setattr(sys, "meta_path", [finder] + list(sys.meta_path))
 
 
+# ---------- npu device shim (hermetic, no torch_npu required) --------------
+#
+# ``torch.device('npu[...]')`` string parsing fails on hosts without
+# ``torch_npu`` — the parser doesn't know the ``npu`` type name. Tests that
+# only need to *reason about* an ``npu`` device (cache-key isolation,
+# accelerator-index rejection, etc.) shouldn't require torch_npu wheels.
+#
+# This fixture intercepts ``torch.device('npu', ...)`` / ``torch.device('npu:i')``
+# with a lightweight stand-in that mimics the surface ``_normalize_device``
+# consumes: ``.type``, ``.index``, equality, and hashability. All other
+# ``torch.device(...)`` inputs (cpu, meta, cuda:i) fall through to the real
+# parser.
+
+
+class _NpuDeviceStub:
+    __slots__ = ("type", "index")
+
+    def __init__(self, index):
+        self.type = "npu"
+        self.index = index
+
+    def __repr__(self):
+        if self.index is None:
+            return "device(type='npu')"
+        return f"device(type='npu', index={self.index})"
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, _NpuDeviceStub)
+            and self.type == other.type
+            and self.index == other.index
+        )
+
+    def __hash__(self):
+        return hash((self.type, self.index))
+
+
+@pytest.fixture
+def npu_device_shim(monkeypatch):
+    """Return a ``make(type, index=None)`` builder that produces a stand-in
+    ``torch.device('npu[:i]')`` while patching ``torch.device`` so
+    ``_normalize_device``'s own ``torch.device(device)`` re-wrap step accepts
+    the stub. Non-npu calls fall through to the real constructor unchanged.
+    """
+    real_torch_device = torch.device
+
+    def fake_device(*args, **kwargs):
+        # torch.device(stub) → identity for our stub
+        if len(args) == 1 and isinstance(args[0], _NpuDeviceStub):
+            return args[0]
+        # torch.device("npu", idx)
+        if len(args) >= 1 and args[0] == "npu":
+            idx = args[1] if len(args) > 1 else kwargs.get("index")
+            return _NpuDeviceStub(idx)
+        # torch.device("npu:i") string form
+        if len(args) == 1 and isinstance(args[0], str) and args[0].startswith("npu"):
+            s = args[0]
+            if s == "npu":
+                return _NpuDeviceStub(None)
+            if ":" in s:
+                _, idx_s = s.split(":", 1)
+                return _NpuDeviceStub(int(idx_s))
+        return real_torch_device(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "device", fake_device)
+
+    def make(_type, index=None):
+        assert _type == "npu", "npu_device_shim only synthesises 'npu' devices"
+        return _NpuDeviceStub(index)
+
+    return make
+
+
 # ============================================================ helpers
 class _FakeDevice:
     def __init__(self, t: str) -> None:
@@ -578,3 +651,342 @@ def test_rotary_source_never_coerces_positions_dtype(fresh_rotary):
         "rotary.py must not coerce ``positions`` dtype; found: "
         + "; ".join(offenders)
     )
+
+
+# ==================================================================== #16
+# ---------- Device-keyed cache tests --------------------------------------
+#
+# These tests exercise the split between the public ``get_rope`` (which
+# resolves a target device from setter / ambient) and the private
+# ``_get_rope_cached`` (which is keyed on (params, device)).
+#
+# We deliberately never enter ``with torch.device('npu:0'):`` from these
+# tests: on CI hosts without ``torch_npu`` that would raise from PyTorch's
+# device dispatch. Instead we monkeypatch ``rotary._build_rope`` — the
+# private constructor shim that owns the device context — with a stub that
+# returns a fresh sentinel per call and records what it was asked to build.
+# The cache-key logic under test lives entirely in ``_get_rope_cached`` and
+# is orthogonal to whether real allocation happens.
+
+
+class _RopeSentinel:
+    """Lightweight stand-in for ``RotaryEmbedding`` returned by the stub."""
+
+    __slots__ = ("device", "tag")
+
+    def __init__(self, device: torch.device, tag: object) -> None:
+        self.device = device
+        self.tag = tag
+
+
+@pytest.fixture
+def stub_build(fresh_rotary):
+    """Rebind ``rotary._build_rope`` to a stub that never touches PyTorch's
+    device dispatch.
+
+    ``_get_rope_cached`` resolves ``_build_rope`` from the module globals at
+    call time, so simply reassigning the attribute is enough — no cache
+    surgery required. We also clear any residual cache entries so tests
+    that run after another test in the same module see a virgin cache.
+    """
+    calls: list[dict] = []
+
+    def stub(head_dim, rotary_dim, max_position, base, rope_scaling, device):
+        payload = dict(
+            head_dim=head_dim,
+            rotary_dim=rotary_dim,
+            max_position=max_position,
+            base=base,
+            rope_scaling=rope_scaling,
+            device=device,
+        )
+        calls.append(payload)
+        return _RopeSentinel(device=device, tag=len(calls))
+
+    fresh_rotary._build_rope = stub
+    fresh_rotary.get_rope.cache_clear()
+    return calls
+
+
+# --- resolver rules -------------------------------------------------------
+
+def test_resolve_setter_wins_when_no_meta(fresh_rotary):
+    """(rule 1) Setter takes precedence over the ambient CPU default."""
+    fresh_rotary.set_rope_device(torch.device("cuda:0"))
+    resolved = fresh_rotary._resolve_rope_device()
+    assert resolved.type == "cuda"
+    assert resolved.index == 0
+
+
+def test_resolve_setter_wins_under_meta(fresh_rotary):
+    """(rule 1 under meta) Setter still wins inside ``torch.device('meta')``."""
+    fresh_rotary.set_rope_device(torch.device("cuda:0"))
+    with torch.device("meta"):
+        resolved = fresh_rotary._resolve_rope_device()
+    assert resolved.type == "cuda"
+    assert resolved.index == 0
+
+
+def test_resolve_falls_back_to_ambient_cpu(fresh_rotary):
+    """(rule 2) With no setter and no meta scope, ambient CPU is returned."""
+    assert fresh_rotary._ROPE_DEVICE is None
+    resolved = fresh_rotary._resolve_rope_device()
+    assert resolved == torch.device("cpu")
+
+
+def test_resolve_raises_on_meta_without_setter(fresh_rotary):
+    """(rule 3) Meta ambient with no setter must raise a clear ``RuntimeError``."""
+    assert fresh_rotary._ROPE_DEVICE is None
+    with torch.device("meta"):
+        with pytest.raises(RuntimeError, match="set_rope_device"):
+            fresh_rotary._resolve_rope_device()
+
+
+def test_normalize_device_cpu_variants_collapse(fresh_rotary):
+    """``cpu`` and ``cpu:0`` normalise to the same, type-only, cache key."""
+    a = fresh_rotary._normalize_device(torch.device("cpu"))
+    b = fresh_rotary._normalize_device(torch.device("cpu", 0))
+    assert a == b == torch.device("cpu")
+    assert hash(a) == hash(b)
+
+
+def test_normalize_device_meta_collapses_to_type_only(fresh_rotary):
+    """``meta`` normalises to type-only (never gains a spurious index)."""
+    a = fresh_rotary._normalize_device(torch.device("meta"))
+    assert a == torch.device("meta")
+
+
+def test_normalize_device_preserves_distinct_indices_cuda(fresh_rotary):
+    """``cuda:0`` and ``cuda:1`` must stay distinct after normalisation."""
+    a = fresh_rotary._normalize_device(torch.device("cuda:0"))
+    b = fresh_rotary._normalize_device(torch.device("cuda:1"))
+    assert a != b
+    assert a.type == "cuda" and a.index == 0
+    assert b.type == "cuda" and b.index == 1
+
+
+def test_normalize_device_preserves_distinct_indices_npu(fresh_rotary, npu_device_shim):
+    """``npu:0`` and ``npu:1`` must stay distinct after normalisation.
+
+    ``torch.device('npu[...]')`` string parsing fails on CI hosts without
+    ``torch_npu`` — the ``npu_device_shim`` fixture intercepts just those
+    calls with a hermetic stand-in.
+    """
+    make = npu_device_shim
+    a = fresh_rotary._normalize_device(make("npu", 0))
+    b = fresh_rotary._normalize_device(make("npu", 1))
+    assert a != b
+    assert a.type == "npu" and a.index == 0
+    assert b.type == "npu" and b.index == 1
+
+
+def test_normalize_device_rejects_cuda_without_index(fresh_rotary):
+    """Bare ``torch.device('cuda')`` must be rejected (was: silent → cuda:0)."""
+    with pytest.raises(ValueError, match="explicit index"):
+        fresh_rotary._normalize_device(torch.device("cuda"))
+
+
+def test_normalize_device_rejects_npu_without_index(fresh_rotary, npu_device_shim):
+    """Bare ``torch.device('npu')`` must be rejected (was: silent → npu:0)."""
+    make = npu_device_shim
+    with pytest.raises(ValueError, match="explicit index"):
+        fresh_rotary._normalize_device(make("npu"))
+
+
+def test_engine_style_explicit_index_setter_normalises_cleanly(fresh_rotary, npu_device_shim):
+    """The production Engine passes ``torch.device('npu:{rank}')`` — this must
+    round-trip through ``_normalize_device`` without raising and preserve
+    both type and index.
+    """
+    make = npu_device_shim
+    r0 = fresh_rotary._normalize_device(make("npu", 0))
+    assert r0.type == "npu" and r0.index == 0
+    r3 = fresh_rotary._normalize_device(make("npu", 3))
+    assert r3.type == "npu" and r3.index == 3
+
+
+# --- cache key & identity -------------------------------------------------
+
+def test_cache_hit_same_params_same_device(fresh_rotary, stub_build):
+    """Same (params, device) → cache hit and object identity."""
+    fresh_rotary.set_rope_device(torch.device("cuda:0"))
+    r1 = fresh_rotary.get_rope(128, 128, 128, 1_000_000.0, None)
+    info1 = fresh_rotary.get_rope.cache_info()
+    r2 = fresh_rotary.get_rope(128, 128, 128, 1_000_000.0, None)
+    info2 = fresh_rotary.get_rope.cache_info()
+
+    assert r1 is r2
+    assert len(stub_build) == 1
+    assert info1.misses == 1 and info1.hits == 0 and info1.currsize == 1
+    assert info2.misses == 1 and info2.hits == 1 and info2.currsize == 1
+
+
+def test_cache_cpu_then_switch_to_gpu_returns_different_object(fresh_rotary, stub_build):
+    """CPU → NPU (represented here as ``cuda:0`` for CI portability):
+    the second call must return a distinct module on the new device.
+    """
+    # first: no setter → ambient CPU
+    r_cpu = fresh_rotary.get_rope(128, 128, 128, 1_000_000.0, None)
+    # then: switch target device via setter
+    fresh_rotary.set_rope_device(torch.device("cuda:0"))
+    r_gpu = fresh_rotary.get_rope(128, 128, 128, 1_000_000.0, None)
+
+    assert r_cpu is not r_gpu
+    assert r_cpu.device == torch.device("cpu")
+    assert r_gpu.device == torch.device("cuda", 0)
+    info = fresh_rotary.get_rope.cache_info()
+    assert info.misses == 2 and info.currsize == 2
+
+
+def test_cache_gpu_then_switch_to_cpu_returns_different_object(fresh_rotary, stub_build):
+    """NPU → CPU: the second call must return a distinct CPU module."""
+    fresh_rotary.set_rope_device(torch.device("cuda:0"))
+    r_gpu = fresh_rotary.get_rope(128, 128, 128, 1_000_000.0, None)
+    # clear the explicit setter → resolver falls back to ambient CPU
+    fresh_rotary._ROPE_DEVICE = None
+    r_cpu = fresh_rotary.get_rope(128, 128, 128, 1_000_000.0, None)
+
+    assert r_gpu is not r_cpu
+    assert r_gpu.device == torch.device("cuda", 0)
+    assert r_cpu.device == torch.device("cpu")
+
+
+def test_cache_distinguishes_accelerator_indices(fresh_rotary, stub_build):
+    """``cuda:0`` and ``cuda:1`` are distinct cache keys (proxy for npu:0 / npu:1)."""
+    fresh_rotary.set_rope_device(torch.device("cuda:0"))
+    r0 = fresh_rotary.get_rope(128, 128, 128, 1_000_000.0, None)
+    fresh_rotary.set_rope_device(torch.device("cuda:1"))
+    r1 = fresh_rotary.get_rope(128, 128, 128, 1_000_000.0, None)
+
+    assert r0 is not r1
+    assert r0.device.index == 0
+    assert r1.device.index == 1
+    info = fresh_rotary.get_rope.cache_info()
+    assert info.misses == 2 and info.currsize == 2
+
+
+# --- setter / cache_clear semantics --------------------------------------
+
+def test_setter_switch_does_not_mutate_existing(fresh_rotary, stub_build):
+    """Rebinding the setter must not migrate or invalidate already-returned modules."""
+    fresh_rotary.set_rope_device(torch.device("cuda:0"))
+    r0 = fresh_rotary.get_rope(128, 128, 128, 1_000_000.0, None)
+    original_id = id(r0)
+    original_device = r0.device
+
+    # switch away, then back
+    fresh_rotary.set_rope_device(torch.device("cuda:1"))
+    _ = fresh_rotary.get_rope(128, 128, 128, 1_000_000.0, None)
+
+    # r0 itself untouched
+    assert id(r0) == original_id
+    assert r0.device == original_device
+
+    # returning to cuda:0 hits the same cached object
+    fresh_rotary.set_rope_device(torch.device("cuda:0"))
+    r0_again = fresh_rotary.get_rope(128, 128, 128, 1_000_000.0, None)
+    assert r0_again is r0
+
+
+def test_setter_does_not_call_cache_clear(fresh_rotary, stub_build):
+    """``set_rope_device`` is not allowed to flush the cache."""
+    fresh_rotary.set_rope_device(torch.device("cuda:0"))
+    _ = fresh_rotary.get_rope(128, 128, 128, 1_000_000.0, None)
+    assert fresh_rotary.get_rope.cache_info().currsize == 1
+
+    fresh_rotary.set_rope_device(torch.device("cuda:1"))
+    # cuda:0 entry must survive; only a new call would grow the cache.
+    assert fresh_rotary.get_rope.cache_info().currsize == 1
+
+
+def test_explicit_cache_clear_forces_reconstruction(fresh_rotary, stub_build):
+    """After ``get_rope.cache_clear()`` the next call must miss and produce a new object."""
+    fresh_rotary.set_rope_device(torch.device("cuda:0"))
+    r0 = fresh_rotary.get_rope(128, 128, 128, 1_000_000.0, None)
+    fresh_rotary.get_rope.cache_clear()
+    assert fresh_rotary.get_rope.cache_info().currsize == 0
+
+    r1 = fresh_rotary.get_rope(128, 128, 128, 1_000_000.0, None)
+    assert r0 is not r1
+    info = fresh_rotary.get_rope.cache_info()
+    assert info.misses == 1 and info.hits == 0 and info.currsize == 1
+
+
+def test_cache_diagnostics_forwarded_from_get_rope(fresh_rotary):
+    """``get_rope.cache_info`` / ``cache_clear`` are aliased from the private cached fn.
+
+    We cannot compare bound-method identity directly (each attribute access
+    yields a fresh bound-method wrapper), so we assert behavioural
+    equivalence: (1) diagnostics agree on the current state, and
+    (2) clearing via ``get_rope`` is observable via the private fn's
+    ``cache_info``.
+    """
+    # after a fresh import the cache is empty from both viewpoints.
+    assert fresh_rotary.get_rope.cache_info() == fresh_rotary._get_rope_cached.cache_info()
+    # populate the cache
+    _ = fresh_rotary.get_rope(128, 128, 32, 10000.0, None)
+    info_public = fresh_rotary.get_rope.cache_info()
+    info_private = fresh_rotary._get_rope_cached.cache_info()
+    assert info_public == info_private
+    assert info_public.currsize == 1
+    # clearing through the public alias is observed on the private fn
+    fresh_rotary.get_rope.cache_clear()
+    assert fresh_rotary._get_rope_cached.cache_info().currsize == 0
+
+
+def test_cache_info_hit_miss_accounting(fresh_rotary, stub_build):
+    """Sanity-check the arithmetic on hit / miss counters across a mixed sequence."""
+    # miss 1: cpu default
+    _ = fresh_rotary.get_rope(128, 128, 128, 1_000_000.0, None)
+    # hit 1
+    _ = fresh_rotary.get_rope(128, 128, 128, 1_000_000.0, None)
+    # miss 2: different params (max_position)
+    _ = fresh_rotary.get_rope(128, 128, 64, 1_000_000.0, None)
+    # miss 3: different device
+    fresh_rotary.set_rope_device(torch.device("cuda:0"))
+    _ = fresh_rotary.get_rope(128, 128, 128, 1_000_000.0, None)
+    # hit 2 on the cuda entry
+    _ = fresh_rotary.get_rope(128, 128, 128, 1_000_000.0, None)
+
+    info = fresh_rotary.get_rope.cache_info()
+    assert info.misses == 3
+    assert info.hits == 2
+    assert info.currsize == 3
+
+
+# --- integration with AttentionLayer ------------------------------------
+
+def test_attention_layer_call_signature_still_works(fresh_rotary):
+    """AttentionLayer calls ``get_rope`` with kwargs and ``rope_scaling=None``
+    (or a tuple). The public signature must accept both without change.
+    """
+    # kw-only, rope_scaling=None (Qwen / Llama base case)
+    r = fresh_rotary.get_rope(
+        head_dim=128, rotary_dim=128, max_position=32, base=10000.0, rope_scaling=None,
+    )
+    assert r.head_size == 128
+    assert r.rotary_dim == 128
+    assert r._cos_sin_cache.device == torch.device("cpu")
+
+    # kw-only, rope_scaling=tuple(...) (Llama-3 / YaRN base case)
+    scaling = (
+        ("rope_type", "llama3"),
+        ("factor", 8.0),
+        ("low_freq_factor", 1.0),
+        ("high_freq_factor", 4.0),
+        ("original_max_position_embeddings", 8192),
+    )
+    r2 = fresh_rotary.get_rope(
+        head_dim=128, rotary_dim=128, max_position=32, base=10000.0, rope_scaling=scaling,
+    )
+    assert isinstance(r2, fresh_rotary.RotaryEmbedding)
+    # different scaling → different cache key → different object
+    assert r is not r2
+
+
+def test_public_module_import_still_hides_torch_npu(fresh_rotary):
+    """Regression guard for #1 / #2 after the split: no lazy import path
+    should have leaked into rotary.py.
+    """
+    assert "torch_npu" not in sys.modules
+    assert "flashinfer" not in sys.modules

--- a/tests/misc/test_ascend_fia_backend.py
+++ b/tests/misc/test_ascend_fia_backend.py
@@ -1,0 +1,333 @@
+"""Gate 1.8a: hermetic tests for the AscendFIABackend skeleton and its wiring.
+
+The class module (``minisgl.attention.ascend_fia``) is torch-free at import
+time, so we can exercise real Python semantics — instantiation, method calls,
+and registry state — without pulling in the CUDA / Ascend runtime.
+
+The engine wiring test uses ``ast``-inspection because
+``minisgl.engine.engine`` transitively imports torch + huggingface + kernels.
+
+What's checked here:
+
+1. ``AscendFIABackend`` is instantiable (all abstract methods overridden).
+2. All five ``BaseAttnBackend`` interface methods exist on the class.
+3. ``init_capture_graph`` / ``prepare_for_capture`` / ``prepare_for_replay``
+   are callable no-ops (return ``None``).
+4. ``prepare_metadata`` returns ``None``.
+5. ``forward`` raises the exact ``NotImplementedError`` mandated by the spec.
+6. ``SUPPORTED_ATTENTION_BACKENDS`` contains ``"npu_fia"``.
+7. Registering ``"npu_fia"`` does not import ``ascend_fia`` until the factory
+   is actually invoked (lazy import).
+8. ``_adjust_config`` maps ``device_type == "npu"`` + ``auto`` → ``"npu_fia"``.
+9. ``_adjust_config`` keeps the existing SM100 / SM90 / other selection on
+   CUDA/CPU auto.
+10. Explicit ``fi`` / ``fa`` / ``trtllm`` / ``npu_fia`` are not overridden.
+11. ``ascend_fia`` module has no top-level ``torch_npu`` import.
+"""
+from __future__ import annotations
+
+import ast
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PYTHON_ROOT = _REPO_ROOT / "python"
+_ASCEND_FIA_PATH = _PYTHON_ROOT / "minisgl" / "attention" / "ascend_fia.py"
+_ATTN_INIT_PATH = _PYTHON_ROOT / "minisgl" / "attention" / "__init__.py"
+_ENGINE_PATH = _PYTHON_ROOT / "minisgl" / "engine" / "engine.py"
+
+
+# --------------------------------------------------------------------- helpers
+
+
+def _ensure_python_root_on_path() -> None:
+    p = str(_PYTHON_ROOT)
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+
+def _load_attention() -> object:
+    _ensure_python_root_on_path()
+    try:
+        import minisgl.attention as mod
+    except ImportError as exc:  # pragma: no cover — happens only off the repo
+        pytest.skip(f"minisgl.attention not importable: {exc}")
+    return mod
+
+
+def _load_ascend_fia_module() -> object:
+    _ensure_python_root_on_path()
+    try:
+        return importlib.import_module("minisgl.attention.ascend_fia")
+    except ImportError as exc:  # pragma: no cover
+        pytest.skip(f"minisgl.attention.ascend_fia not importable: {exc}")
+
+
+def _ascend_fia_source() -> str:
+    return _ASCEND_FIA_PATH.read_text()
+
+
+def _attn_init_source() -> str:
+    return _ATTN_INIT_PATH.read_text()
+
+
+def _engine_source() -> str:
+    return _ENGINE_PATH.read_text()
+
+
+def _engine_tree() -> ast.Module:
+    return ast.parse(_engine_source())
+
+
+def _adjust_config_fn() -> ast.FunctionDef:
+    return next(
+        node for node in _engine_tree().body
+        if isinstance(node, ast.FunctionDef) and node.name == "_adjust_config"
+    )
+
+
+# --------------------------------- 1 & 2: class + interface completeness ----
+
+
+def test_ascend_fia_backend_is_instantiable():
+    mod = _load_ascend_fia_module()
+    cls = mod.AscendFIABackend
+    # Abstract classes surface leftover abstract methods here; an empty frozenset
+    # proves the skeleton overrode every abstract slot on BaseAttnBackend.
+    assert cls.__abstractmethods__ == frozenset(), (
+        f"AscendFIABackend still has abstract methods: {cls.__abstractmethods__!r}"
+    )
+    # Should also actually construct.
+    backend = cls(config=None)
+    assert backend is not None
+
+
+def test_ascend_fia_backend_defines_all_five_interfaces():
+    mod = _load_ascend_fia_module()
+    cls = mod.AscendFIABackend
+    for name in (
+        "forward",
+        "prepare_metadata",
+        "init_capture_graph",
+        "prepare_for_capture",
+        "prepare_for_replay",
+    ):
+        method = getattr(cls, name, None)
+        assert callable(method), f"AscendFIABackend must define {name}()"
+
+
+# --------------------------------- 3 & 4: no-op semantics -------------------
+
+
+def test_graph_hooks_return_none():
+    mod = _load_ascend_fia_module()
+    backend = mod.AscendFIABackend(config=None)
+    assert backend.init_capture_graph(max_seq_len=64, bs_list=[1, 2, 4]) is None
+    assert backend.prepare_for_capture(batch=None) is None
+    assert backend.prepare_for_replay(batch=None) is None
+
+
+def test_prepare_metadata_returns_none():
+    mod = _load_ascend_fia_module()
+    backend = mod.AscendFIABackend(config=None)
+    assert backend.prepare_metadata(batch=None) is None
+
+
+# --------------------------------- 5: forward NotImplementedError -----------
+
+
+def test_forward_raises_gate_1_8b_deferred_error():
+    mod = _load_ascend_fia_module()
+    backend = mod.AscendFIABackend(config=None)
+    with pytest.raises(NotImplementedError) as excinfo:
+        backend.forward(q=None, k=None, v=None, layer_id=0, batch=None)
+    assert "Ascend FIA forward is not implemented until Gate 1.8b" in str(excinfo.value)
+
+
+# --------------------------------- 6: registry membership -------------------
+
+
+def test_registry_contains_npu_fia():
+    mod = _load_attention()
+    assert "npu_fia" in mod.SUPPORTED_ATTENTION_BACKENDS.supported_names(), (
+        f"expected 'npu_fia' in {mod.SUPPORTED_ATTENTION_BACKENDS.supported_names()!r}"
+    )
+
+
+# --------------------------------- 7: lazy import ---------------------------
+
+
+def test_registering_npu_fia_does_not_import_ascend_fia_at_attention_import_time():
+    """The factory must be lazy: importing ``minisgl.attention`` alone must
+    not pull in ``minisgl.attention.ascend_fia``. Only invoking the ``npu_fia``
+    factory should trigger the import.
+    """
+    _ensure_python_root_on_path()
+    # Purge both modules so the test genuinely measures lazy semantics.
+    sys.modules.pop("minisgl.attention.ascend_fia", None)
+    sys.modules.pop("minisgl.attention", None)
+    importlib.import_module("minisgl.attention")
+    assert "minisgl.attention.ascend_fia" not in sys.modules, (
+        "ascend_fia was eagerly imported during minisgl.attention import; "
+        "the npu_fia factory must import lazily."
+    )
+    # And now the factory call must actually cause the import.
+    mod = sys.modules["minisgl.attention"]
+    factory = mod.SUPPORTED_ATTENTION_BACKENDS["npu_fia"]
+    backend = factory(None)  # config=None is fine for the skeleton
+    assert backend is not None
+    assert "minisgl.attention.ascend_fia" in sys.modules, (
+        "invoking the npu_fia factory did not import ascend_fia"
+    )
+
+
+# --------------------------------- 8, 9, 10: _adjust_config wiring ----------
+# The engine module transitively imports torch + heavy runtime bits, so use
+# ast-level inspection to verify the auto-selection logic.
+
+
+def test_adjust_config_signature_takes_device_type():
+    fn = _adjust_config_fn()
+    arg_names = [a.arg for a in fn.args.args]
+    assert arg_names == ["config", "device_type"], (
+        f"_adjust_config must accept (config, device_type); got {arg_names!r}"
+    )
+
+
+def test_adjust_config_auto_npu_maps_to_npu_fia():
+    fn = _adjust_config_fn()
+    src = ast.unparse(fn)
+    # The npu branch must produce the "npu_fia" backend string.
+    assert '"npu_fia"' in src or "'npu_fia'" in src, (
+        "_adjust_config must select 'npu_fia' on the npu branch"
+    )
+    # The npu branch must gate on device_type == "npu".
+    # Look for an ast.Compare like device_type == "npu"
+    found = False
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Compare) \
+                and isinstance(node.left, ast.Name) and node.left.id == "device_type" \
+                and any(isinstance(c, ast.Constant) and c.value == "npu"
+                        for c in node.comparators):
+            found = True
+            break
+    assert found, "expected `device_type == 'npu'` inside _adjust_config"
+
+
+def test_adjust_config_cuda_keeps_original_sm_selection():
+    """The non-NPU branch must still consult ``is_sm100_supported`` /
+    ``is_sm90_supported`` and produce the original trtllm / fa,fi / fi
+    ternary. This guards against a refactor that silently drops CUDA."""
+    fn = _adjust_config_fn()
+    src = ast.unparse(fn)
+    assert "is_sm100_supported" in src, \
+        "CUDA branch must still call is_sm100_supported()"
+    assert "is_sm90_supported" in src, \
+        "CUDA branch must still call is_sm90_supported()"
+    assert '"trtllm"' in src or "'trtllm'" in src
+    assert '"fa,fi"' in src or "'fa,fi'" in src
+    assert '"fi"' in src or "'fi'" in src
+
+
+def test_adjust_config_only_overrides_when_backend_is_auto():
+    """Explicit choices — ``"fi"``, ``"fa"``, ``"trtllm"``, ``"npu_fia"`` — must
+    survive intact. The whole selection block must be gated by
+    ``config.attention_backend == "auto"``.
+    """
+    fn = _adjust_config_fn()
+    # Find the top-level `if config.attention_backend == "auto":` guard.
+    guard = None
+    for node in fn.body:
+        if isinstance(node, ast.If):
+            test_text = ast.unparse(node.test)
+            if "config.attention_backend" in test_text and '"auto"' in test_text.replace("'", '"'):
+                guard = node
+                break
+    assert guard is not None, (
+        "_adjust_config must gate backend override on "
+        "`config.attention_backend == \"auto\"`"
+    )
+    # Neither branch inside the guard should reference explicit backend names
+    # in a way that mutates them.
+    body_text = "\n".join(ast.unparse(n) for n in guard.body)
+    # The override happens only inside the auto block; the block must contain
+    # the override() call. This is a positive assertion that the mutation
+    # is scoped to the auto path.
+    assert "override" in body_text, \
+        "the auto branch must call override(...) to install the resolved backend"
+
+
+# --------------------------------- 11: no torch_npu at module top -----------
+
+
+def test_ascend_fia_module_has_no_top_level_torch_npu_import():
+    tree = ast.parse(_ascend_fia_source())
+    for node in tree.body:  # only top-level nodes
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert not alias.name.startswith("torch_npu"), (
+                    f"top-level `import {alias.name}` is forbidden in ascend_fia.py"
+                )
+        elif isinstance(node, ast.ImportFrom):
+            assert node.module is None or not node.module.startswith("torch_npu"), (
+                f"top-level `from {node.module} import ...` is forbidden in ascend_fia.py"
+            )
+
+
+def test_ascend_fia_module_never_calls_or_lazy_imports_torch_npu():
+    """Belt-and-suspenders check — even lazy imports inside functions are
+    forbidden for Gate 1.8a. The FIA op wiring lands separately in 1.8b.
+
+    We walk the AST so docstring prose that mentions ``torch_npu`` for
+    documentation purposes is allowed; only actual ``Import`` / ``ImportFrom``
+    / ``Attribute`` / ``Name`` references are rejected.
+    """
+    tree = ast.parse(_ascend_fia_source())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert not alias.name.startswith("torch_npu"), (
+                    f"lazy `import {alias.name}` forbidden in ascend_fia.py "
+                    "for Gate 1.8a"
+                )
+        elif isinstance(node, ast.ImportFrom):
+            assert node.module is None or not node.module.startswith("torch_npu"), (
+                f"lazy `from {node.module} import ...` forbidden in ascend_fia.py "
+                "for Gate 1.8a"
+            )
+        elif isinstance(node, ast.Attribute):
+            # `torch_npu.foo` or `torch_npu.foo.bar` — chase the root name.
+            root = node
+            while isinstance(root, ast.Attribute):
+                root = root.value
+            if isinstance(root, ast.Name):
+                assert root.id != "torch_npu", (
+                    "ascend_fia.py must not reference torch_npu.* for Gate 1.8a"
+                )
+        elif isinstance(node, ast.Name):
+            assert node.id != "torch_npu", (
+                "ascend_fia.py must not reference `torch_npu` for Gate 1.8a"
+            )
+
+
+# --------------------------------- factory + registry cross-check -----------
+
+
+def test_npu_fia_factory_returns_ascend_fia_backend():
+    mod = _load_attention()
+    factory = mod.SUPPORTED_ATTENTION_BACKENDS["npu_fia"]
+    backend = factory(None)
+    from minisgl.attention.ascend_fia import AscendFIABackend
+    assert isinstance(backend, AscendFIABackend)
+
+
+def test_attention_registry_still_has_original_cuda_backends():
+    """Sanity check that the new registration didn't overwrite existing CUDA
+    entries. The npu_fia addition must be purely additive."""
+    mod = _load_attention()
+    names = set(mod.SUPPORTED_ATTENTION_BACKENDS.supported_names())
+    for expected in ("trtllm", "fi", "fa"):
+        assert expected in names, f"registration for {expected!r} was lost"

--- a/tests/misc/test_ascend_fia_backend.py
+++ b/tests/misc/test_ascend_fia_backend.py
@@ -1,28 +1,38 @@
-"""Gate 1.8a: hermetic tests for the AscendFIABackend skeleton and its wiring.
+"""Hermetic tests for the AscendFIABackend across Gates 1.8a → 1.8e.
 
 The class module (``minisgl.attention.ascend_fia``) is torch-free at import
 time, so we can exercise real Python semantics — instantiation, method calls,
-and registry state — without pulling in the CUDA / Ascend runtime.
+registry state, metadata construction and the FIA forward call — without
+pulling in the CUDA / Ascend runtime.
 
 The engine wiring test uses ``ast``-inspection because
 ``minisgl.engine.engine`` transitively imports torch + huggingface + kernels.
 
 What's checked here:
 
-1. ``AscendFIABackend`` is instantiable (all abstract methods overridden).
-2. All five ``BaseAttnBackend`` interface methods exist on the class.
-3. ``init_capture_graph`` / ``prepare_for_capture`` / ``prepare_for_replay``
-   are callable no-ops (return ``None``).
-4. ``prepare_metadata`` returns ``None``.
-5. ``forward`` raises the exact ``NotImplementedError`` mandated by the spec.
-6. ``SUPPORTED_ATTENTION_BACKENDS`` contains ``"npu_fia"``.
-7. Registering ``"npu_fia"`` does not import ``ascend_fia`` until the factory
-   is actually invoked (lazy import).
-8. ``_adjust_config`` maps ``device_type == "npu"`` + ``auto`` → ``"npu_fia"``.
-9. ``_adjust_config`` keeps the existing SM100 / SM90 / other selection on
-   CUDA/CPU auto.
-10. Explicit ``fi`` / ``fa`` / ``trtllm`` / ``npu_fia`` are not overridden.
-11. ``ascend_fia`` module has no top-level ``torch_npu`` import.
+Gate 1.8a (scaffolding):
+  1. ``AscendFIABackend`` is instantiable (all abstract methods overridden).
+  2. All five ``BaseAttnBackend`` interface methods exist on the class.
+  3. ``init_capture_graph`` / ``prepare_for_capture`` / ``prepare_for_replay``
+     are callable no-ops (return ``None``).
+  4. ``SUPPORTED_ATTENTION_BACKENDS`` contains ``"npu_fia"``.
+  5. Registering ``"npu_fia"`` does not import ``ascend_fia`` until the factory
+     is actually invoked (lazy import).
+  6. ``_adjust_config`` maps ``device_type == "npu"`` + ``auto`` → ``"npu_fia"``.
+  7. ``_adjust_config`` keeps the existing SM100 / SM90 / other selection on
+     CUDA/CPU auto.
+  8. Explicit ``fi`` / ``fa`` / ``trtllm`` / ``npu_fia`` are not overridden.
+  9. ``ascend_fia`` module has no top-level ``torch_npu`` import.
+
+Gate 1.8c (metadata): single-request BSND ``prepare_metadata`` builder,
+block-table stride-then-divide algorithm, field types, ``get_last_indices``,
+multi-request rejection.
+
+Gate 1.8e (forward): end-to-end ``forward`` call with a fake ``torch_npu``
+module — store_kv-before-FIA ordering, BSND view, prefill / decode mask
+construction, KV-dim padding to block boundary, FIA kwargs, tuple return
+handling, dynamic-import failure, and the new invariant that ``torch_npu``
+only appears inside ``forward``.
 """
 from __future__ import annotations
 
@@ -171,17 +181,6 @@ def test_prepare_metadata_returns_none(monkeypatch):
     assert batch.attn_metadata is not None
 
 
-# --------------------------------- 5: forward NotImplementedError -----------
-
-
-def test_forward_raises_gate_1_8b_deferred_error():
-    mod = _load_ascend_fia_module()
-    backend = mod.AscendFIABackend(config=None)
-    with pytest.raises(NotImplementedError) as excinfo:
-        backend.forward(q=None, k=None, v=None, layer_id=0, batch=None)
-    assert "Ascend FIA forward is not implemented until Gate 1.8b" in str(excinfo.value)
-
-
 # --------------------------------- 6: registry membership -------------------
 
 
@@ -309,42 +308,6 @@ def test_ascend_fia_module_has_no_top_level_torch_npu_import():
         elif isinstance(node, ast.ImportFrom):
             assert node.module is None or not node.module.startswith("torch_npu"), (
                 f"top-level `from {node.module} import ...` is forbidden in ascend_fia.py"
-            )
-
-
-def test_ascend_fia_module_never_calls_or_lazy_imports_torch_npu():
-    """Belt-and-suspenders check — even lazy imports inside functions are
-    forbidden for Gate 1.8a. The FIA op wiring lands separately in 1.8b.
-
-    We walk the AST so docstring prose that mentions ``torch_npu`` for
-    documentation purposes is allowed; only actual ``Import`` / ``ImportFrom``
-    / ``Attribute`` / ``Name`` references are rejected.
-    """
-    tree = ast.parse(_ascend_fia_source())
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                assert not alias.name.startswith("torch_npu"), (
-                    f"lazy `import {alias.name}` forbidden in ascend_fia.py "
-                    "for Gate 1.8a"
-                )
-        elif isinstance(node, ast.ImportFrom):
-            assert node.module is None or not node.module.startswith("torch_npu"), (
-                f"lazy `from {node.module} import ...` forbidden in ascend_fia.py "
-                "for Gate 1.8a"
-            )
-        elif isinstance(node, ast.Attribute):
-            # `torch_npu.foo` or `torch_npu.foo.bar` — chase the root name.
-            root = node
-            while isinstance(root, ast.Attribute):
-                root = root.value
-            if isinstance(root, ast.Name):
-                assert root.id != "torch_npu", (
-                    "ascend_fia.py must not reference torch_npu.* for Gate 1.8a"
-                )
-        elif isinstance(node, ast.Name):
-            assert node.id != "torch_npu", (
-                "ascend_fia.py must not reference `torch_npu` for Gate 1.8a"
             )
 
 
@@ -685,40 +648,531 @@ def test_prepare_metadata_multi_request_raises(monkeypatch):
 # --------------------------------- Gate 1.8a invariants (still hold) -----
 
 
-def test_gate18c_forward_still_raises_gate18b_error():
-    """Even with metadata implemented, forward() stays a NotImplementedError
-    until the FIA op wiring lands."""
-    mod = _load_ascend_fia_module()
-    backend = mod.AscendFIABackend(config=None)
-    with pytest.raises(NotImplementedError) as excinfo:
-        backend.forward(q=None, k=None, v=None, layer_id=0, batch=None)
-    assert "Ascend FIA forward is not implemented until Gate 1.8b" in str(excinfo.value)
-
-
-def test_gate18c_module_still_never_references_torch_npu():
-    """Re-assert the Gate 1.8a top-level + lazy torch_npu ban, because
-    Gate 1.8c added new function bodies that could regress it."""
+def test_gate18c_module_torch_npu_only_inside_forward():
+    """Gate 1.8e permits ``torch_npu`` inside ``forward`` (dynamic import +
+    single FIA call), but nowhere else. Walk the AST and require that every
+    ``torch_npu`` reference — import, name lookup, or attribute chain — sits
+    inside the ``forward`` function body of ``AscendFIABackend``.
+    """
     tree = ast.parse(_ascend_fia_source())
+
+    forward_fn = None
+    for cls in tree.body:
+        if isinstance(cls, ast.ClassDef) and cls.name == "AscendFIABackend":
+            for item in cls.body:
+                if isinstance(item, ast.FunctionDef) and item.name == "forward":
+                    forward_fn = item
+                    break
+    assert forward_fn is not None, "AscendFIABackend.forward not found"
+
+    forward_nodes = set(id(n) for n in ast.walk(forward_fn))
+
     for node in ast.walk(tree):
+        offending = False
         if isinstance(node, ast.Import):
             for alias in node.names:
-                assert not alias.name.startswith("torch_npu"), (
-                    f"`import {alias.name}` forbidden in ascend_fia.py until "
-                    "the FIA op wiring Gate"
-                )
+                if alias.name.startswith("torch_npu"):
+                    offending = True
         elif isinstance(node, ast.ImportFrom):
-            assert node.module is None or not node.module.startswith("torch_npu"), (
-                f"`from {node.module} import ...` forbidden in ascend_fia.py"
-            )
+            if node.module is not None and node.module.startswith("torch_npu"):
+                offending = True
         elif isinstance(node, ast.Attribute):
             root = node
             while isinstance(root, ast.Attribute):
                 root = root.value
-            if isinstance(root, ast.Name):
-                assert root.id != "torch_npu", (
-                    "ascend_fia.py must not reference torch_npu.*"
-                )
+            if isinstance(root, ast.Name) and root.id == "torch_npu":
+                offending = True
         elif isinstance(node, ast.Name):
-            assert node.id != "torch_npu", (
-                "ascend_fia.py must not reference `torch_npu`"
+            if node.id == "torch_npu":
+                offending = True
+
+        if offending:
+            assert id(node) in forward_nodes, (
+                "torch_npu references are only allowed inside "
+                "AscendFIABackend.forward"
+            )
+
+
+# =====================================================================
+# Gate 1.8e: single-request BSND FIA forward
+#
+# All tests below stub ``minisgl.core.get_global_ctx`` with a fake context
+# that exposes a fake ``kv_cache`` (recording ``store_kv`` + returning fake
+# BnNBsD tensors from ``k_cache`` / ``v_cache``), and inject a fake
+# ``torch_npu`` module into ``sys.modules`` so ``forward`` picks it up on the
+# next dynamic ``import torch_npu``.
+#
+# No real Ascend runtime or CUDA runtime is exercised — every tensor lives on
+# CPU. The fake FIA op records its inputs and returns a well-shaped
+# ``(attention_out, softmax_lse)`` tuple.
+# =====================================================================
+
+
+import types  # noqa: E402 — placed here so the Gate 1.8e block reads as a unit
+
+
+class _RecordingKVCache:
+    """Fake KV cache exercising the exact surface ``forward`` touches.
+
+    * ``store_kv(k, v, out_loc, layer_id)`` — appends the call to
+      ``store_kv_calls`` so tests can assert ordering / arguments.
+    * ``k_cache(layer_id)`` / ``v_cache(layer_id)`` — return per-layer tensors
+      that stand in for the paged BnNBsD cache. ``forward`` must pass these
+      through verbatim; we use ``is`` identity in the tests to prove no
+      permute / contiguous / clone happened.
+    """
+
+    def __init__(self, num_pages: int, num_kv_heads: int, page_size: int,
+                 head_dim: int, num_layers: int, dtype) -> None:
+        import torch as _t
+
+        self.store_kv_calls = []
+        # Distinct per-layer tensors so a test can assert that ``layer_id`` is
+        # threaded through correctly.
+        self._k_caches = [
+            _t.randn((num_pages, num_kv_heads, page_size, head_dim), dtype=dtype)
+            for _ in range(num_layers)
+        ]
+        self._v_caches = [
+            _t.randn((num_pages, num_kv_heads, page_size, head_dim), dtype=dtype)
+            for _ in range(num_layers)
+        ]
+
+    def store_kv(self, k, v, out_loc, layer_id):
+        self.store_kv_calls.append(
+            {"k": k, "v": v, "out_loc": out_loc, "layer_id": layer_id}
+        )
+
+    def k_cache(self, layer_id):
+        return self._k_caches[layer_id]
+
+    def v_cache(self, layer_id):
+        return self._v_caches[layer_id]
+
+
+class _FakeCtxFIA:
+    def __init__(self, page_table, page_size, kv_cache) -> None:
+        self.page_table = page_table
+        self.page_size = page_size
+        self.kv_cache = kv_cache
+
+
+class _FakeBatchFIA:
+    def __init__(self, padded_reqs, out_loc) -> None:
+        self.padded_reqs = padded_reqs
+        self.out_loc = out_loc
+        self.attn_metadata = None
+
+
+def _install_fake_torch_npu(monkeypatch, calls, out_shape, out_dtype, out_device):
+    """Install a fake ``torch_npu`` in ``sys.modules`` with a recording
+    ``npu_fused_infer_attention_score`` that returns ``(attention_out,
+    softmax_lse)`` — matching FIA's real inference-mode arity."""
+    import torch as _t
+
+    fake = types.ModuleType("torch_npu")
+
+    def _fake_fia(query, key, value, **kwargs):
+        calls.append({
+            "query": query,
+            "key": key,
+            "value": value,
+            "kwargs": kwargs,
+        })
+        attention_out = _t.zeros(out_shape, dtype=out_dtype, device=out_device)
+        softmax_lse = _t.empty((0,), dtype=_t.float32, device=out_device)
+        return (attention_out, softmax_lse)
+
+    fake.npu_fused_infer_attention_score = _fake_fia
+    monkeypatch.setitem(sys.modules, "torch_npu", fake)
+    return fake
+
+
+def _prime_forward(monkeypatch, *, query_seq_len, kv_seq_len,
+                    num_heads=4, num_kv_heads=2, head_dim=8, page_size=4,
+                    num_pages=8, num_layers=2, layer_id=0):
+    """Build a wired-up (backend, batch, ctx, fake_npu_calls) tuple.
+
+    ``prepare_metadata`` is invoked so ``batch.attn_metadata`` is a real
+    :class:`FIAMetadata`; then a fake ``torch_npu`` is injected so
+    ``forward`` can be called without any real Ascend runtime.
+    """
+    import torch as _t
+
+    mod, backend = _make_backend()
+
+    # ``device_len`` is total KV, ``cached_len`` = kv_seq_len - query_seq_len.
+    cached_len = kv_seq_len - query_seq_len
+    device_len = kv_seq_len
+
+    # page_table row 0 uses contiguous physical pages 0..N-1 → simplifies
+    # the block_table assertions to consecutive small ints.
+    num_blocks = (kv_seq_len + page_size - 1) // page_size
+    row = list(range(num_blocks * page_size))
+    # Pad to at least device_len (metadata slices ``: num_blocks * page_size``).
+    page_table = _t.tensor([row], dtype=_t.int32)
+
+    kv_cache = _RecordingKVCache(
+        num_pages=num_pages, num_kv_heads=num_kv_heads,
+        page_size=page_size, head_dim=head_dim,
+        num_layers=num_layers, dtype=_t.float32,
+    )
+
+    ctx = _FakeCtxFIA(page_table=page_table, page_size=page_size, kv_cache=kv_cache)
+
+    import minisgl.core as core_mod
+
+    monkeypatch.setattr(core_mod, "get_global_ctx", lambda: ctx)
+
+    req = _FakeReq(table_idx=0, cached_len=cached_len, device_len=device_len)
+    # ``out_loc`` is opaque to forward — just a marker object we can identity-check.
+    out_loc = _t.arange(query_seq_len, dtype=_t.int32)
+    batch = _FakeBatchFIA(padded_reqs=[req], out_loc=out_loc)
+
+    backend.prepare_metadata(batch)
+
+    q = _t.randn((query_seq_len, num_heads, head_dim), dtype=_t.float32)
+    k = _t.randn((query_seq_len, num_kv_heads, head_dim), dtype=_t.float32)
+    v = _t.randn((query_seq_len, num_kv_heads, head_dim), dtype=_t.float32)
+
+    calls = []
+    _install_fake_torch_npu(
+        monkeypatch, calls,
+        out_shape=(1, query_seq_len, num_heads, head_dim),
+        out_dtype=_t.float32, out_device=q.device,
+    )
+
+    return {
+        "mod": mod,
+        "backend": backend,
+        "batch": batch,
+        "ctx": ctx,
+        "kv_cache": kv_cache,
+        "q": q, "k": k, "v": v,
+        "layer_id": layer_id,
+        "calls": calls,
+        "num_blocks": num_blocks,
+        "page_size": page_size,
+        "num_heads": num_heads,
+        "num_kv_heads": num_kv_heads,
+        "head_dim": head_dim,
+        "query_seq_len": query_seq_len,
+        "kv_seq_len": kv_seq_len,
+        "cached_len": cached_len,
+    }
+
+
+# --------------------------------- 1. store_kv before FIA ------------------
+
+
+def test_forward_calls_store_kv_before_fia(monkeypatch):
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward(monkeypatch, query_seq_len=4, kv_seq_len=4, layer_id=1)
+    backend, batch = setup["backend"], setup["batch"]
+
+    # Cross-reference the two call recorders by wall-clock order — but since
+    # this test runs synchronously, a simpler check is: at the moment the fake
+    # FIA op fires, ``store_kv_calls`` already has exactly one entry.
+    kv_cache = setup["kv_cache"]
+    fia_calls = setup["calls"]
+
+    original_fake = sys.modules["torch_npu"].npu_fused_infer_attention_score
+
+    def _wrapped(*args, **kwargs):
+        # When FIA runs, store_kv must already have been called exactly once.
+        assert len(kv_cache.store_kv_calls) == 1, (
+            "store_kv must run before FIA"
+        )
+        return original_fake(*args, **kwargs)
+
+    sys.modules["torch_npu"].npu_fused_infer_attention_score = _wrapped
+
+    backend.forward(setup["q"], setup["k"], setup["v"],
+                    layer_id=setup["layer_id"], batch=batch)
+
+    assert len(fia_calls) == 1
+    assert len(kv_cache.store_kv_calls) == 1
+    call = kv_cache.store_kv_calls[0]
+    assert call["k"] is setup["k"]
+    assert call["v"] is setup["v"]
+    assert call["out_loc"] is batch.out_loc
+    assert call["layer_id"] == setup["layer_id"]
+
+
+# --------------------------------- 2. q view to BSND -----------------------
+
+
+def test_forward_views_q_to_bsnd(monkeypatch):
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward(monkeypatch, query_seq_len=3, kv_seq_len=3)
+    backend, batch = setup["backend"], setup["batch"]
+
+    backend.forward(setup["q"], setup["k"], setup["v"],
+                    layer_id=setup["layer_id"], batch=batch)
+
+    query = setup["calls"][0]["query"]
+    # [1, T, H, D]
+    assert tuple(query.shape) == (
+        1, setup["query_seq_len"], setup["num_heads"], setup["head_dim"],
+    )
+    # unsqueeze is a non-copy view → underlying storage is shared with the
+    # flat q. ``data_ptr`` equality is the crispest form of this check.
+    assert query.data_ptr() == setup["q"].data_ptr()
+
+
+# --------------------------------- 3. Prefill no-prefix mask ---------------
+
+
+def test_forward_prefill_no_prefix_mask(monkeypatch):
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward(monkeypatch, query_seq_len=4, kv_seq_len=4, page_size=4)
+    backend, batch = setup["backend"], setup["batch"]
+
+    backend.forward(setup["q"], setup["k"], setup["v"],
+                    layer_id=setup["layer_id"], batch=batch)
+
+    mask = setup["calls"][0]["kwargs"]["atten_mask"]
+    assert mask is not None
+    # num_blocks == 1, page_size == 4 → padded KV dim == 4 (already equals kv_seq_len).
+    assert tuple(mask.shape) == (4, 4)
+    # No cached prefix ⇒ standard upper-triangular causal mask (diagonal=1).
+    expected = torch.triu(torch.ones((4, 4), dtype=torch.bool), diagonal=1)
+    assert torch.equal(mask, expected)
+
+
+# --------------------------------- 4. Prefill cached-prefix mask -----------
+
+
+def test_forward_prefill_cached_prefix_offset_mask(monkeypatch):
+    torch = pytest.importorskip("torch")
+    # cached_len=14, query_seq_len=4, kv_seq_len=18 → the Gate 1.8d shape.
+    setup = _prime_forward(monkeypatch, query_seq_len=4, kv_seq_len=18, page_size=16)
+    backend, batch = setup["backend"], setup["batch"]
+
+    backend.forward(setup["q"], setup["k"], setup["v"],
+                    layer_id=setup["layer_id"], batch=batch)
+
+    mask = setup["calls"][0]["kwargs"]["atten_mask"]
+    assert mask is not None
+    # num_blocks == ceil(18/16) == 2 → padded KV dim == 32.
+    assert tuple(mask.shape) == (4, 32)
+
+    # Visible KV per row (up to the true kv_seq_len == 18) must match
+    # [15, 16, 17, 18] — the Gate 1.8d visibility spec.
+    visible = (~mask[:, :18]).sum(dim=1).tolist()
+    assert visible == [15, 16, 17, 18]
+
+
+# --------------------------------- 5. Mask KV padded to block boundary ----
+
+
+def test_forward_mask_kv_dim_padded_to_block_boundary(monkeypatch):
+    torch = pytest.importorskip("torch")
+    # Deliberately choose a kv_seq_len that is NOT a multiple of page_size so
+    # the padding is non-trivial.
+    setup = _prime_forward(monkeypatch, query_seq_len=3, kv_seq_len=5, page_size=4)
+    backend, batch = setup["backend"], setup["batch"]
+
+    backend.forward(setup["q"], setup["k"], setup["v"],
+                    layer_id=setup["layer_id"], batch=batch)
+
+    mask = setup["calls"][0]["kwargs"]["atten_mask"]
+    # num_blocks == ceil(5/4) == 2; padded == 8. This is the FIA-tiling
+    # requirement surfaced by the Gate 1.8d probe.
+    assert tuple(mask.shape) == (3, 8)
+
+
+# --------------------------------- 6. Padding columns all masked ----------
+
+
+def test_forward_padding_columns_are_all_true(monkeypatch):
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward(monkeypatch, query_seq_len=3, kv_seq_len=5, page_size=4)
+    backend, batch = setup["backend"], setup["batch"]
+
+    backend.forward(setup["q"], setup["k"], setup["v"],
+                    layer_id=setup["layer_id"], batch=batch)
+
+    mask = setup["calls"][0]["kwargs"]["atten_mask"]
+    # Columns >= kv_seq_len == 5 are the "padding" columns — they must be
+    # entirely True (== masked out) so they can never contribute to any row.
+    pad_cols = mask[:, 5:]
+    assert bool(pad_cols.all().item()), (
+        "padding columns must all be True (== masked out)"
+    )
+
+
+# --------------------------------- 7. Decode atten_mask is None -----------
+
+
+def test_forward_decode_mask_is_none(monkeypatch):
+    torch = pytest.importorskip("torch")
+    # query_seq_len == 1 is the decode path.
+    setup = _prime_forward(monkeypatch, query_seq_len=1, kv_seq_len=6, page_size=4)
+    backend, batch = setup["backend"], setup["batch"]
+
+    backend.forward(setup["q"], setup["k"], setup["v"],
+                    layer_id=setup["layer_id"], batch=batch)
+
+    assert setup["calls"][0]["kwargs"]["atten_mask"] is None
+
+
+# --------------------------------- 8. FIA kwargs correct ------------------
+
+
+def test_forward_fia_kwargs_are_correct(monkeypatch):
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward(
+        monkeypatch, query_seq_len=6, kv_seq_len=6, page_size=4,
+        num_heads=4, num_kv_heads=2, head_dim=8,
+    )
+    backend, batch = setup["backend"], setup["batch"]
+
+    backend.forward(setup["q"], setup["k"], setup["v"],
+                    layer_id=setup["layer_id"], batch=batch)
+
+    kwargs = setup["calls"][0]["kwargs"]
+
+    # block_table is what metadata built (page 0, page 1 for a 6-token seq at
+    # page_size=4 → ceil(6/4)=2 pages).
+    assert kwargs["block_table"] is batch.attn_metadata.block_table
+    # Python-list scalar lengths (Gate 1.8c invariant preserved through 1.8e).
+    assert kwargs["actual_seq_lengths"] == [6]
+    assert kwargs["actual_seq_lengths_kv"] == [6]
+    # Head counts derived from tensor shapes, not stashed constants.
+    assert kwargs["num_heads"] == setup["num_heads"]
+    assert kwargs["num_key_value_heads"] == setup["num_kv_heads"]
+    # scale must be 1/sqrt(head_dim) — spelled ``scale`` (NOT ``scale_value``)
+    # to match the aclnn v3 binding.
+    assert "scale" in kwargs and "scale_value" not in kwargs
+    import math
+    assert kwargs["scale"] == pytest.approx(1.0 / math.sqrt(setup["head_dim"]))
+    # BSND single-request path.
+    assert kwargs["input_layout"] == "BSND"
+    assert kwargs["block_size"] == setup["page_size"]
+    assert kwargs["sparse_mode"] == 0
+
+
+# --------------------------------- 9. K/V passed verbatim ------------------
+
+
+def test_forward_kv_cache_tensors_passed_by_identity(monkeypatch):
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward(monkeypatch, query_seq_len=4, kv_seq_len=4, layer_id=1)
+    backend, batch = setup["backend"], setup["batch"]
+
+    backend.forward(setup["q"], setup["k"], setup["v"],
+                    layer_id=setup["layer_id"], batch=batch)
+
+    call = setup["calls"][0]
+    # The paged BnNBsD caches must be forwarded without permute / contiguous /
+    # clone. ``is`` identity is the tightest check.
+    assert call["key"] is setup["kv_cache"].k_cache(setup["layer_id"])
+    assert call["value"] is setup["kv_cache"].v_cache(setup["layer_id"])
+
+
+# --------------------------------- 10. FIA tuple second item ignored ------
+
+
+def test_forward_ignores_second_tuple_item(monkeypatch):
+    """FIA returns ``(attention_out, softmax_lse)`` in inference mode;
+    softmax_lse is empty and must not be consumed by the backend."""
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward(monkeypatch, query_seq_len=2, kv_seq_len=2)
+    backend, batch = setup["backend"], setup["batch"]
+
+    import torch as _t
+
+    poisoned_lse = _t.full((3,), float("nan"), dtype=_t.float32)
+    expected_out = _t.zeros(
+        (1, setup["query_seq_len"], setup["num_heads"], setup["head_dim"]),
+        dtype=_t.float32,
+    )
+    expected_out.fill_(7.0)
+
+    def _fake_fia_two_items(query, key, value, **kwargs):
+        setup["calls"].append({
+            "query": query, "key": key, "value": value, "kwargs": kwargs,
+        })
+        return (expected_out, poisoned_lse)
+
+    sys.modules["torch_npu"].npu_fused_infer_attention_score = _fake_fia_two_items
+
+    out = backend.forward(setup["q"], setup["k"], setup["v"],
+                          layer_id=setup["layer_id"], batch=batch)
+
+    # Result must be the first tuple item, reshaped, not the LSE.
+    assert not bool(torch.isnan(out).any().item())
+    assert torch.allclose(out, expected_out.view(setup["q"].shape))
+
+
+# --------------------------------- 11. Return shape == q shape ------------
+
+
+def test_forward_return_shape_matches_q(monkeypatch):
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward(monkeypatch, query_seq_len=5, kv_seq_len=9, page_size=4)
+    backend, batch = setup["backend"], setup["batch"]
+
+    out = backend.forward(setup["q"], setup["k"], setup["v"],
+                          layer_id=setup["layer_id"], batch=batch)
+
+    assert tuple(out.shape) == tuple(setup["q"].shape)
+
+
+# --------------------------------- 12. Dynamic import failure -------------
+
+
+def test_forward_raises_runtimeerror_when_torch_npu_missing(monkeypatch):
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward(monkeypatch, query_seq_len=2, kv_seq_len=2)
+    backend, batch = setup["backend"], setup["batch"]
+
+    # ``sys.modules[name] = None`` is Python's canonical way to force
+    # ``import name`` to raise ``ImportError`` on the next attempt.
+    monkeypatch.setitem(sys.modules, "torch_npu", None)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        backend.forward(setup["q"], setup["k"], setup["v"],
+                        layer_id=setup["layer_id"], batch=batch)
+    msg = str(excinfo.value)
+    assert "torch_npu" in msg
+    assert "npu_fia" in msg
+
+
+# --------------------------------- 13. Multi-request still rejected -------
+
+
+def test_forward_multi_request_still_rejected(monkeypatch):
+    """Even if a caller mutated ``padded_reqs`` between ``prepare_metadata``
+    and ``forward``, the batch-size check inside ``forward`` must catch it."""
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward(monkeypatch, query_seq_len=2, kv_seq_len=2)
+    backend, batch = setup["backend"], setup["batch"]
+
+    # Poison the metadata so B==2.
+    batch.attn_metadata.actual_seq_lengths = [2, 2]
+
+    with pytest.raises(NotImplementedError) as excinfo:
+        backend.forward(setup["q"], setup["k"], setup["v"],
+                        layer_id=setup["layer_id"], batch=batch)
+    assert "batch size 1 only" in str(excinfo.value)
+
+
+# --------------------------------- 14. Module top-level no torch_npu ------
+
+
+def test_gate18e_module_no_top_level_torch_npu():
+    """Gate 1.8e still forbids top-level ``import torch_npu`` — the dynamic
+    import must sit inside ``forward``."""
+    tree = ast.parse(_ascend_fia_source())
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert not alias.name.startswith("torch_npu"), (
+                    f"top-level `import {alias.name}` is forbidden"
+                )
+        elif isinstance(node, ast.ImportFrom):
+            assert node.module is None or not node.module.startswith("torch_npu"), (
+                f"top-level `from {node.module} import ...` is forbidden"
             )

--- a/tests/misc/test_ascend_fia_backend.py
+++ b/tests/misc/test_ascend_fia_backend.py
@@ -608,26 +608,10 @@ def test_get_last_indices_decode(monkeypatch):
     assert idx.dtype == torch.int32
 
 
-def test_get_last_indices_bs_not_one_raises(monkeypatch):
-    torch = pytest.importorskip("torch")
-    mod, backend = _make_backend()
-    page_table = torch.tensor([[0, 1, 2, 3]], dtype=torch.int32)
-    _install_ctx(monkeypatch, page_table, page_size=4)
-
-    req = _FakeReq(table_idx=0, cached_len=0, device_len=4)
-    batch = _FakeBatch(padded_reqs=[req])
-    backend.prepare_metadata(batch)
-
-    with pytest.raises(NotImplementedError) as excinfo:
-        batch.attn_metadata.get_last_indices(2)
-    assert "batch size 1 only" in str(excinfo.value)
-
-
-# --------------------------------- multi-request rejection ---------------
-
-
-def test_prepare_metadata_multi_request_raises(monkeypatch):
-    """`len(padded_reqs) > 1` must fail loudly until the TND path lands."""
+def test_get_last_indices_bs_two_equal_length(monkeypatch):
+    """Gate 2.2c: equal-length B=2 → last indices are the flat-buffer offsets
+    of the last query token per request.
+    """
     torch = pytest.importorskip("torch")
     mod, backend = _make_backend()
     page_table = torch.tensor(
@@ -640,9 +624,152 @@ def test_prepare_metadata_multi_request_raises(monkeypatch):
         _FakeReq(table_idx=1, cached_len=0, device_len=4),
     ]
     batch = _FakeBatch(padded_reqs=reqs)
+    backend.prepare_metadata(batch)
+
+    # Flat layout is [r0_t0..r0_t3, r1_t0..r1_t3]; last-per-req = [3, 7].
+    idx = batch.attn_metadata.get_last_indices(2)
+    assert idx.tolist() == [3, 7]
+    assert idx.dtype == torch.int32
+    assert idx.device == page_table.device
+
+
+# --------------------------------- Gate 2.2c: equal-length B>=1 ----------
+
+
+def test_prepare_metadata_equal_length_b2_prefill(monkeypatch):
+    """Gate 2.2c: equal-length B=2 prefill must build a shared metadata."""
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    # Two independent physical-page rows: req0 → pages [0,1], req1 → pages [4,5].
+    page_table = torch.tensor(
+        [
+            [0, 1, 2, 3, 4, 5, 6, 7],
+            [16, 17, 18, 19, 20, 21, 22, 23],
+        ],
+        dtype=torch.int32,
+    )
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    reqs = [
+        _FakeReq(table_idx=0, cached_len=0, device_len=6),
+        _FakeReq(table_idx=1, cached_len=0, device_len=6),
+    ]
+    batch = _FakeBatch(padded_reqs=reqs)
+    backend.prepare_metadata(batch)
+
+    meta = batch.attn_metadata
+    assert isinstance(meta, mod.FIAMetadata)
+    assert meta.batch_size == 2
+    assert meta.query_seq_len == 6
+    assert meta.kv_seq_len == 6
+    assert meta.actual_seq_lengths == [6, 6]
+    assert meta.actual_seq_lengths_kv == [6, 6]
+    assert meta.input_layout == "BSND"
+    # ceil(6/4) = 2 blocks; stride-4 picks slots; /4 → page ids per row.
+    assert meta.block_table.tolist() == [[0, 1], [4, 5]]
+    assert meta.block_table.shape == (2, 2)
+    assert meta.block_table.dtype == torch.int32
+    assert meta.block_table.device == page_table.device
+
+
+def test_prepare_metadata_equal_length_b2_decode(monkeypatch):
+    """Gate 2.2c: equal-length B=2 decode (query_seq_len=1)."""
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    page_table = torch.tensor(
+        [
+            [8, 9, 10, 11, 12, 13, 14, 15],
+            [40, 41, 42, 43, 44, 45, 46, 47],
+        ],
+        dtype=torch.int32,
+    )
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    # Both requests: 1 new token this step, KV of length 6.
+    reqs = [
+        _FakeReq(table_idx=0, cached_len=5, device_len=6),
+        _FakeReq(table_idx=1, cached_len=5, device_len=6),
+    ]
+    batch = _FakeBatch(padded_reqs=reqs)
+    backend.prepare_metadata(batch)
+
+    meta = batch.attn_metadata
+    assert meta.batch_size == 2
+    assert meta.query_seq_len == 1
+    assert meta.kv_seq_len == 6
+    assert meta.actual_seq_lengths == [1, 1]
+    assert meta.actual_seq_lengths_kv == [6, 6]
+    # Row 0 uses raw slots [8,12] → pages [2,3]; row 1 uses [40,44] → [10,11].
+    assert meta.block_table.tolist() == [[2, 3], [10, 11]]
+
+
+def test_prepare_metadata_block_table_rows_independent(monkeypatch):
+    """Gate 2.2c: each row of block_table must be sourced from its own
+    page_table row — no cross-request contamination."""
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    # Row 0 uses fragmented physical pages [2, 0]; row 1 uses [1, 3].
+    page_table = torch.tensor(
+        [
+            [8, 9, 10, 11, 0, 1, 2, 3],
+            [4, 5, 6, 7, 12, 13, 14, 15],
+        ],
+        dtype=torch.int32,
+    )
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    reqs = [
+        _FakeReq(table_idx=0, cached_len=0, device_len=8),
+        _FakeReq(table_idx=1, cached_len=0, device_len=8),
+    ]
+    batch = _FakeBatch(padded_reqs=reqs)
+    backend.prepare_metadata(batch)
+
+    # Row 0: stride-4 picks [8, 0] → [2, 0]. Row 1: picks [4, 12] → [1, 3].
+    assert batch.attn_metadata.block_table.tolist() == [[2, 0], [1, 3]]
+
+
+def test_prepare_metadata_rejects_ragged_extend_len(monkeypatch):
+    """Gate 2.2c: mismatched ``extend_len`` must raise NotImplementedError."""
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    page_table = torch.tensor(
+        [[0, 1, 2, 3], [4, 5, 6, 7]], dtype=torch.int32
+    )
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    reqs = [
+        _FakeReq(table_idx=0, cached_len=0, device_len=4),   # extend_len=4
+        _FakeReq(table_idx=1, cached_len=0, device_len=3),   # extend_len=3
+    ]
+    batch = _FakeBatch(padded_reqs=reqs)
     with pytest.raises(NotImplementedError) as excinfo:
         backend.prepare_metadata(batch)
-    assert "batch size 1 only" in str(excinfo.value)
+    msg = str(excinfo.value)
+    assert "ragged" in msg
+    assert "extend_len" in msg
+
+
+def test_prepare_metadata_rejects_ragged_cached_len(monkeypatch):
+    """Gate 2.2c: mismatched ``cached_len`` must raise NotImplementedError,
+    even when ``extend_len`` matches. This is the mixed-prefix-hit case."""
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    page_table = torch.tensor(
+        [[0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14, 15]],
+        dtype=torch.int32,
+    )
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    # Both extend_len=2 but cached_len differs (0 vs 4).
+    reqs = [
+        _FakeReq(table_idx=0, cached_len=0, device_len=2),
+        _FakeReq(table_idx=1, cached_len=4, device_len=6),
+    ]
+    batch = _FakeBatch(padded_reqs=reqs)
+    with pytest.raises(NotImplementedError) as excinfo:
+        backend.prepare_metadata(batch)
+    assert "ragged" in str(excinfo.value)
 
 
 # --------------------------------- Gate 1.8a invariants (still hold) -----
@@ -1143,20 +1270,25 @@ def test_forward_raises_runtimeerror_when_torch_npu_missing(monkeypatch):
 # --------------------------------- 13. Multi-request still rejected -------
 
 
-def test_forward_multi_request_still_rejected(monkeypatch):
-    """Even if a caller mutated ``padded_reqs`` between ``prepare_metadata``
-    and ``forward``, the batch-size check inside ``forward`` must catch it."""
+def test_forward_flat_query_shape_mismatch_rejected(monkeypatch):
+    """Gate 2.2c: if a caller mutates ``padded_reqs`` between
+    ``prepare_metadata`` and ``forward`` so that the flat query no longer
+    matches ``batch_size * query_seq_len``, ``forward`` must refuse."""
     torch = pytest.importorskip("torch")
     setup = _prime_forward(monkeypatch, query_seq_len=2, kv_seq_len=2)
     backend, batch = setup["backend"], setup["batch"]
 
-    # Poison the metadata so B==2.
+    # Poison the metadata so it claims B=2 while the flat q is still B=1.
     batch.attn_metadata.actual_seq_lengths = [2, 2]
+    batch.attn_metadata.actual_seq_lengths_kv = [2, 2]
+    batch.attn_metadata.batch_size = 2
 
-    with pytest.raises(NotImplementedError) as excinfo:
+    with pytest.raises(ValueError) as excinfo:
         backend.forward(setup["q"], setup["k"], setup["v"],
                         layer_id=setup["layer_id"], batch=batch)
-    assert "batch size 1 only" in str(excinfo.value)
+    msg = str(excinfo.value)
+    assert "flat query" in msg
+    assert "batch_size" in msg
 
 
 # --------------------------------- 14. Module top-level no torch_npu ------
@@ -1176,3 +1308,218 @@ def test_gate18e_module_no_top_level_torch_npu():
             assert node.module is None or not node.module.startswith("torch_npu"), (
                 f"top-level `from {node.module} import ...` is forbidden"
             )
+
+
+# =====================================================================
+# Gate 2.2c: equal-length B>=1 forward
+#
+# The fake torch_npu records the query BSND shape and the FIA kwargs — we
+# assert the metadata is threaded through correctly and that the shared
+# causal mask is broadcast across the batch (single 2-D mask, not per-req).
+# =====================================================================
+
+
+def _prime_forward_b2(monkeypatch, *, query_seq_len, kv_seq_len,
+                       num_heads=4, num_kv_heads=2, head_dim=8, page_size=4,
+                       num_pages=16, num_layers=2, layer_id=0):
+    """Two-request equal-length variant of :func:`_prime_forward`.
+
+    Row 0 uses physical pages [0..num_blocks-1]; row 1 uses
+    [num_blocks..2*num_blocks-1]. Both rows are equal-length so
+    ``prepare_metadata`` accepts them.
+    """
+    import torch as _t
+
+    mod, backend = _make_backend()
+
+    cached_len = kv_seq_len - query_seq_len
+    device_len = kv_seq_len
+
+    num_blocks = (kv_seq_len + page_size - 1) // page_size
+    row0 = list(range(num_blocks * page_size))
+    # Row 1 uses a disjoint physical page range so tests can distinguish rows.
+    offset = num_blocks * page_size
+    row1 = list(range(offset, offset + num_blocks * page_size))
+    page_table = _t.tensor([row0, row1], dtype=_t.int32)
+
+    kv_cache = _RecordingKVCache(
+        num_pages=num_pages, num_kv_heads=num_kv_heads,
+        page_size=page_size, head_dim=head_dim,
+        num_layers=num_layers, dtype=_t.float32,
+    )
+    ctx = _FakeCtxFIA(page_table=page_table, page_size=page_size, kv_cache=kv_cache)
+
+    import minisgl.core as core_mod
+    monkeypatch.setattr(core_mod, "get_global_ctx", lambda: ctx)
+
+    reqs = [
+        _FakeReq(table_idx=0, cached_len=cached_len, device_len=device_len),
+        _FakeReq(table_idx=1, cached_len=cached_len, device_len=device_len),
+    ]
+    # ``out_loc`` layout: req0 raw slots then req1 raw slots, flat.
+    out_loc = _t.tensor(
+        row0[cached_len:cached_len + query_seq_len]
+        + row1[cached_len:cached_len + query_seq_len],
+        dtype=_t.int32,
+    )
+    batch = _FakeBatchFIA(padded_reqs=reqs, out_loc=out_loc)
+
+    backend.prepare_metadata(batch)
+
+    total_tokens = 2 * query_seq_len
+    q = _t.randn((total_tokens, num_heads, head_dim), dtype=_t.float32)
+    k = _t.randn((total_tokens, num_kv_heads, head_dim), dtype=_t.float32)
+    v = _t.randn((total_tokens, num_kv_heads, head_dim), dtype=_t.float32)
+
+    calls = []
+    _install_fake_torch_npu(
+        monkeypatch, calls,
+        out_shape=(2, query_seq_len, num_heads, head_dim),
+        out_dtype=_t.float32, out_device=q.device,
+    )
+
+    return {
+        "backend": backend, "batch": batch, "ctx": ctx, "kv_cache": kv_cache,
+        "q": q, "k": k, "v": v, "layer_id": layer_id, "calls": calls,
+        "num_blocks": num_blocks, "page_size": page_size,
+        "num_heads": num_heads, "num_kv_heads": num_kv_heads, "head_dim": head_dim,
+        "query_seq_len": query_seq_len, "kv_seq_len": kv_seq_len,
+        "cached_len": cached_len, "row0": row0, "row1": row1,
+    }
+
+
+def test_forward_b2_prefill_query_bsnd_shape(monkeypatch):
+    """Gate 2.2c: flat q [B*S, Hq, D] → BSND [B=2, S, Hq, D]."""
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward_b2(monkeypatch, query_seq_len=4, kv_seq_len=4)
+    setup["backend"].forward(setup["q"], setup["k"], setup["v"],
+                             layer_id=setup["layer_id"], batch=setup["batch"])
+    query = setup["calls"][0]["query"]
+    assert tuple(query.shape) == (
+        2, setup["query_seq_len"], setup["num_heads"], setup["head_dim"],
+    )
+
+
+def test_forward_b2_prefill_kwargs(monkeypatch):
+    """Gate 2.2c: FIA kwargs mirror the equal-length metadata."""
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward_b2(monkeypatch, query_seq_len=6, kv_seq_len=6)
+    setup["backend"].forward(setup["q"], setup["k"], setup["v"],
+                             layer_id=setup["layer_id"], batch=setup["batch"])
+    kwargs = setup["calls"][0]["kwargs"]
+    assert kwargs["actual_seq_lengths"] == [6, 6]
+    assert kwargs["actual_seq_lengths_kv"] == [6, 6]
+    # Row 0 → pages [0, 1]; row 1 → pages [2, 3] (offset 8//4=2).
+    assert kwargs["block_table"].tolist() == [[0, 1], [2, 3]]
+    assert tuple(kwargs["block_table"].shape) == (2, 2)
+    assert kwargs["input_layout"] == "BSND"
+    assert kwargs["num_heads"] == setup["num_heads"]
+    assert kwargs["num_key_value_heads"] == setup["num_kv_heads"]
+
+
+def test_forward_b2_prefill_shared_causal_mask(monkeypatch):
+    """Gate 2.2c: prefill uses a shared [S, padded_kv_len] causal mask; the
+    shared cached prefix is visible to every row."""
+    torch = pytest.importorskip("torch")
+    # cached_len=4, extend_len=4, kv_seq_len=8, page_size=4 → num_blocks=2,
+    # padded_kv_len=8. Mask must reveal 5,6,7,8 columns per row.
+    setup = _prime_forward_b2(monkeypatch, query_seq_len=4, kv_seq_len=8, page_size=4)
+    setup["backend"].forward(setup["q"], setup["k"], setup["v"],
+                             layer_id=setup["layer_id"], batch=setup["batch"])
+    mask = setup["calls"][0]["kwargs"]["atten_mask"]
+    assert mask is not None
+    # Shape is [S, padded_kv_len], NOT [B, S, padded_kv_len] — shared broadcast.
+    assert tuple(mask.shape) == (4, 8)
+    visible = (~mask).sum(dim=1).tolist()
+    assert visible == [5, 6, 7, 8]
+
+
+def test_forward_b2_decode_atten_mask_none(monkeypatch):
+    """Gate 2.2c: decode (S==1) sets atten_mask=None regardless of B."""
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward_b2(monkeypatch, query_seq_len=1, kv_seq_len=6, page_size=4)
+    setup["backend"].forward(setup["q"], setup["k"], setup["v"],
+                             layer_id=setup["layer_id"], batch=setup["batch"])
+    kwargs = setup["calls"][0]["kwargs"]
+    assert kwargs["atten_mask"] is None
+    query = setup["calls"][0]["query"]
+    assert tuple(query.shape) == (2, 1, setup["num_heads"], setup["head_dim"])
+    assert kwargs["actual_seq_lengths"] == [1, 1]
+    assert kwargs["actual_seq_lengths_kv"] == [6, 6]
+
+
+def test_forward_b2_store_kv_receives_full_out_loc(monkeypatch):
+    """Gate 2.2c: store_kv is called once per layer with the concatenated
+    flat ``batch.out_loc``; per-request slot ranges are preserved so pages
+    stay isolated. We verify the ranges point into disjoint physical pages
+    (row0 vs row1)."""
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward_b2(monkeypatch, query_seq_len=4, kv_seq_len=4)
+    setup["backend"].forward(setup["q"], setup["k"], setup["v"],
+                             layer_id=setup["layer_id"], batch=setup["batch"])
+    assert len(setup["kv_cache"].store_kv_calls) == 1
+    call = setup["kv_cache"].store_kv_calls[0]
+    assert call["k"] is setup["k"]
+    assert call["v"] is setup["v"]
+    assert call["out_loc"] is setup["batch"].out_loc
+    # First half comes from row0's page range, second half from row1's.
+    row0_ids = set(setup["row0"])
+    row1_ids = set(setup["row1"])
+    out_loc_list = call["out_loc"].tolist()
+    first_half = out_loc_list[: setup["query_seq_len"]]
+    second_half = out_loc_list[setup["query_seq_len"]:]
+    assert all(s in row0_ids for s in first_half)
+    assert all(s in row1_ids for s in second_half)
+    assert row0_ids.isdisjoint(row1_ids)
+
+
+def test_forward_b2_return_shape_matches_flat_q(monkeypatch):
+    """Gate 2.2c: forward must reshape FIA's [B, S, Hq, D] back to the
+    caller's flat [B*S, Hq, D]."""
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward_b2(monkeypatch, query_seq_len=3, kv_seq_len=3)
+    out = setup["backend"].forward(setup["q"], setup["k"], setup["v"],
+                                    layer_id=setup["layer_id"], batch=setup["batch"])
+    assert tuple(out.shape) == tuple(setup["q"].shape)
+
+
+# --------------------------------- Gate 2.2c: CUDA registration guard ----
+
+
+def test_gate22c_cuda_backends_still_registered():
+    """Gate 2.2c must not disturb CUDA backend registration — the lifting of
+    the B=1 hard limit is Ascend-only. Any accidental import churn that
+    dropped ``trtllm`` / ``fi`` / ``fa`` from the factory registry would
+    surface here.
+    """
+    mod = _load_attention()
+    names = set(mod.SUPPORTED_ATTENTION_BACKENDS.supported_names())
+    for expected in ("trtllm", "fi", "fa", "npu_fia"):
+        assert expected in names, f"registration for {expected!r} was lost"
+
+
+def test_gate22c_cuda_backend_metadata_types_unchanged():
+    """The CUDA backends still bundle their own metadata dataclasses that
+    keep ``get_last_indices`` on ``cu_seqlens_q`` — untouched by 2.2c.
+
+    Read the sources directly (torch-free) so the test is hermetic on hosts
+    that don't have torch installed.
+    """
+    for name in ("fa", "fi", "trtllm"):
+        src = (_PYTHON_ROOT / "minisgl" / "attention" / f"{name}.py").read_text()
+        assert "get_last_indices" in src, (
+            f"{name}: get_last_indices was unexpectedly removed"
+        )
+        assert "cu_seqlens_q" in src, (
+            f"{name}: cu_seqlens_q was unexpectedly removed"
+        )
+
+
+def test_gate22c_only_ascend_fia_touched_batch_limit():
+    """Guard: the ``batch size 1 only`` phrase must be absent from
+    ascend_fia.py after 2.2c. It also must never leak into another backend.
+    """
+    src = _ascend_fia_source()
+    assert "batch size 1 only" not in src, (
+        "Gate 2.2c must remove the legacy 'batch size 1 only' hard limit"
+    )

--- a/tests/misc/test_ascend_fia_backend.py
+++ b/tests/misc/test_ascend_fia_backend.py
@@ -130,10 +130,45 @@ def test_graph_hooks_return_none():
     assert backend.prepare_for_replay(batch=None) is None
 
 
-def test_prepare_metadata_returns_none():
+def test_prepare_metadata_returns_none(monkeypatch):
+    """Gate 1.8a promised ``prepare_metadata`` was a no-op returning ``None``.
+    Gate 1.8c makes it a real builder — the ``-> None`` contract is preserved
+    (it mutates ``batch.attn_metadata`` rather than returning a value), but
+    the test now feeds a valid single-req fake batch since the empty-batch
+    no-op behaviour is gone.
+    """
+    torch = pytest.importorskip("torch")
     mod = _load_ascend_fia_module()
     backend = mod.AscendFIABackend(config=None)
-    assert backend.prepare_metadata(batch=None) is None
+
+    # Lightweight fakes — defined below in the Gate 1.8c section.
+    page_table = torch.tensor([[0, 1, 2, 3]], dtype=torch.int32)
+    import minisgl.core as core_mod
+
+    class _C:
+        page_table = None  # patched below
+        page_size = 4
+
+    ctx = _C()
+    ctx.page_table = page_table
+    monkeypatch.setattr(core_mod, "get_global_ctx", lambda: ctx)
+
+    class _R:
+        table_idx = 0
+        cached_len = 0
+        device_len = 4
+        @property
+        def extend_len(self) -> int:
+            return self.device_len - self.cached_len
+
+    class _B:
+        def __init__(self):
+            self.padded_reqs = [_R()]
+            self.attn_metadata = None
+
+    batch = _B()
+    assert backend.prepare_metadata(batch) is None
+    assert batch.attn_metadata is not None
 
 
 # --------------------------------- 5: forward NotImplementedError -----------
@@ -331,3 +366,359 @@ def test_attention_registry_still_has_original_cuda_backends():
     names = set(mod.SUPPORTED_ATTENTION_BACKENDS.supported_names())
     for expected in ("trtllm", "fi", "fa"):
         assert expected in names, f"registration for {expected!r} was lost"
+
+
+# =====================================================================
+# Gate 1.8c: single-request BSND FIA metadata
+#
+# All tests below monkeypatch ``minisgl.core.get_global_ctx`` (which the
+# lazy import inside ``prepare_metadata`` picks up on the next call). No
+# CUDA / NPU is required — the fake ``page_table`` lives on CPU and the
+# assertions in ``prepare_metadata`` only require ``block_table.device``
+# to equal ``page_table.device``, which holds trivially here.
+# =====================================================================
+
+
+class _FakeCtx:
+    def __init__(self, page_table, page_size: int) -> None:
+        self.page_table = page_table
+        self.page_size = page_size
+
+
+class _FakeReq:
+    """Minimal ``Req`` stand-in — only the fields ``prepare_metadata``
+    actually reads. Avoids pulling the real ``Req`` dataclass (which
+    validates via ``__post_init__`` on a CPU tensor)."""
+
+    def __init__(self, table_idx: int, cached_len: int, device_len: int) -> None:
+        self.table_idx = table_idx
+        self.cached_len = cached_len
+        self.device_len = device_len
+
+    @property
+    def extend_len(self) -> int:
+        return self.device_len - self.cached_len
+
+
+class _FakeBatch:
+    def __init__(self, padded_reqs) -> None:
+        self.padded_reqs = padded_reqs
+        self.attn_metadata = None
+
+
+def _install_ctx(monkeypatch, page_table, page_size: int) -> _FakeCtx:
+    """Patch ``minisgl.core.get_global_ctx`` to yield a ``_FakeCtx``.
+
+    ``ascend_fia.prepare_metadata`` does ``from minisgl.core import
+    get_global_ctx`` inside the function body (lazy), so patching the
+    attribute on ``minisgl.core`` is picked up on the next call.
+    """
+    import minisgl.core as core_mod
+
+    ctx = _FakeCtx(page_table=page_table, page_size=page_size)
+    monkeypatch.setattr(core_mod, "get_global_ctx", lambda: ctx)
+    return ctx
+
+
+def _make_backend():
+    mod = _load_ascend_fia_module()
+    return mod, mod.AscendFIABackend(config=None)
+
+
+# --------------------------------- basic single-request paths --------------
+
+
+def test_prepare_metadata_single_prefill_no_prefix(monkeypatch):
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    # page_size=4, row 0 uses physical pages 0 and 1 (raw slots 0..7).
+    page_table = torch.tensor(
+        [[0, 1, 2, 3, 4, 5, 6, 7]], dtype=torch.int32
+    )
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    req = _FakeReq(table_idx=0, cached_len=0, device_len=6)
+    batch = _FakeBatch(padded_reqs=[req])
+    backend.prepare_metadata(batch)
+
+    meta = batch.attn_metadata
+    assert isinstance(meta, mod.FIAMetadata)
+    assert meta.query_seq_len == 6
+    assert meta.kv_seq_len == 6
+    assert meta.actual_seq_lengths == [6]
+    assert meta.actual_seq_lengths_kv == [6]
+    assert meta.input_layout == "BSND"
+    # ceil(6/4) = 2 blocks; stride-4 picks raw slots [0, 4]; /4 → page ids [0, 1]
+    assert meta.block_table.tolist() == [[0, 1]]
+    assert meta.block_table.shape == (1, 2)
+    assert meta.block_table.dtype == torch.int32
+    assert meta.block_table.device == page_table.device
+
+
+def test_prepare_metadata_single_prefill_with_cached_prefix(monkeypatch):
+    """`extend_len < device_len` is the partial-prefix-hit prefill case."""
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    # Row uses physical pages 4, 5, 6 → raw slots [16..27]. page_size=4.
+    page_table = torch.tensor(
+        [[16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27]], dtype=torch.int32
+    )
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    # cached_len=3 in page 0; device_len=10 → new tokens fill through page 2.
+    req = _FakeReq(table_idx=0, cached_len=3, device_len=10)
+    batch = _FakeBatch(padded_reqs=[req])
+    backend.prepare_metadata(batch)
+
+    meta = batch.attn_metadata
+    assert meta.query_seq_len == 7  # extend_len
+    assert meta.kv_seq_len == 10  # device_len
+    assert meta.actual_seq_lengths == [7]
+    assert meta.actual_seq_lengths_kv == [10]
+    # ceil(10/4)=3; stride-4 picks slots [16, 20, 24]; /4 → [4, 5, 6]
+    assert meta.block_table.tolist() == [[4, 5, 6]]
+    assert meta.block_table.shape == (1, 3)
+
+
+def test_prepare_metadata_single_decode(monkeypatch):
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    # Row uses physical pages 2 and 3 → raw slots [8..15].
+    page_table = torch.tensor(
+        [[8, 9, 10, 11, 12, 13, 14, 15]], dtype=torch.int32
+    )
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    # Decode step: cached_len=5, device_len=6 (1 new token this step).
+    req = _FakeReq(table_idx=0, cached_len=5, device_len=6)
+    batch = _FakeBatch(padded_reqs=[req])
+    backend.prepare_metadata(batch)
+
+    meta = batch.attn_metadata
+    assert meta.query_seq_len == 1
+    assert meta.kv_seq_len == 6
+    assert meta.actual_seq_lengths == [1]
+    assert meta.actual_seq_lengths_kv == [6]
+    # ceil(6/4)=2; stride-4 picks slots [8, 12]; /4 → [2, 3]
+    assert meta.block_table.tolist() == [[2, 3]]
+
+
+# --------------------------------- block-table shape / algorithm ----------
+
+
+def test_block_table_multi_page(monkeypatch):
+    """A three-page KV must yield block_table shape [1, 3]."""
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    page_table = torch.tensor(
+        [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]], dtype=torch.int32
+    )
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    req = _FakeReq(table_idx=0, cached_len=0, device_len=12)
+    batch = _FakeBatch(padded_reqs=[req])
+    backend.prepare_metadata(batch)
+
+    meta = batch.attn_metadata
+    assert meta.block_table.shape == (1, 3)
+    assert meta.block_table.tolist() == [[0, 1, 2]]
+
+
+def test_block_table_non_contiguous_page_ids(monkeypatch):
+    """Physical pages allocated out of logical order (e.g. [2, 0]) must
+    survive the raw-slot → page-id conversion intact."""
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    # Row uses physical page 2 first (raw slots 8..11), then page 0
+    # (raw slots 0..3). This is a real cache-allocator pattern under
+    # fragmentation.
+    page_table = torch.tensor(
+        [[8, 9, 10, 11, 0, 1, 2, 3]], dtype=torch.int32
+    )
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    req = _FakeReq(table_idx=0, cached_len=0, device_len=8)
+    batch = _FakeBatch(padded_reqs=[req])
+    backend.prepare_metadata(batch)
+
+    meta = batch.attn_metadata
+    # stride-4 picks first slot of each page: [8, 0]; /4 → [2, 0]
+    assert meta.block_table.tolist() == [[2, 0]]
+
+
+def test_block_table_stride_then_divide_order(monkeypatch):
+    """Guard the ordering: (stride the row, then divide) — divide-first
+    on the full row would produce wrong page ids for non-first-of-page
+    slots. The test sets non-first slots to a poison value that would
+    surface if the algorithm ever regressed."""
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    # First slot of each page correctly encodes the page id * page_size.
+    # Non-first slots are poison = 99 — if the implementation divided the
+    # whole row by page_size and then picked stride, it would look at
+    # 99 // 4 == 24 and produce [24, ...] instead of [0, 1].
+    page_table = torch.tensor(
+        [[0, 99, 99, 99, 4, 99, 99, 99]], dtype=torch.int32
+    )
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    req = _FakeReq(table_idx=0, cached_len=0, device_len=8)
+    batch = _FakeBatch(padded_reqs=[req])
+    backend.prepare_metadata(batch)
+
+    meta = batch.attn_metadata
+    assert meta.block_table.tolist() == [[0, 1]]
+
+
+# --------------------------------- field types ---------------------------
+
+
+def test_actual_seq_lengths_are_python_lists(monkeypatch):
+    """FIA's actual_seq_lengths* are Python lists, not tensors — this
+    lets torch_npu skip a device round-trip. Regressing this to a tensor
+    is a silent perf pitfall we guard against."""
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    page_table = torch.tensor([[0, 1, 2, 3]], dtype=torch.int32)
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    req = _FakeReq(table_idx=0, cached_len=0, device_len=4)
+    batch = _FakeBatch(padded_reqs=[req])
+    backend.prepare_metadata(batch)
+
+    meta = batch.attn_metadata
+    assert isinstance(meta.actual_seq_lengths, list)
+    assert isinstance(meta.actual_seq_lengths_kv, list)
+    assert all(isinstance(x, int) for x in meta.actual_seq_lengths)
+    assert all(isinstance(x, int) for x in meta.actual_seq_lengths_kv)
+
+
+def test_input_layout_is_bsnd(monkeypatch):
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    page_table = torch.tensor([[0, 1, 2, 3]], dtype=torch.int32)
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    req = _FakeReq(table_idx=0, cached_len=0, device_len=4)
+    batch = _FakeBatch(padded_reqs=[req])
+    backend.prepare_metadata(batch)
+
+    assert batch.attn_metadata.input_layout == "BSND"
+
+
+# --------------------------------- get_last_indices ----------------------
+
+
+def test_get_last_indices_prefill(monkeypatch):
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    page_table = torch.tensor(
+        [[0, 1, 2, 3, 4, 5, 6, 7]], dtype=torch.int32
+    )
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    # extend_len == 6 → last index in the flat Q buffer == 5
+    req = _FakeReq(table_idx=0, cached_len=0, device_len=6)
+    batch = _FakeBatch(padded_reqs=[req])
+    backend.prepare_metadata(batch)
+
+    idx = batch.attn_metadata.get_last_indices(1)
+    assert idx.tolist() == [5]
+    assert idx.dtype == torch.int32
+    assert idx.shape == (1,)
+    assert idx.device == page_table.device
+
+
+def test_get_last_indices_decode(monkeypatch):
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    page_table = torch.tensor([[0, 1, 2, 3]], dtype=torch.int32)
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    # decode step: extend_len == 1 → last index == 0
+    req = _FakeReq(table_idx=0, cached_len=3, device_len=4)
+    batch = _FakeBatch(padded_reqs=[req])
+    backend.prepare_metadata(batch)
+
+    idx = batch.attn_metadata.get_last_indices(1)
+    assert idx.tolist() == [0]
+    assert idx.dtype == torch.int32
+
+
+def test_get_last_indices_bs_not_one_raises(monkeypatch):
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    page_table = torch.tensor([[0, 1, 2, 3]], dtype=torch.int32)
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    req = _FakeReq(table_idx=0, cached_len=0, device_len=4)
+    batch = _FakeBatch(padded_reqs=[req])
+    backend.prepare_metadata(batch)
+
+    with pytest.raises(NotImplementedError) as excinfo:
+        batch.attn_metadata.get_last_indices(2)
+    assert "batch size 1 only" in str(excinfo.value)
+
+
+# --------------------------------- multi-request rejection ---------------
+
+
+def test_prepare_metadata_multi_request_raises(monkeypatch):
+    """`len(padded_reqs) > 1` must fail loudly until the TND path lands."""
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    page_table = torch.tensor(
+        [[0, 1, 2, 3], [4, 5, 6, 7]], dtype=torch.int32
+    )
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    reqs = [
+        _FakeReq(table_idx=0, cached_len=0, device_len=4),
+        _FakeReq(table_idx=1, cached_len=0, device_len=4),
+    ]
+    batch = _FakeBatch(padded_reqs=reqs)
+    with pytest.raises(NotImplementedError) as excinfo:
+        backend.prepare_metadata(batch)
+    assert "batch size 1 only" in str(excinfo.value)
+
+
+# --------------------------------- Gate 1.8a invariants (still hold) -----
+
+
+def test_gate18c_forward_still_raises_gate18b_error():
+    """Even with metadata implemented, forward() stays a NotImplementedError
+    until the FIA op wiring lands."""
+    mod = _load_ascend_fia_module()
+    backend = mod.AscendFIABackend(config=None)
+    with pytest.raises(NotImplementedError) as excinfo:
+        backend.forward(q=None, k=None, v=None, layer_id=0, batch=None)
+    assert "Ascend FIA forward is not implemented until Gate 1.8b" in str(excinfo.value)
+
+
+def test_gate18c_module_still_never_references_torch_npu():
+    """Re-assert the Gate 1.8a top-level + lazy torch_npu ban, because
+    Gate 1.8c added new function bodies that could regress it."""
+    tree = ast.parse(_ascend_fia_source())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert not alias.name.startswith("torch_npu"), (
+                    f"`import {alias.name}` forbidden in ascend_fia.py until "
+                    "the FIA op wiring Gate"
+                )
+        elif isinstance(node, ast.ImportFrom):
+            assert node.module is None or not node.module.startswith("torch_npu"), (
+                f"`from {node.module} import ...` forbidden in ascend_fia.py"
+            )
+        elif isinstance(node, ast.Attribute):
+            root = node
+            while isinstance(root, ast.Attribute):
+                root = root.value
+            if isinstance(root, ast.Name):
+                assert root.id != "torch_npu", (
+                    "ascend_fia.py must not reference torch_npu.*"
+                )
+        elif isinstance(node, ast.Name):
+            assert node.id != "torch_npu", (
+                "ascend_fia.py must not reference `torch_npu`"
+            )

--- a/tests/misc/test_ascend_fia_backend.py
+++ b/tests/misc/test_ascend_fia_backend.py
@@ -730,7 +730,15 @@ def test_prepare_metadata_block_table_rows_independent(monkeypatch):
 
 
 def test_prepare_metadata_rejects_ragged_extend_len(monkeypatch):
-    """Gate 2.2c: mismatched ``extend_len`` must raise NotImplementedError."""
+    """Gate 2.2c required rejection of ragged ``extend_len``; Gate 2.2f
+    relaxes this to accept the cached_len==0 case. This test now verifies
+    that acceptance: a batch with mixed extend_len but zero cached_len on
+    every request is a valid ragged-prefill batch.
+
+    The strict rejection is retained by
+    :func:`test_gate22f_prepare_metadata_rejects_ragged_with_cached` below,
+    which covers the mixed-prefix-hit ragged case.
+    """
     torch = pytest.importorskip("torch")
     mod, backend = _make_backend()
     page_table = torch.tensor(
@@ -743,11 +751,12 @@ def test_prepare_metadata_rejects_ragged_extend_len(monkeypatch):
         _FakeReq(table_idx=1, cached_len=0, device_len=3),   # extend_len=3
     ]
     batch = _FakeBatch(padded_reqs=reqs)
-    with pytest.raises(NotImplementedError) as excinfo:
-        backend.prepare_metadata(batch)
-    msg = str(excinfo.value)
-    assert "ragged" in msg
-    assert "extend_len" in msg
+    # Gate 2.2f: accepted.
+    backend.prepare_metadata(batch)
+    meta = batch.attn_metadata
+    assert meta.query_seq_lens == [4, 3]
+    assert meta.max_query_len == 4
+    assert meta.query_seq_len is None  # ragged sentinel
 
 
 def test_prepare_metadata_rejects_ragged_cached_len(monkeypatch):
@@ -1271,24 +1280,30 @@ def test_forward_raises_runtimeerror_when_torch_npu_missing(monkeypatch):
 
 
 def test_forward_flat_query_shape_mismatch_rejected(monkeypatch):
-    """Gate 2.2c: if a caller mutates ``padded_reqs`` between
+    """Gate 2.2c / 2.2f: if a caller mutates ``padded_reqs`` between
     ``prepare_metadata`` and ``forward`` so that the flat query no longer
-    matches ``batch_size * query_seq_len``, ``forward`` must refuse."""
+    matches ``sum(query_seq_lens)`` (== ``query_offsets[-1]``), ``forward``
+    must refuse."""
     torch = pytest.importorskip("torch")
     setup = _prime_forward(monkeypatch, query_seq_len=2, kv_seq_len=2)
     backend, batch = setup["backend"], setup["batch"]
 
-    # Poison the metadata so it claims B=2 while the flat q is still B=1.
+    # Poison the metadata so it claims B=2 (4 tokens total) while the flat q
+    # is still B=1 (2 tokens).
     batch.attn_metadata.actual_seq_lengths = [2, 2]
     batch.attn_metadata.actual_seq_lengths_kv = [2, 2]
     batch.attn_metadata.batch_size = 2
+    batch.attn_metadata.query_seq_lens = [2, 2]
+    batch.attn_metadata.kv_seq_lens = [2, 2]
+    batch.attn_metadata.max_query_len = 2
+    batch.attn_metadata.query_offsets = [0, 2, 4]
 
     with pytest.raises(ValueError) as excinfo:
         backend.forward(setup["q"], setup["k"], setup["v"],
                         layer_id=setup["layer_id"], batch=batch)
     msg = str(excinfo.value)
     assert "flat query" in msg
-    assert "batch_size" in msg
+    assert "sum(query_seq_lens)" in msg
 
 
 # --------------------------------- 14. Module top-level no torch_npu ------
@@ -1523,3 +1538,459 @@ def test_gate22c_only_ascend_fia_touched_batch_limit():
     assert "batch size 1 only" not in src, (
         "Gate 2.2c must remove the legacy 'batch size 1 only' hard limit"
     )
+
+
+# =====================================================================
+# Gate 2.2f: ragged prefill (all cached_len==0, varied extend_len)
+#
+# Metadata expansion + prepare_metadata acceptance + pack/unpack in forward.
+# Fake torch_npu records the packed BSND query, per-batch mask and kwargs.
+# =====================================================================
+
+
+def test_gate22f_prepare_metadata_ragged_prefill_lengths_4_2(monkeypatch):
+    """Gate 2.2f: ragged prefill B=2 with extend_len=[4,2], both cached_len==0."""
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    page_table = torch.tensor(
+        [
+            [0, 1, 2, 3, 4, 5, 6, 7],     # req0: page 0 first raw slot 0 → id 0
+            [16, 17, 18, 19, 20, 21, 22, 23],  # req1: page 4 first raw slot 16 → id 4
+        ],
+        dtype=torch.int32,
+    )
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    reqs = [
+        _FakeReq(table_idx=0, cached_len=0, device_len=4),  # extend=4 → 1 block
+        _FakeReq(table_idx=1, cached_len=0, device_len=2),  # extend=2 → 1 block
+    ]
+    batch = _FakeBatch(padded_reqs=reqs)
+    backend.prepare_metadata(batch)
+
+    meta = batch.attn_metadata
+    assert isinstance(meta, mod.FIAMetadata)
+    assert meta.batch_size == 2
+    assert meta.query_seq_lens == [4, 2]
+    assert meta.kv_seq_lens == [4, 2]
+    assert meta.max_query_len == 4
+    assert meta.query_offsets == [0, 4, 6]
+    assert meta.actual_seq_lengths == [4, 2]
+    assert meta.actual_seq_lengths_kv == [4, 2]
+    # Equal-length shortcuts must be None under ragged.
+    assert meta.query_seq_len is None
+    assert meta.kv_seq_len is None
+    # block_table: each row has ceil(kv/page_size)=1 block; padded to
+    # max_blocks=1 so [[0], [4]].
+    assert meta.block_table.tolist() == [[0], [4]]
+    assert meta.block_table.shape == (2, 1)
+
+
+def test_gate22f_prepare_metadata_pads_block_table_rows(monkeypatch):
+    """Gate 2.2f: request with fewer blocks than max_blocks gets row padding.
+
+    extend_len=[6, 2] at page_size=4 → num_blocks=[2, 1]; max_blocks=2.
+    Row 1 (2 tokens, 1 page) is right-padded with page id 0 to width 2.
+    """
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    page_table = torch.tensor(
+        [
+            [0, 1, 2, 3, 4, 5, 6, 7],       # req0 pages 0, 1
+            [40, 41, 42, 43, 0, 0, 0, 0],   # req1 page 10; tail is unused.
+        ],
+        dtype=torch.int32,
+    )
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    reqs = [
+        _FakeReq(table_idx=0, cached_len=0, device_len=6),  # 2 pages
+        _FakeReq(table_idx=1, cached_len=0, device_len=2),  # 1 page
+    ]
+    batch = _FakeBatch(padded_reqs=reqs)
+    backend.prepare_metadata(batch)
+
+    meta = batch.attn_metadata
+    assert meta.max_query_len == 6
+    assert meta.query_offsets == [0, 6, 8]
+    # Row 0: pages [0, 1]. Row 1: page [10] pad-with-0 → [10, 0].
+    assert meta.block_table.tolist() == [[0, 1], [10, 0]]
+    assert meta.block_table.shape == (2, 2)
+
+
+def test_gate22f_prepare_metadata_rejects_ragged_with_cached(monkeypatch):
+    """Gate 2.2f: any non-zero cached_len in a ragged batch must raise."""
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    page_table = torch.tensor(
+        [[0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14, 15]],
+        dtype=torch.int32,
+    )
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    # req0: cached=0 extend=4 device=4; req1: cached=2 extend=2 device=4.
+    reqs = [
+        _FakeReq(table_idx=0, cached_len=0, device_len=4),
+        _FakeReq(table_idx=1, cached_len=2, device_len=4),
+    ]
+    batch = _FakeBatch(padded_reqs=reqs)
+    with pytest.raises(NotImplementedError) as excinfo:
+        backend.prepare_metadata(batch)
+    msg = str(excinfo.value)
+    assert "cached_len" in msg
+    assert "ragged" in msg
+
+
+def test_gate22f_get_last_indices_ragged(monkeypatch):
+    """Gate 2.2f: last-index per request under ragged prefill."""
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    page_table = torch.tensor(
+        [[0, 1, 2, 3], [4, 5, 6, 7]], dtype=torch.int32
+    )
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    reqs = [
+        _FakeReq(table_idx=0, cached_len=0, device_len=4),
+        _FakeReq(table_idx=1, cached_len=0, device_len=2),
+    ]
+    batch = _FakeBatch(padded_reqs=reqs)
+    backend.prepare_metadata(batch)
+
+    # Flat layout: [r0_t0..r0_t3, r1_t0, r1_t1]; last idx per req = [3, 5].
+    idx = batch.attn_metadata.get_last_indices(2)
+    assert idx.tolist() == [3, 5]
+    assert idx.dtype == torch.int32
+
+
+def _prime_forward_ragged(monkeypatch, query_lens, *, page_size=4,
+                          num_heads=4, num_kv_heads=2, head_dim=8,
+                          num_pages=32, num_layers=2, layer_id=0):
+    """Ragged variant: each request has cached_len==0 and its own extend_len.
+
+    Row ``b`` in page_table gets a disjoint physical-page range so tests can
+    trace out_loc.
+    """
+    import torch as _t
+
+    mod, backend = _make_backend()
+    reqs = []
+    rows = []
+    offset = 0
+    row_slots = []
+    for b, q_len in enumerate(query_lens):
+        nb = (q_len + page_size - 1) // page_size
+        row = list(range(offset, offset + nb * page_size))
+        # Pad row to a shared width so page_table is rectangular.
+        row_slots.append(row)
+        rows.append(row)
+        offset += nb * page_size
+        reqs.append(_FakeReq(table_idx=b, cached_len=0, device_len=q_len))
+    max_width = max(len(r) for r in rows)
+    padded_rows = [r + [0] * (max_width - len(r)) for r in rows]
+    page_table = _t.tensor(padded_rows, dtype=_t.int32)
+
+    kv_cache = _RecordingKVCache(
+        num_pages=num_pages, num_kv_heads=num_kv_heads,
+        page_size=page_size, head_dim=head_dim,
+        num_layers=num_layers, dtype=_t.float32,
+    )
+    ctx = _FakeCtxFIA(page_table=page_table, page_size=page_size, kv_cache=kv_cache)
+    import minisgl.core as core_mod
+    monkeypatch.setattr(core_mod, "get_global_ctx", lambda: ctx)
+
+    # out_loc = concatenation of per-req real slot ranges.
+    ol_pieces = []
+    for row, q_len in zip(row_slots, query_lens):
+        ol_pieces.extend(row[:q_len])
+    out_loc = _t.tensor(ol_pieces, dtype=_t.int32)
+    batch = _FakeBatchFIA(padded_reqs=reqs, out_loc=out_loc)
+
+    backend.prepare_metadata(batch)
+
+    total_tokens = sum(query_lens)
+    q = _t.randn((total_tokens, num_heads, head_dim), dtype=_t.float32)
+    k = _t.randn((total_tokens, num_kv_heads, head_dim), dtype=_t.float32)
+    v = _t.randn((total_tokens, num_kv_heads, head_dim), dtype=_t.float32)
+
+    max_q = max(query_lens)
+    calls = []
+    _install_fake_torch_npu(
+        monkeypatch, calls,
+        out_shape=(len(query_lens), max_q, num_heads, head_dim),
+        out_dtype=_t.float32, out_device=q.device,
+    )
+    return {
+        "backend": backend, "batch": batch, "ctx": ctx, "kv_cache": kv_cache,
+        "q": q, "k": k, "v": v, "layer_id": layer_id, "calls": calls,
+        "query_lens": query_lens, "max_q": max_q,
+        "num_heads": num_heads, "num_kv_heads": num_kv_heads, "head_dim": head_dim,
+        "page_size": page_size, "row_slots": row_slots,
+    }
+
+
+def test_gate22f_forward_ragged_query_bsnd_shape(monkeypatch):
+    """Gate 2.2f: flat q [sum_q, Hq, D] → packed BSND [B, max_q, Hq, D]."""
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward_ragged(monkeypatch, [4, 2])
+    setup["backend"].forward(setup["q"], setup["k"], setup["v"],
+                             layer_id=setup["layer_id"], batch=setup["batch"])
+    query = setup["calls"][0]["query"]
+    assert tuple(query.shape) == (2, 4, setup["num_heads"], setup["head_dim"])
+
+
+def test_gate22f_forward_ragged_pack_unpack_order(monkeypatch):
+    """Gate 2.2f: real query rows are packed into positions [0..q_len) per
+    batch; padded rows are zero; unpack must recover the flat rows in order.
+
+    We arrange the fake FIA to echo its ``query`` back as the output so
+    that unpack correctness reduces to bit-equality between the returned
+    flat result and the original ``q``.
+    """
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward_ragged(monkeypatch, [4, 2])
+
+    def _echo_fia(query, key, value, **kwargs):
+        setup["calls"].append({"query": query, "key": key, "value": value,
+                               "kwargs": kwargs})
+        # Echo query as attention_out to check pack/unpack round-trip.
+        return (query, torch.empty((0,), dtype=torch.float32))
+    sys.modules["torch_npu"].npu_fused_infer_attention_score = _echo_fia
+
+    out = setup["backend"].forward(setup["q"], setup["k"], setup["v"],
+                                    layer_id=setup["layer_id"],
+                                    batch=setup["batch"])
+    # Ragged echo returns [B, max_q, H, D] with padding rows zero; unpack
+    # must slice each req's real rows back in order.
+    assert torch.equal(out, setup["q"].view(setup["q"].shape))
+    # Also verify the packed input: batch 0 rows 0..3 = q[0..3]; batch 1
+    # rows 0..1 = q[4..5]; batch 1 rows 2..3 = 0.
+    packed = setup["calls"][0]["query"]
+    assert torch.equal(packed[0, :4], setup["q"][0:4])
+    assert torch.equal(packed[1, :2], setup["q"][4:6])
+    assert torch.equal(packed[1, 2:], torch.zeros_like(packed[1, 2:]))
+
+
+def test_gate22f_forward_ragged_mask_shape_and_visibility(monkeypatch):
+    """Gate 2.2f: per-batch mask [B, 1, max_q, padded_kv_len]; padded query
+    rows are all True (== masked out); real rows are strictly causal.
+    """
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward_ragged(monkeypatch, [4, 2])
+    setup["backend"].forward(setup["q"], setup["k"], setup["v"],
+                             layer_id=setup["layer_id"], batch=setup["batch"])
+    mask = setup["calls"][0]["kwargs"]["atten_mask"]
+    # max_blocks = ceil(4/4) = 1 → padded_kv_len = 1 * 4 = 4.
+    assert tuple(mask.shape) == (2, 1, 4, 4)
+    # Batch 0 real rows 0..3, KV visible = [1, 2, 3, 4].
+    visible_a = (~mask[0, 0, :4]).sum(dim=1).tolist()
+    assert visible_a == [1, 2, 3, 4]
+    # Batch 1 real rows 0..1, KV visible = [1, 2]. Padding rows 2, 3
+    # fully masked.
+    visible_b = (~mask[1, 0, :2]).sum(dim=1).tolist()
+    assert visible_b == [1, 2]
+    assert bool(mask[1, 0, 2:].all().item())
+
+
+def test_gate22f_forward_ragged_kwargs(monkeypatch):
+    """Gate 2.2f: FIA kwargs for ragged prefill carry per-batch seqlens."""
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward_ragged(monkeypatch, [4, 2])
+    setup["backend"].forward(setup["q"], setup["k"], setup["v"],
+                             layer_id=setup["layer_id"], batch=setup["batch"])
+    kwargs = setup["calls"][0]["kwargs"]
+    assert kwargs["actual_seq_lengths"] == [4, 2]
+    assert kwargs["actual_seq_lengths_kv"] == [4, 2]
+    assert kwargs["input_layout"] == "BSND"
+    # block_table row 0 → page id 0; row 1 → page id 4 (offset by row0's
+    # page count = 1 → 1 page * page_size 4 = 4).
+    assert kwargs["block_table"].tolist() == [[0], [1]]
+
+
+def test_gate22f_forward_ragged_store_kv_uses_full_out_loc(monkeypatch):
+    """Gate 2.2f: KV store uses the flat ``out_loc`` verbatim; no reorder."""
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward_ragged(monkeypatch, [4, 2])
+    setup["backend"].forward(setup["q"], setup["k"], setup["v"],
+                             layer_id=setup["layer_id"], batch=setup["batch"])
+    assert len(setup["kv_cache"].store_kv_calls) == 1
+    call = setup["kv_cache"].store_kv_calls[0]
+    assert call["k"] is setup["k"]
+    assert call["v"] is setup["v"]
+    assert call["out_loc"] is setup["batch"].out_loc
+    # Total scatter slots equal sum(query_lens); no padding slots injected.
+    assert call["out_loc"].numel() == sum(setup["query_lens"])
+
+
+def test_gate22f_equal_length_b2_still_uses_shared_2d_mask(monkeypatch):
+    """Gate 2.2f regression: equal-length B>=1 must still ship a shared 2-D
+    causal mask, NOT the per-batch 4-D mask that ragged uses. This keeps the
+    Gate 2.2c behaviour intact.
+    """
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward_b2(monkeypatch, query_seq_len=4, kv_seq_len=8, page_size=4)
+    setup["backend"].forward(setup["q"], setup["k"], setup["v"],
+                             layer_id=setup["layer_id"], batch=setup["batch"])
+    mask = setup["calls"][0]["kwargs"]["atten_mask"]
+    assert mask.dim() == 2, (
+        f"equal-length B=2 must still use the shared 2-D mask, got shape "
+        f"{tuple(mask.shape)}"
+    )
+
+
+def test_gate22f_b1_single_prefill_still_works(monkeypatch):
+    """Gate 2.2f regression: B=1 metadata unchanged."""
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward(monkeypatch, query_seq_len=4, kv_seq_len=4, page_size=4)
+    setup["backend"].forward(setup["q"], setup["k"], setup["v"],
+                             layer_id=setup["layer_id"], batch=setup["batch"])
+    kwargs = setup["calls"][0]["kwargs"]
+    assert kwargs["actual_seq_lengths"] == [4]
+    assert kwargs["actual_seq_lengths_kv"] == [4]
+    # B=1 equal-length falls through the equal-length shared-mask branch;
+    # shape must be [S, padded_kv_len].
+    assert kwargs["atten_mask"].dim() == 2
+
+
+def test_gate22f_forward_flat_query_shape_mismatch_rejected_ragged(monkeypatch):
+    """Gate 2.2f: mismatch between metadata sum(query_seq_lens) and flat q
+    row count must still raise ValueError."""
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward_ragged(monkeypatch, [4, 2])
+    # Truncate q to only 5 rows while metadata claims 4+2=6.
+    q_short = setup["q"][:5]
+    with pytest.raises(ValueError) as excinfo:
+        setup["backend"].forward(q_short, setup["k"][:5], setup["v"][:5],
+                                 layer_id=setup["layer_id"], batch=setup["batch"])
+    msg = str(excinfo.value)
+    assert "flat query" in msg
+
+
+def _prime_forward_decode_mixed(monkeypatch, kv_lens, *, page_size=4,
+                                num_heads=4, num_kv_heads=2, head_dim=8,
+                                num_pages=32, num_layers=2, layer_id=0):
+    """Pure-decode fixture: each request has ``extend_len==1`` but its own
+    ``cached_len`` (and hence its own ``device_len``). Rows in ``page_table``
+    are disjoint so tests can trace out_loc / block_table independence.
+    """
+    import torch as _t
+
+    mod, backend = _make_backend()
+    reqs = []
+    rows = []
+    offset = 0
+    for b, kv_len in enumerate(kv_lens):
+        nb = (kv_len + page_size - 1) // page_size
+        row = list(range(offset, offset + nb * page_size))
+        rows.append(row)
+        offset += nb * page_size
+        reqs.append(_FakeReq(table_idx=b, cached_len=kv_len - 1, device_len=kv_len))
+    max_width = max(len(r) for r in rows)
+    padded_rows = [r + [0] * (max_width - len(r)) for r in rows]
+    page_table = _t.tensor(padded_rows, dtype=_t.int32)
+
+    kv_cache = _RecordingKVCache(
+        num_pages=num_pages, num_kv_heads=num_kv_heads,
+        page_size=page_size, head_dim=head_dim,
+        num_layers=num_layers, dtype=_t.float32,
+    )
+    ctx = _FakeCtxFIA(page_table=page_table, page_size=page_size, kv_cache=kv_cache)
+    import minisgl.core as core_mod
+    monkeypatch.setattr(core_mod, "get_global_ctx", lambda: ctx)
+
+    # out_loc = the single new-token slot per request, flat.
+    ol_pieces = [rows[b][kv_lens[b] - 1] for b in range(len(kv_lens))]
+    out_loc = _t.tensor(ol_pieces, dtype=_t.int32)
+    batch = _FakeBatchFIA(padded_reqs=reqs, out_loc=out_loc)
+
+    backend.prepare_metadata(batch)
+
+    total_tokens = len(kv_lens)  # one row per request in decode
+    q = _t.randn((total_tokens, num_heads, head_dim), dtype=_t.float32)
+    k = _t.randn((total_tokens, num_kv_heads, head_dim), dtype=_t.float32)
+    v = _t.randn((total_tokens, num_kv_heads, head_dim), dtype=_t.float32)
+
+    calls = []
+    _install_fake_torch_npu(
+        monkeypatch, calls,
+        out_shape=(len(kv_lens), 1, num_heads, head_dim),
+        out_dtype=_t.float32, out_device=q.device,
+    )
+    return {
+        "backend": backend, "batch": batch, "ctx": ctx, "kv_cache": kv_cache,
+        "q": q, "k": k, "v": v, "layer_id": layer_id, "calls": calls,
+        "kv_lens": kv_lens, "num_heads": num_heads, "num_kv_heads": num_kv_heads,
+        "head_dim": head_dim, "page_size": page_size, "rows": rows,
+    }
+
+
+def test_gate22f_prepare_metadata_pure_decode_mixed_cached(monkeypatch):
+    """Gate 2.2f: pure-decode batch with different cached_len is accepted;
+    metadata reports per-req kv lengths and shared query length 1."""
+    torch = pytest.importorskip("torch")
+    mod, backend = _make_backend()
+    page_table = torch.tensor(
+        [[0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14, 15]],
+        dtype=torch.int32,
+    )
+    _install_ctx(monkeypatch, page_table, page_size=4)
+
+    # A: cached=4, device=5, extend=1 ; B: cached=2, device=3, extend=1
+    reqs = [
+        _FakeReq(table_idx=0, cached_len=4, device_len=5),
+        _FakeReq(table_idx=1, cached_len=2, device_len=3),
+    ]
+    batch = _FakeBatch(padded_reqs=reqs)
+    backend.prepare_metadata(batch)
+    meta = batch.attn_metadata
+    assert meta.batch_size == 2
+    assert list(meta.query_seq_lens) == [1, 1]
+    assert list(meta.kv_seq_lens) == [5, 3]
+    assert list(meta.actual_seq_lengths) == [1, 1]
+    assert list(meta.actual_seq_lengths_kv) == [5, 3]
+    assert meta.max_query_len == 1
+    assert list(meta.query_offsets) == [0, 1, 2]
+    # Rows independent: row 0 must reference req A's real pages only, row 1 req B's.
+    bt = meta.block_table
+    assert bt.shape[0] == 2
+    # A needs ceil(5/4)=2 blocks; B needs ceil(3/4)=1 block. max_blocks=2.
+    assert bt.shape[1] == 2
+    # Row 0 (A) real page ids: raw slots 0 and 4 / page_size=4 → pages 0 and 1
+    assert bt[0].tolist()[:2] == [0, 1]
+    # Row 1 (B) real page id: raw slot 8 / 4 = page 2; second col padded with 0
+    assert bt[1, 0].item() == 2
+    assert bt[1, 1].item() == 0  # padding column
+
+
+def test_gate22f_forward_pure_decode_mask_is_none(monkeypatch):
+    """Gate 2.2f: pure-decode mixed-cached forward passes atten_mask=None."""
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward_decode_mixed(monkeypatch, [5, 3])
+    setup["backend"].forward(setup["q"], setup["k"], setup["v"],
+                             layer_id=setup["layer_id"], batch=setup["batch"])
+    kwargs = setup["calls"][0]["kwargs"]
+    assert kwargs.get("atten_mask") is None
+    assert list(kwargs.get("actual_seq_lengths")) == [1, 1]
+    assert list(kwargs.get("actual_seq_lengths_kv")) == [5, 3]
+
+
+def test_gate22f_forward_pure_decode_query_and_output_shape(monkeypatch):
+    """Gate 2.2f: [B,Hq,D] flat q → [B,1,Hq,D] BSND; output flattens back."""
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward_decode_mixed(monkeypatch, [5, 3])
+    out = setup["backend"].forward(setup["q"], setup["k"], setup["v"],
+                                   layer_id=setup["layer_id"], batch=setup["batch"])
+    query = setup["calls"][0]["query"]
+    assert tuple(query.shape) == (2, 1, setup["num_heads"], setup["head_dim"])
+    # Output shape must match the flat q shape the caller supplied.
+    assert tuple(out.shape) == tuple(setup["q"].shape)
+
+
+def test_gate22f_forward_pure_decode_store_kv_uses_full_out_loc(monkeypatch):
+    """Gate 2.2f: pure-decode store_kv scatter uses batch.out_loc unchanged."""
+    torch = pytest.importorskip("torch")
+    setup = _prime_forward_decode_mixed(monkeypatch, [5, 3])
+    setup["backend"].forward(setup["q"], setup["k"], setup["v"],
+                             layer_id=setup["layer_id"], batch=setup["batch"])
+    scatter = setup["kv_cache"].store_kv_calls[0]
+    assert scatter["out_loc"].tolist() == setup["batch"].out_loc.tolist()

--- a/tests/misc/test_device.py
+++ b/tests/misc/test_device.py
@@ -1,0 +1,188 @@
+"""Unit tests for :mod:`minisgl.utils.device`.
+
+The device-probe layer must be safe to import on hosts without CUDA or
+``torch_npu`` (e.g. developer macOS boxes). These tests use ``monkeypatch``
+plus fake modules injected into ``sys.modules`` — no real hardware, no real
+``torch_npu`` install, no reliance on the wider ``minisgl`` runtime deps.
+
+To keep the tests hermetic on macOS the ``device`` module is loaded directly
+from its file location, bypassing ``minisgl.utils.__init__`` which pulls in
+``torch``, ``transformers`` and other heavyweight optional dependencies that
+are not part of the device-probe contract under test.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEVICE_PATH = _REPO_ROOT / "python" / "minisgl" / "utils" / "device.py"
+_ARCH_PATH = _REPO_ROOT / "python" / "minisgl" / "utils" / "arch.py"
+
+
+def _load_isolated(module_name: str, path: Path) -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None, f"cannot build spec for {path}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Import device.py in isolation and expose it under its canonical dotted name
+# so that ``from .device import ...`` inside arch.py resolves to the same
+# object we monkeypatch below.
+device = _load_isolated("minisgl.utils.device", _DEVICE_PATH)
+
+
+@pytest.fixture(autouse=True)
+def _reset_device_cache():
+    """Clear the ``@functools.cache`` on each probe before and after every test."""
+    device.is_cuda_available.cache_clear()
+    device.is_npu_available.cache_clear()
+    device.get_device_type.cache_clear()
+    yield
+    device.is_cuda_available.cache_clear()
+    device.is_npu_available.cache_clear()
+    device.get_device_type.cache_clear()
+
+
+def _make_fake_torch_npu(available: bool) -> types.ModuleType:
+    fake_npu = types.ModuleType("torch_npu.npu")
+    fake_npu.is_available = lambda: available
+    fake_torch_npu = types.ModuleType("torch_npu")
+    fake_torch_npu.npu = fake_npu
+    return fake_torch_npu
+
+
+def _install_import_hook(
+    monkeypatch: pytest.MonkeyPatch, name: str, exc: BaseException
+) -> None:
+    """Make ``import <name>`` raise ``exc`` even if the real module exists."""
+    monkeypatch.delitem(sys.modules, name, raising=False)
+    real_import = __import__
+
+    def fake_import(module_name, globals=None, locals=None, fromlist=(), level=0):  # noqa: A002
+        if module_name == name or module_name.startswith(name + "."):
+            raise exc
+        return real_import(module_name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+
+def test_module_imports_without_torch_npu() -> None:
+    """The module must load on a host that has neither CUDA nor ``torch_npu``."""
+    assert "torch_npu" not in sys.modules or sys.modules["torch_npu"] is not None
+    # Public API surface exists and is callable without side effects.
+    assert callable(device.get_device_type)
+    assert callable(device.is_cuda_available)
+    assert callable(device.is_npu_available)
+
+
+def test_cuda_available_returns_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When CUDA reports available, the type is 'cuda' regardless of NPU state."""
+    monkeypatch.setattr(device, "_probe_cuda", lambda: True)
+    # NPU status must not matter when CUDA is present.
+    monkeypatch.setattr(device, "_probe_npu", lambda: False)
+
+    assert device.is_cuda_available() is True
+    assert device.get_device_type() == "cuda"
+
+
+def test_cuda_absent_and_no_torch_npu_returns_cpu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No CUDA + ``torch_npu`` missing must fall through to 'cpu' cleanly."""
+    monkeypatch.setattr(device, "_probe_cuda", lambda: False)
+    _install_import_hook(monkeypatch, "torch_npu", ImportError("no torch_npu on this host"))
+
+    assert device.is_cuda_available() is False
+    assert device.is_npu_available() is False
+    assert device.get_device_type() == "cpu"
+
+
+def test_cuda_absent_but_npu_available_returns_npu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No CUDA + fake ``torch_npu`` reporting a device yields 'npu'."""
+    monkeypatch.setattr(device, "_probe_cuda", lambda: False)
+    fake = _make_fake_torch_npu(available=True)
+    monkeypatch.setitem(sys.modules, "torch_npu", fake)
+    monkeypatch.setitem(sys.modules, "torch_npu.npu", fake.npu)
+
+    assert device.is_cuda_available() is False
+    assert device.is_npu_available() is True
+    assert device.get_device_type() == "npu"
+
+
+def test_torch_npu_import_raises_falls_back_to_cpu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed ``torch_npu`` that raises on import must not crash callers."""
+    monkeypatch.setattr(device, "_probe_cuda", lambda: False)
+    _install_import_hook(monkeypatch, "torch_npu", RuntimeError("torch_npu ffi failure"))
+
+    # Neither call may raise.
+    assert device.is_npu_available() is False
+    assert device.get_device_type() == "cpu"
+
+
+def test_torch_npu_present_but_reports_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``torch_npu`` that imports but reports ``is_available() is False`` yields cpu."""
+    monkeypatch.setattr(device, "_probe_cuda", lambda: False)
+    fake = _make_fake_torch_npu(available=False)
+    monkeypatch.setitem(sys.modules, "torch_npu", fake)
+    monkeypatch.setitem(sys.modules, "torch_npu.npu", fake.npu)
+
+    assert device.is_npu_available() is False
+    assert device.get_device_type() == "cpu"
+
+
+def test_get_device_type_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``get_device_type`` memoises — repeated probe swaps do not leak through."""
+    monkeypatch.setattr(device, "_probe_cuda", lambda: True)
+    assert device.get_device_type() == "cuda"
+
+    # Change the underlying probe: cached value should stick until cleared.
+    monkeypatch.setattr(device, "_probe_cuda", lambda: False)
+    assert device.get_device_type() == "cuda"
+
+    device.get_device_type.cache_clear()
+    device.is_cuda_available.cache_clear()
+    device.is_npu_available.cache_clear()
+    _install_import_hook(monkeypatch, "torch_npu", ImportError("absent"))
+    assert device.get_device_type() == "cpu"
+
+
+def test_arch_module_uses_device_layer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``arch.is_arch_supported`` must delegate CUDA presence to the device layer."""
+    # Load arch.py in isolation; its ``from .device import is_cuda_available``
+    # will resolve to the already-registered ``minisgl.utils.device`` above.
+    # Also register a minimal ``minisgl.utils`` package so the relative import
+    # can bind ``.device`` without executing the real ``__init__.py``.
+    if "minisgl" not in sys.modules:
+        pkg_minisgl = types.ModuleType("minisgl")
+        pkg_minisgl.__path__ = [str(_REPO_ROOT / "python" / "minisgl")]
+        sys.modules["minisgl"] = pkg_minisgl
+    if "minisgl.utils" not in sys.modules:
+        pkg_utils = types.ModuleType("minisgl.utils")
+        pkg_utils.__path__ = [str(_REPO_ROOT / "python" / "minisgl" / "utils")]
+        sys.modules["minisgl.utils"] = pkg_utils
+
+    arch = _load_isolated("minisgl.utils.arch", _ARCH_PATH)
+    arch._get_torch_cuda_version.cache_clear()
+
+    monkeypatch.setattr(device, "_probe_cuda", lambda: False)
+    _install_import_hook(monkeypatch, "torch_npu", ImportError("absent"))
+
+    assert arch.is_arch_supported(9, 0) is False
+    assert arch.is_sm90_supported() is False
+    assert arch.is_sm100_supported() is False
+
+    arch._get_torch_cuda_version.cache_clear()

--- a/tests/misc/test_device_runtime.py
+++ b/tests/misc/test_device_runtime.py
@@ -121,6 +121,20 @@ def _install_fake_torch(
         log.append(("cuda.mem_get_info", device))
         return (1234, 5678)
 
+    class _CudaStreamCtx:
+        """Fake context manager returned by ``torch.cuda.stream(stream)``."""
+
+        def __init__(self, stream: Any) -> None:
+            self.stream = stream
+            log.append(("cuda.stream", stream))
+
+        def __enter__(self) -> "_CudaStreamCtx":
+            log.append(("cuda.stream.__enter__", self.stream))
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            log.append(("cuda.stream.__exit__", self.stream))
+
     fake_cuda.Stream = _cuda_Stream  # type: ignore[attr-defined]
     fake_cuda.set_stream = _cuda_set_stream  # type: ignore[attr-defined]
     fake_cuda.current_stream = _cuda_current_stream  # type: ignore[attr-defined]
@@ -129,6 +143,7 @@ def _install_fake_torch(
     fake_cuda.empty_cache = _cuda_empty_cache  # type: ignore[attr-defined]
     fake_cuda.reset_peak_memory_stats = _cuda_reset_peak_memory_stats  # type: ignore[attr-defined]
     fake_cuda.mem_get_info = _cuda_mem_get_info  # type: ignore[attr-defined]
+    fake_cuda.stream = _CudaStreamCtx  # type: ignore[attr-defined]
 
     fake_npu = types.ModuleType("torch.npu")
     _npu_current = _Stream("npu-current")
@@ -163,6 +178,20 @@ def _install_fake_torch(
         log.append(("npu.mem_get_info", device))
         return (7777, 9999)
 
+    class _NpuStreamCtx:
+        """Fake context manager returned by ``torch.npu.stream(stream)``."""
+
+        def __init__(self, stream: Any) -> None:
+            self.stream = stream
+            log.append(("npu.stream", stream))
+
+        def __enter__(self) -> "_NpuStreamCtx":
+            log.append(("npu.stream.__enter__", self.stream))
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            log.append(("npu.stream.__exit__", self.stream))
+
     fake_npu.Stream = _npu_Stream  # type: ignore[attr-defined]
     fake_npu.set_stream = _npu_set_stream  # type: ignore[attr-defined]
     fake_npu.current_stream = _npu_current_stream  # type: ignore[attr-defined]
@@ -171,6 +200,7 @@ def _install_fake_torch(
     fake_npu.empty_cache = _npu_empty_cache  # type: ignore[attr-defined]
     fake_npu.reset_peak_memory_stats = _npu_reset_peak_memory_stats  # type: ignore[attr-defined]
     fake_npu.mem_get_info = _npu_mem_get_info  # type: ignore[attr-defined]
+    fake_npu.stream = _NpuStreamCtx  # type: ignore[attr-defined]
 
     fake_torch.cuda = fake_cuda  # type: ignore[attr-defined]
     fake_torch.npu = fake_npu  # type: ignore[attr-defined]
@@ -351,6 +381,102 @@ def test_cpu_synchronize_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert dr.synchronize_device("cpu") is None
     assert log == []
+
+
+# ---------------------------------------------------------------------------
+# stream_context — cuda / npu / cpu dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_cuda_stream_context_calls_torch_cuda_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    payload = _Stream("cuda-payload")
+    ctx = dr.stream_context("cuda", payload)
+
+    # Construction dispatched to torch.cuda.stream(payload) — no npu import.
+    assert [name for name, _ in log] == ["cuda.stream"]
+    assert "torch_npu" not in sys.modules
+
+    # The returned object is a real context manager, and re-entering it works.
+    with ctx:
+        pass
+    with ctx:
+        pass
+
+    assert [name for name, _ in log] == [
+        "cuda.stream",
+        "cuda.stream.__enter__",
+        "cuda.stream.__exit__",
+        "cuda.stream.__enter__",
+        "cuda.stream.__exit__",
+    ]
+
+
+def test_npu_stream_context_imports_torch_npu_and_calls_torch_npu_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+    _install_torch_npu(monkeypatch)
+
+    payload = _Stream("npu-payload")
+    ctx = dr.stream_context("npu", payload)
+
+    # Construction dispatched to torch.npu.stream(payload). Also, torch.cuda.stream
+    # must not have been touched — NPU hosts have no CUDA.
+    assert [name for name, _ in log] == ["npu.stream"]
+    assert "torch_npu" in sys.modules
+
+    with ctx:
+        pass
+    assert [name for name, _ in log] == [
+        "npu.stream",
+        "npu.stream.__enter__",
+        "npu.stream.__exit__",
+    ]
+
+
+def test_cpu_stream_context_returns_nullcontext(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    ctx = dr.stream_context("cpu", None)
+
+    with ctx:
+        pass
+    with ctx:  # nullcontext is safely re-entrant
+        pass
+    # CPU branch must not touch torch.cuda.stream or torch.npu.stream.
+    assert log == []
+
+
+def test_stream_context_cpu_never_touches_torch_npu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CPU stream_context must not trigger a torch_npu import."""
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+    _install_torch_npu_import_hook(
+        monkeypatch, ImportError("torch_npu deliberately absent")
+    )
+    # Must not raise even though torch_npu import is booby-trapped.
+    with dr.stream_context("cpu", None):
+        pass
+
+
+def test_stream_context_rejects_unknown_device_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+    with pytest.raises(ValueError, match="unsupported device_type"):
+        dr.stream_context("mps", None)  # type: ignore[arg-type]
 
 
 def test_cpu_branch_never_touches_torch_npu(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -792,6 +918,7 @@ def test_public_surface_is_the_documented_functions() -> None:
         "create_stream",
         "set_stream",
         "current_stream",
+        "stream_context",
         "synchronize_device",
         "create_event",
         "record_event",

--- a/tests/misc/test_device_runtime.py
+++ b/tests/misc/test_device_runtime.py
@@ -1,0 +1,413 @@
+"""Unit tests for :mod:`minisgl.utils.device_runtime`.
+
+These tests never require a real CUDA / NPU install. They inject fake
+``torch`` and ``torch_npu`` modules into ``sys.modules`` and swap the
+``builtins.__import__`` hook to control ``import torch_npu`` failures.
+
+The module under test is loaded via ``importlib.util`` so we bypass
+``minisgl.utils.__init__`` (which pulls in heavyweight optional deps like
+``transformers`` and ``huggingface_hub``). This mirrors the pattern used by
+:mod:`tests.misc.test_device` and :mod:`tests.misc.test_distributed_runtime`.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any, List, Tuple
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PY_ROOT = _REPO_ROOT / "python"
+_DEVICE_PATH = _PY_ROOT / "minisgl" / "utils" / "device.py"
+_DEVICE_RUNTIME_PATH = _PY_ROOT / "minisgl" / "utils" / "device_runtime.py"
+
+
+def _install_package_stub(name: str, path: Path) -> None:
+    if name in sys.modules:
+        return
+    pkg = types.ModuleType(name)
+    pkg.__path__ = [str(path)]
+    sys.modules[name] = pkg
+
+
+def _load_isolated(module_name: str, path: Path) -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None, f"cannot build spec for {path}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Register minimal package stubs so ``from .device import ...`` inside
+# device_runtime.py resolves without executing the real utils/__init__.py.
+_install_package_stub("minisgl", _PY_ROOT / "minisgl")
+_install_package_stub("minisgl.utils", _PY_ROOT / "minisgl" / "utils")
+
+device = _load_isolated("minisgl.utils.device", _DEVICE_PATH)
+dr = _load_isolated("minisgl.utils.device_runtime", _DEVICE_RUNTIME_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Fake torch fixture
+# ---------------------------------------------------------------------------
+
+
+class _Stream:
+    """Marker object we can hand around to prove the plumbing is untouched."""
+
+    def __init__(self, backend: str) -> None:
+        self.backend = backend
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return f"_Stream({self.backend!r})"
+
+
+def _install_fake_torch(
+    monkeypatch: pytest.MonkeyPatch, log: List[Tuple[str, Any]]
+) -> types.ModuleType:
+    fake_torch = types.ModuleType("torch")
+
+    fake_cuda = types.ModuleType("torch.cuda")
+    _cuda_current = _Stream("cuda-current")
+
+    def _cuda_Stream() -> _Stream:
+        s = _Stream("cuda")
+        log.append(("cuda.Stream", s))
+        return s
+
+    def _cuda_set_stream(s: Any) -> None:
+        log.append(("cuda.set_stream", s))
+
+    def _cuda_current_stream() -> _Stream:
+        log.append(("cuda.current_stream", _cuda_current))
+        return _cuda_current
+
+    def _cuda_synchronize() -> None:
+        log.append(("cuda.synchronize", None))
+
+    fake_cuda.Stream = _cuda_Stream  # type: ignore[attr-defined]
+    fake_cuda.set_stream = _cuda_set_stream  # type: ignore[attr-defined]
+    fake_cuda.current_stream = _cuda_current_stream  # type: ignore[attr-defined]
+    fake_cuda.synchronize = _cuda_synchronize  # type: ignore[attr-defined]
+
+    fake_npu = types.ModuleType("torch.npu")
+    _npu_current = _Stream("npu-current")
+
+    def _npu_Stream() -> _Stream:
+        s = _Stream("npu")
+        log.append(("npu.Stream", s))
+        return s
+
+    def _npu_set_stream(s: Any) -> None:
+        log.append(("npu.set_stream", s))
+
+    def _npu_current_stream() -> _Stream:
+        log.append(("npu.current_stream", _npu_current))
+        return _npu_current
+
+    def _npu_synchronize() -> None:
+        log.append(("npu.synchronize", None))
+
+    fake_npu.Stream = _npu_Stream  # type: ignore[attr-defined]
+    fake_npu.set_stream = _npu_set_stream  # type: ignore[attr-defined]
+    fake_npu.current_stream = _npu_current_stream  # type: ignore[attr-defined]
+    fake_npu.synchronize = _npu_synchronize  # type: ignore[attr-defined]
+
+    fake_torch.cuda = fake_cuda  # type: ignore[attr-defined]
+    fake_torch.npu = fake_npu  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setitem(sys.modules, "torch.cuda", fake_cuda)
+    monkeypatch.setitem(sys.modules, "torch.npu", fake_npu)
+    return fake_torch
+
+
+def _install_torch_npu(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "torch_npu", types.ModuleType("torch_npu"))
+
+
+def _install_torch_npu_import_hook(
+    monkeypatch: pytest.MonkeyPatch, exc: BaseException
+) -> None:
+    monkeypatch.delitem(sys.modules, "torch_npu", raising=False)
+    real_import = __import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):  # noqa: A002
+        if name == "torch_npu" or name.startswith("torch_npu."):
+            raise exc
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+
+# ---------------------------------------------------------------------------
+# CUDA branch — all four entrypoints
+# ---------------------------------------------------------------------------
+
+
+def test_cuda_create_stream_calls_torch_cuda_Stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    s = dr.create_stream("cuda")
+
+    assert isinstance(s, _Stream) and s.backend == "cuda"
+    assert [name for name, _ in log] == ["cuda.Stream"]
+    # Must not have imported torch_npu on the CUDA branch.
+    assert "torch_npu" not in sys.modules
+
+
+def test_cuda_set_stream_calls_torch_cuda_set_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    payload = _Stream("payload")
+    result = dr.set_stream("cuda", payload)
+
+    assert result is None
+    assert log == [("cuda.set_stream", payload)]
+
+
+def test_cuda_current_stream_calls_torch_cuda_current_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    got = dr.current_stream("cuda")
+
+    assert isinstance(got, _Stream) and got.backend == "cuda-current"
+    assert [name for name, _ in log] == ["cuda.current_stream"]
+
+
+def test_cuda_synchronize_calls_torch_cuda_synchronize(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    result = dr.synchronize_device("cuda")
+
+    assert result is None
+    assert log == [("cuda.synchronize", None)]
+
+
+# ---------------------------------------------------------------------------
+# NPU branch — all four entrypoints (dynamic torch_npu import required)
+# ---------------------------------------------------------------------------
+
+
+def test_npu_create_stream_imports_torch_npu_and_calls_torch_npu_Stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+    _install_torch_npu(monkeypatch)
+
+    s = dr.create_stream("npu")
+
+    assert isinstance(s, _Stream) and s.backend == "npu"
+    assert [name for name, _ in log] == ["npu.Stream"]
+    assert "torch_npu" in sys.modules
+
+
+def test_npu_set_stream_calls_torch_npu_set_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+    _install_torch_npu(monkeypatch)
+
+    payload = _Stream("payload")
+    result = dr.set_stream("npu", payload)
+
+    assert result is None
+    assert log == [("npu.set_stream", payload)]
+
+
+def test_npu_current_stream_calls_torch_npu_current_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+    _install_torch_npu(monkeypatch)
+
+    got = dr.current_stream("npu")
+
+    assert isinstance(got, _Stream) and got.backend == "npu-current"
+    assert [name for name, _ in log] == ["npu.current_stream"]
+
+
+def test_npu_synchronize_calls_torch_npu_synchronize(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+    _install_torch_npu(monkeypatch)
+
+    result = dr.synchronize_device("npu")
+
+    assert result is None
+    assert log == [("npu.synchronize", None)]
+
+
+# ---------------------------------------------------------------------------
+# CPU branch — all four entrypoints are no-ops / None
+# ---------------------------------------------------------------------------
+
+
+def test_cpu_create_stream_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    assert dr.create_stream("cpu") is None
+    assert log == []
+
+
+def test_cpu_set_stream_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    assert dr.set_stream("cpu", None) is None
+    # Non-None payloads are also accepted silently.
+    assert dr.set_stream("cpu", _Stream("garbage")) is None
+    assert log == []
+
+
+def test_cpu_current_stream_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    assert dr.current_stream("cpu") is None
+    assert log == []
+
+
+def test_cpu_synchronize_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    assert dr.synchronize_device("cpu") is None
+    assert log == []
+
+
+def test_cpu_branch_never_touches_torch_npu(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CPU calls must not trigger a torch_npu import even if the module isn't installed."""
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+    _install_torch_npu_import_hook(
+        monkeypatch, ImportError("torch_npu deliberately absent")
+    )
+
+    # None of these may raise.
+    assert dr.create_stream("cpu") is None
+    dr.set_stream("cpu", None)
+    assert dr.current_stream("cpu") is None
+    dr.synchronize_device("cpu")
+
+
+# ---------------------------------------------------------------------------
+# NPU import failure — every NPU entrypoint must surface a clean RuntimeError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fn_name, args",
+    [
+        ("create_stream", ()),
+        ("set_stream", (None,)),
+        ("current_stream", ()),
+        ("synchronize_device", ()),
+    ],
+)
+def test_npu_import_failure_raises_runtime_error(
+    monkeypatch: pytest.MonkeyPatch, fn_name: str, args: tuple
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+    _install_torch_npu_import_hook(monkeypatch, ImportError("no torch_npu wheel"))
+
+    fn = getattr(dr, fn_name)
+    with pytest.raises(RuntimeError, match="torch_npu"):
+        fn("npu", *args)
+
+    # Nothing should have executed on the fake torch.npu namespace.
+    assert log == []
+
+
+def test_npu_import_failure_preserves_non_import_exceptions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-ImportError from ``import torch_npu`` also becomes a RuntimeError."""
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+    _install_torch_npu_import_hook(monkeypatch, RuntimeError("ffi bind failure"))
+
+    with pytest.raises(RuntimeError, match="torch_npu"):
+        dr.create_stream("npu")
+
+
+# ---------------------------------------------------------------------------
+# Invalid device type
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fn_name, args",
+    [
+        ("create_stream", ()),
+        ("set_stream", (None,)),
+        ("current_stream", ()),
+        ("synchronize_device", ()),
+    ],
+)
+def test_invalid_device_type_raises_value_error(
+    monkeypatch: pytest.MonkeyPatch, fn_name: str, args: tuple
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    fn = getattr(dr, fn_name)
+    with pytest.raises(ValueError) as excinfo:
+        fn("tpu", *args)  # type: ignore[arg-type]
+
+    msg = str(excinfo.value)
+    assert "tpu" in msg
+    # Error message must be actionable — list the supported values.
+    assert "cuda" in msg and "npu" in msg and "cpu" in msg
+    assert log == []
+
+
+# ---------------------------------------------------------------------------
+# Module-scope hygiene
+# ---------------------------------------------------------------------------
+
+
+def test_module_top_level_does_not_import_torch_npu() -> None:
+    """``device_runtime`` must be importable on hosts without ``torch_npu``.
+
+    ``dr`` was loaded above at module-import time; if a top-level
+    ``import torch_npu`` existed we would see it in ``sys.modules`` before
+    any test ran. We also check the module object itself has no ``torch_npu``
+    attribute — a stronger guarantee that survives shared ``sys.modules``
+    state from parametrised tests earlier in the suite.
+    """
+    assert not hasattr(dr, "torch_npu")
+
+
+def test_public_surface_is_the_four_documented_functions() -> None:
+    assert set(dr.__all__) == {
+        "create_stream",
+        "set_stream",
+        "current_stream",
+        "synchronize_device",
+    }
+    for name in dr.__all__:
+        assert callable(getattr(dr, name))

--- a/tests/misc/test_device_runtime.py
+++ b/tests/misc/test_device_runtime.py
@@ -66,6 +66,21 @@ class _Stream:
         return f"_Stream({self.backend!r})"
 
 
+class _Event:
+    """Marker event that records which stream (if any) ``.record`` was called on."""
+
+    def __init__(self, backend: str) -> None:
+        self.backend = backend
+        self.recorded_on: List[Any] = []
+
+    def record(self, stream: Any = None) -> None:
+        # Mirror torch.{cuda,npu}.Event.record: single optional stream arg.
+        self.recorded_on.append(stream)
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return f"_Event({self.backend!r}, recorded_on={self.recorded_on!r})"
+
+
 def _install_fake_torch(
     monkeypatch: pytest.MonkeyPatch, log: List[Tuple[str, Any]]
 ) -> types.ModuleType:
@@ -89,10 +104,16 @@ def _install_fake_torch(
     def _cuda_synchronize() -> None:
         log.append(("cuda.synchronize", None))
 
+    def _cuda_Event() -> _Event:
+        e = _Event("cuda")
+        log.append(("cuda.Event", e))
+        return e
+
     fake_cuda.Stream = _cuda_Stream  # type: ignore[attr-defined]
     fake_cuda.set_stream = _cuda_set_stream  # type: ignore[attr-defined]
     fake_cuda.current_stream = _cuda_current_stream  # type: ignore[attr-defined]
     fake_cuda.synchronize = _cuda_synchronize  # type: ignore[attr-defined]
+    fake_cuda.Event = _cuda_Event  # type: ignore[attr-defined]
 
     fake_npu = types.ModuleType("torch.npu")
     _npu_current = _Stream("npu-current")
@@ -112,10 +133,16 @@ def _install_fake_torch(
     def _npu_synchronize() -> None:
         log.append(("npu.synchronize", None))
 
+    def _npu_Event() -> _Event:
+        e = _Event("npu")
+        log.append(("npu.Event", e))
+        return e
+
     fake_npu.Stream = _npu_Stream  # type: ignore[attr-defined]
     fake_npu.set_stream = _npu_set_stream  # type: ignore[attr-defined]
     fake_npu.current_stream = _npu_current_stream  # type: ignore[attr-defined]
     fake_npu.synchronize = _npu_synchronize  # type: ignore[attr-defined]
+    fake_npu.Event = _npu_Event  # type: ignore[attr-defined]
 
     fake_torch.cuda = fake_cuda  # type: ignore[attr-defined]
     fake_torch.npu = fake_npu  # type: ignore[attr-defined]
@@ -260,7 +287,7 @@ def test_npu_synchronize_calls_torch_npu_synchronize(
 
 
 # ---------------------------------------------------------------------------
-# CPU branch — all four entrypoints are no-ops / None
+# CPU branch — Stream entrypoints are no-ops / None (Event covered separately)
 # ---------------------------------------------------------------------------
 
 
@@ -311,6 +338,124 @@ def test_cpu_branch_never_touches_torch_npu(monkeypatch: pytest.MonkeyPatch) -> 
     dr.set_stream("cpu", None)
     assert dr.current_stream("cpu") is None
     dr.synchronize_device("cpu")
+    assert dr.create_event("cpu") is None
+    dr.record_event("cpu", None, None)
+
+
+# ---------------------------------------------------------------------------
+# Event: CUDA branch
+# ---------------------------------------------------------------------------
+
+
+def test_cuda_create_event_calls_torch_cuda_Event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    ev = dr.create_event("cuda")
+
+    assert isinstance(ev, _Event) and ev.backend == "cuda"
+    assert [name for name, _ in log] == ["cuda.Event"]
+    # CUDA branch must not have imported torch_npu.
+    assert "torch_npu" not in sys.modules
+
+
+def test_cuda_record_event_forwards_stream(monkeypatch: pytest.MonkeyPatch) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    ev = dr.create_event("cuda")
+    stream = _Stream("cuda-payload")
+
+    result = dr.record_event("cuda", ev, stream)
+
+    assert result is None
+    # The stream we handed in was the only argument event.record saw.
+    assert ev.recorded_on == [stream]
+
+
+def test_cuda_record_event_defaults_to_none_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``record_event`` without a stream forwards ``None`` (== current stream)."""
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    ev = dr.create_event("cuda")
+    dr.record_event("cuda", ev)
+
+    assert ev.recorded_on == [None]
+
+
+# ---------------------------------------------------------------------------
+# Event: NPU branch (dynamic torch_npu import required)
+# ---------------------------------------------------------------------------
+
+
+def test_npu_create_event_imports_torch_npu_and_calls_torch_npu_Event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+    _install_torch_npu(monkeypatch)
+
+    ev = dr.create_event("npu")
+
+    assert isinstance(ev, _Event) and ev.backend == "npu"
+    assert [name for name, _ in log] == ["npu.Event"]
+    assert "torch_npu" in sys.modules
+
+
+def test_npu_record_event_forwards_stream(monkeypatch: pytest.MonkeyPatch) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+    _install_torch_npu(monkeypatch)
+
+    ev = dr.create_event("npu")
+    stream = _Stream("npu-payload")
+
+    result = dr.record_event("npu", ev, stream)
+
+    assert result is None
+    assert ev.recorded_on == [stream]
+
+
+def test_npu_record_event_defaults_to_none_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+    _install_torch_npu(monkeypatch)
+
+    ev = dr.create_event("npu")
+    dr.record_event("npu", ev)
+
+    assert ev.recorded_on == [None]
+
+
+# ---------------------------------------------------------------------------
+# Event: CPU branch
+# ---------------------------------------------------------------------------
+
+
+def test_cpu_create_event_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    assert dr.create_event("cpu") is None
+    assert log == []
+
+
+def test_cpu_record_event_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    # None/None matches the "no event, no stream" case documented for CPU.
+    assert dr.record_event("cpu", None, None) is None
+    # A stray non-None payload must not raise either — record is a pure no-op.
+    assert dr.record_event("cpu", _Event("garbage"), _Stream("garbage")) is None
+    assert log == []
 
 
 # ---------------------------------------------------------------------------
@@ -325,6 +470,8 @@ def test_cpu_branch_never_touches_torch_npu(monkeypatch: pytest.MonkeyPatch) -> 
         ("set_stream", (None,)),
         ("current_stream", ()),
         ("synchronize_device", ()),
+        ("create_event", ()),
+        ("record_event", (None, None)),
     ],
 )
 def test_npu_import_failure_raises_runtime_error(
@@ -366,6 +513,8 @@ def test_npu_import_failure_preserves_non_import_exceptions(
         ("set_stream", (None,)),
         ("current_stream", ()),
         ("synchronize_device", ()),
+        ("create_event", ()),
+        ("record_event", (None, None)),
     ],
 )
 def test_invalid_device_type_raises_value_error(
@@ -402,12 +551,14 @@ def test_module_top_level_does_not_import_torch_npu() -> None:
     assert not hasattr(dr, "torch_npu")
 
 
-def test_public_surface_is_the_four_documented_functions() -> None:
+def test_public_surface_is_the_documented_functions() -> None:
     assert set(dr.__all__) == {
         "create_stream",
         "set_stream",
         "current_stream",
         "synchronize_device",
+        "create_event",
+        "record_event",
     }
     for name in dr.__all__:
         assert callable(getattr(dr, name))

--- a/tests/misc/test_device_runtime.py
+++ b/tests/misc/test_device_runtime.py
@@ -115,6 +115,12 @@ def _install_fake_torch(
     def _cuda_reset_peak_memory_stats() -> None:
         log.append(("cuda.reset_peak_memory_stats", None))
 
+    def _cuda_mem_get_info(device: Any) -> Tuple[int, int]:
+        # Return (free, total). We stamp both slots into the log so tests can
+        # prove the device arg was forwarded and that free is the [0] slot.
+        log.append(("cuda.mem_get_info", device))
+        return (1234, 5678)
+
     fake_cuda.Stream = _cuda_Stream  # type: ignore[attr-defined]
     fake_cuda.set_stream = _cuda_set_stream  # type: ignore[attr-defined]
     fake_cuda.current_stream = _cuda_current_stream  # type: ignore[attr-defined]
@@ -122,6 +128,7 @@ def _install_fake_torch(
     fake_cuda.Event = _cuda_Event  # type: ignore[attr-defined]
     fake_cuda.empty_cache = _cuda_empty_cache  # type: ignore[attr-defined]
     fake_cuda.reset_peak_memory_stats = _cuda_reset_peak_memory_stats  # type: ignore[attr-defined]
+    fake_cuda.mem_get_info = _cuda_mem_get_info  # type: ignore[attr-defined]
 
     fake_npu = types.ModuleType("torch.npu")
     _npu_current = _Stream("npu-current")
@@ -152,6 +159,10 @@ def _install_fake_torch(
     def _npu_reset_peak_memory_stats() -> None:
         log.append(("npu.reset_peak_memory_stats", None))
 
+    def _npu_mem_get_info(device: Any) -> Tuple[int, int]:
+        log.append(("npu.mem_get_info", device))
+        return (7777, 9999)
+
     fake_npu.Stream = _npu_Stream  # type: ignore[attr-defined]
     fake_npu.set_stream = _npu_set_stream  # type: ignore[attr-defined]
     fake_npu.current_stream = _npu_current_stream  # type: ignore[attr-defined]
@@ -159,6 +170,7 @@ def _install_fake_torch(
     fake_npu.Event = _npu_Event  # type: ignore[attr-defined]
     fake_npu.empty_cache = _npu_empty_cache  # type: ignore[attr-defined]
     fake_npu.reset_peak_memory_stats = _npu_reset_peak_memory_stats  # type: ignore[attr-defined]
+    fake_npu.mem_get_info = _npu_mem_get_info  # type: ignore[attr-defined]
 
     fake_torch.cuda = fake_cuda  # type: ignore[attr-defined]
     fake_torch.npu = fake_npu  # type: ignore[attr-defined]
@@ -563,6 +575,120 @@ def test_cpu_reset_peak_memory_stats_is_noop(monkeypatch: pytest.MonkeyPatch) ->
 
 
 # ---------------------------------------------------------------------------
+# Free memory: CUDA branch
+# ---------------------------------------------------------------------------
+
+
+def test_cuda_get_free_memory_bytes_calls_torch_cuda_mem_get_info(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    result = dr.get_free_memory_bytes("cuda", 3)
+
+    # Fake returns (1234, 5678); we must expose the *free* slot as an int.
+    assert result == 1234
+    assert isinstance(result, int)
+    assert log == [("cuda.mem_get_info", 3)]
+    # CUDA branch must not have imported torch_npu.
+    assert "torch_npu" not in sys.modules
+
+
+def test_cuda_get_free_memory_bytes_forwards_arbitrary_device_argument(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ``device`` param is passed through verbatim — no coercion."""
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    marker = object()  # anything hashable that torch would normally accept
+    dr.get_free_memory_bytes("cuda", marker)
+
+    assert log == [("cuda.mem_get_info", marker)]
+
+
+def test_cuda_get_free_memory_bytes_return_type_is_native_int(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The return value is coerced to a real ``int``, never a torch/np scalar.
+
+    Reinstall the fake with a mem_get_info that returns numpy-style ints via a
+    subclass; the wrapper must still hand back a plain ``int``.
+    """
+
+    class _WeirdInt(int):
+        pass
+
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+    # Overwrite mem_get_info with a version that returns a non-plain int.
+    import torch  # comes from the fake we just installed
+
+    def _weird(device: Any):
+        log.append(("cuda.mem_get_info", device))
+        return (_WeirdInt(42), _WeirdInt(100))
+
+    monkeypatch.setattr(torch.cuda, "mem_get_info", _weird)
+
+    result = dr.get_free_memory_bytes("cuda", 0)
+
+    assert result == 42
+    assert type(result) is int  # not _WeirdInt — the wrapper coerced it
+
+
+# ---------------------------------------------------------------------------
+# Free memory: NPU branch (dynamic torch_npu import required)
+# ---------------------------------------------------------------------------
+
+
+def test_npu_get_free_memory_bytes_imports_torch_npu_and_calls_torch_npu_mem_get_info(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+    _install_torch_npu(monkeypatch)
+
+    result = dr.get_free_memory_bytes("npu", 5)
+
+    assert result == 7777
+    assert isinstance(result, int)
+    assert log == [("npu.mem_get_info", 5)]
+    assert "torch_npu" in sys.modules
+
+
+def test_npu_get_free_memory_bytes_forwards_arbitrary_device_argument(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+    _install_torch_npu(monkeypatch)
+
+    marker = object()
+    dr.get_free_memory_bytes("npu", marker)
+
+    assert log == [("npu.mem_get_info", marker)]
+
+
+# ---------------------------------------------------------------------------
+# Free memory: CPU branch — must raise NotImplementedError
+# ---------------------------------------------------------------------------
+
+
+def test_cpu_get_free_memory_bytes_raises_not_implemented(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    with pytest.raises(NotImplementedError, match="CPU"):
+        dr.get_free_memory_bytes("cpu", None)
+
+    # Nothing on the fake torch namespaces was touched.
+    assert log == []
+
+
+# ---------------------------------------------------------------------------
 # NPU import failure — every NPU entrypoint must surface a clean RuntimeError
 # ---------------------------------------------------------------------------
 
@@ -578,6 +704,7 @@ def test_cpu_reset_peak_memory_stats_is_noop(monkeypatch: pytest.MonkeyPatch) ->
         ("record_event", (None, None)),
         ("empty_device_cache", ()),
         ("reset_peak_memory_stats", ()),
+        ("get_free_memory_bytes", (0,)),
     ],
 )
 def test_npu_import_failure_raises_runtime_error(
@@ -623,6 +750,7 @@ def test_npu_import_failure_preserves_non_import_exceptions(
         ("record_event", (None, None)),
         ("empty_device_cache", ()),
         ("reset_peak_memory_stats", ()),
+        ("get_free_memory_bytes", (0,)),
     ],
 )
 def test_invalid_device_type_raises_value_error(
@@ -669,6 +797,7 @@ def test_public_surface_is_the_documented_functions() -> None:
         "record_event",
         "empty_device_cache",
         "reset_peak_memory_stats",
+        "get_free_memory_bytes",
     }
     for name in dr.__all__:
         assert callable(getattr(dr, name))

--- a/tests/misc/test_device_runtime.py
+++ b/tests/misc/test_device_runtime.py
@@ -109,11 +109,19 @@ def _install_fake_torch(
         log.append(("cuda.Event", e))
         return e
 
+    def _cuda_empty_cache() -> None:
+        log.append(("cuda.empty_cache", None))
+
+    def _cuda_reset_peak_memory_stats() -> None:
+        log.append(("cuda.reset_peak_memory_stats", None))
+
     fake_cuda.Stream = _cuda_Stream  # type: ignore[attr-defined]
     fake_cuda.set_stream = _cuda_set_stream  # type: ignore[attr-defined]
     fake_cuda.current_stream = _cuda_current_stream  # type: ignore[attr-defined]
     fake_cuda.synchronize = _cuda_synchronize  # type: ignore[attr-defined]
     fake_cuda.Event = _cuda_Event  # type: ignore[attr-defined]
+    fake_cuda.empty_cache = _cuda_empty_cache  # type: ignore[attr-defined]
+    fake_cuda.reset_peak_memory_stats = _cuda_reset_peak_memory_stats  # type: ignore[attr-defined]
 
     fake_npu = types.ModuleType("torch.npu")
     _npu_current = _Stream("npu-current")
@@ -138,11 +146,19 @@ def _install_fake_torch(
         log.append(("npu.Event", e))
         return e
 
+    def _npu_empty_cache() -> None:
+        log.append(("npu.empty_cache", None))
+
+    def _npu_reset_peak_memory_stats() -> None:
+        log.append(("npu.reset_peak_memory_stats", None))
+
     fake_npu.Stream = _npu_Stream  # type: ignore[attr-defined]
     fake_npu.set_stream = _npu_set_stream  # type: ignore[attr-defined]
     fake_npu.current_stream = _npu_current_stream  # type: ignore[attr-defined]
     fake_npu.synchronize = _npu_synchronize  # type: ignore[attr-defined]
     fake_npu.Event = _npu_Event  # type: ignore[attr-defined]
+    fake_npu.empty_cache = _npu_empty_cache  # type: ignore[attr-defined]
+    fake_npu.reset_peak_memory_stats = _npu_reset_peak_memory_stats  # type: ignore[attr-defined]
 
     fake_torch.cuda = fake_cuda  # type: ignore[attr-defined]
     fake_torch.npu = fake_npu  # type: ignore[attr-defined]
@@ -340,6 +356,8 @@ def test_cpu_branch_never_touches_torch_npu(monkeypatch: pytest.MonkeyPatch) -> 
     dr.synchronize_device("cpu")
     assert dr.create_event("cpu") is None
     dr.record_event("cpu", None, None)
+    dr.empty_device_cache("cpu")
+    dr.reset_peak_memory_stats("cpu")
 
 
 # ---------------------------------------------------------------------------
@@ -459,6 +477,92 @@ def test_cpu_record_event_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Memory maintenance: CUDA branch
+# ---------------------------------------------------------------------------
+
+
+def test_cuda_empty_device_cache_calls_torch_cuda_empty_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    result = dr.empty_device_cache("cuda")
+
+    assert result is None
+    assert log == [("cuda.empty_cache", None)]
+    # CUDA branch must not have imported torch_npu.
+    assert "torch_npu" not in sys.modules
+
+
+def test_cuda_reset_peak_memory_stats_calls_torch_cuda_reset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    result = dr.reset_peak_memory_stats("cuda")
+
+    assert result is None
+    assert log == [("cuda.reset_peak_memory_stats", None)]
+    assert "torch_npu" not in sys.modules
+
+
+# ---------------------------------------------------------------------------
+# Memory maintenance: NPU branch (dynamic torch_npu import required)
+# ---------------------------------------------------------------------------
+
+
+def test_npu_empty_device_cache_imports_torch_npu_and_calls_torch_npu_empty_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+    _install_torch_npu(monkeypatch)
+
+    result = dr.empty_device_cache("npu")
+
+    assert result is None
+    assert log == [("npu.empty_cache", None)]
+    assert "torch_npu" in sys.modules
+
+
+def test_npu_reset_peak_memory_stats_imports_torch_npu_and_calls_torch_npu_reset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+    _install_torch_npu(monkeypatch)
+
+    result = dr.reset_peak_memory_stats("npu")
+
+    assert result is None
+    assert log == [("npu.reset_peak_memory_stats", None)]
+    assert "torch_npu" in sys.modules
+
+
+# ---------------------------------------------------------------------------
+# Memory maintenance: CPU branch
+# ---------------------------------------------------------------------------
+
+
+def test_cpu_empty_device_cache_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    assert dr.empty_device_cache("cpu") is None
+    assert log == []
+
+
+def test_cpu_reset_peak_memory_stats_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    log: List[Tuple[str, Any]] = []
+    _install_fake_torch(monkeypatch, log)
+
+    assert dr.reset_peak_memory_stats("cpu") is None
+    assert log == []
+
+
+# ---------------------------------------------------------------------------
 # NPU import failure — every NPU entrypoint must surface a clean RuntimeError
 # ---------------------------------------------------------------------------
 
@@ -472,6 +576,8 @@ def test_cpu_record_event_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
         ("synchronize_device", ()),
         ("create_event", ()),
         ("record_event", (None, None)),
+        ("empty_device_cache", ()),
+        ("reset_peak_memory_stats", ()),
     ],
 )
 def test_npu_import_failure_raises_runtime_error(
@@ -515,6 +621,8 @@ def test_npu_import_failure_preserves_non_import_exceptions(
         ("synchronize_device", ()),
         ("create_event", ()),
         ("record_event", (None, None)),
+        ("empty_device_cache", ()),
+        ("reset_peak_memory_stats", ()),
     ],
 )
 def test_invalid_device_type_raises_value_error(
@@ -559,6 +667,8 @@ def test_public_surface_is_the_documented_functions() -> None:
         "synchronize_device",
         "create_event",
         "record_event",
+        "empty_device_cache",
+        "reset_peak_memory_stats",
     }
     for name in dr.__all__:
         assert callable(getattr(dr, name))

--- a/tests/misc/test_distributed_backend.py
+++ b/tests/misc/test_distributed_backend.py
@@ -1,0 +1,153 @@
+"""Unit tests for :mod:`minisgl.distributed.backend`.
+
+The backend selector must be a pure lookup — no torch, no ``torch_npu``, no
+process-group init, no environment reads. These tests exercise the mapping
+directly and use ``monkeypatch`` to swap the underlying device probes.
+
+Like :mod:`tests.misc.test_device`, the modules under test are loaded via
+``importlib.util`` so the suite runs on macOS without the heavyweight optional
+runtime dependencies (``torch``, ``huggingface_hub``, ...) referenced by the
+package ``__init__`` files.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PY_ROOT = _REPO_ROOT / "python"
+_DEVICE_PATH = _PY_ROOT / "minisgl" / "utils" / "device.py"
+_BACKEND_PATH = _PY_ROOT / "minisgl" / "distributed" / "backend.py"
+
+
+def _install_package_stub(name: str, path: Path) -> None:
+    if name in sys.modules:
+        return
+    pkg = types.ModuleType(name)
+    pkg.__path__ = [str(path)]
+    sys.modules[name] = pkg
+
+
+def _load_isolated(module_name: str, path: Path) -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None, f"cannot build spec for {path}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Register a minimal ``minisgl`` / ``minisgl.utils`` / ``minisgl.distributed``
+# package skeleton so the relative import ``from ..utils.device import ...``
+# inside backend.py resolves without executing the real ``__init__`` files
+# (which pull in torch, huggingface_hub, and the PyNCCL wrapper).
+_install_package_stub("minisgl", _PY_ROOT / "minisgl")
+_install_package_stub("minisgl.utils", _PY_ROOT / "minisgl" / "utils")
+_install_package_stub("minisgl.distributed", _PY_ROOT / "minisgl" / "distributed")
+
+device = _load_isolated("minisgl.utils.device", _DEVICE_PATH)
+backend = _load_isolated("minisgl.distributed.backend", _BACKEND_PATH)
+
+
+@pytest.fixture(autouse=True)
+def _reset_device_cache():
+    device.is_cuda_available.cache_clear()
+    device.is_npu_available.cache_clear()
+    device.get_device_type.cache_clear()
+    yield
+    device.is_cuda_available.cache_clear()
+    device.is_npu_available.cache_clear()
+    device.get_device_type.cache_clear()
+
+
+def test_explicit_cuda_maps_to_nccl() -> None:
+    assert backend.get_distributed_backend("cuda") == "nccl"
+
+
+def test_explicit_npu_maps_to_hccl() -> None:
+    assert backend.get_distributed_backend("npu") == "hccl"
+
+
+def test_explicit_cpu_maps_to_gloo() -> None:
+    assert backend.get_distributed_backend("cpu") == "gloo"
+
+
+def test_none_defers_to_device_probe_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(device, "_probe_cuda", lambda: True)
+    monkeypatch.setattr(device, "_probe_npu", lambda: False)
+
+    assert backend.get_distributed_backend() == "nccl"
+    assert backend.get_distributed_backend(None) == "nccl"
+
+
+def test_none_defers_to_device_probe_npu(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(device, "_probe_cuda", lambda: False)
+    monkeypatch.setattr(device, "_probe_npu", lambda: True)
+
+    assert backend.get_distributed_backend() == "hccl"
+
+
+def test_none_defers_to_device_probe_cpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(device, "_probe_cuda", lambda: False)
+    monkeypatch.setattr(device, "_probe_npu", lambda: False)
+
+    assert backend.get_distributed_backend() == "gloo"
+
+
+def test_explicit_value_does_not_reprobe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the caller supplies ``device_type`` we must NOT hit the probes."""
+    calls: list[str] = []
+
+    def spy_get_device_type() -> str:  # pragma: no cover - must not fire
+        calls.append("get_device_type")
+        return "cuda"
+
+    def spy_probe_cuda() -> bool:  # pragma: no cover - must not fire
+        calls.append("_probe_cuda")
+        return True
+
+    def spy_probe_npu() -> bool:  # pragma: no cover - must not fire
+        calls.append("_probe_npu")
+        return True
+
+    monkeypatch.setattr(device, "get_device_type", spy_get_device_type)
+    monkeypatch.setattr(device, "_probe_cuda", spy_probe_cuda)
+    monkeypatch.setattr(device, "_probe_npu", spy_probe_npu)
+    # backend.py imported the symbol at load time; patch its local binding too.
+    monkeypatch.setattr(backend, "get_device_type", spy_get_device_type)
+
+    assert backend.get_distributed_backend("npu") == "hccl"
+    assert backend.get_distributed_backend("cuda") == "nccl"
+    assert backend.get_distributed_backend("cpu") == "gloo"
+    assert calls == []
+
+
+def test_invalid_device_type_raises_value_error() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        backend.get_distributed_backend("tpu")  # type: ignore[arg-type]
+
+    msg = str(excinfo.value)
+    assert "tpu" in msg
+    # Error message must be actionable — list the supported values.
+    assert "cuda" in msg and "npu" in msg and "cpu" in msg
+
+
+def test_invalid_device_type_from_probe_raises_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even a corrupt probe result surfaces as ValueError, not KeyError."""
+    monkeypatch.setattr(backend, "get_device_type", lambda: "wat")
+
+    with pytest.raises(ValueError, match="wat"):
+        backend.get_distributed_backend()
+
+
+def test_backend_module_does_not_import_torch_npu() -> None:
+    """The lookup module must stay import-free of ``torch_npu``."""
+    # backend.py has already been executed above; if it imported torch_npu at
+    # module scope we would see it registered in sys.modules.
+    assert "torch_npu" not in sys.modules

--- a/tests/misc/test_distributed_runtime.py
+++ b/tests/misc/test_distributed_runtime.py
@@ -1,0 +1,331 @@
+"""Unit tests for :mod:`minisgl.distributed.runtime`.
+
+The runtime initialiser touches ``torch`` and optionally ``torch_npu``. This
+suite fakes both via ``sys.modules`` injection so it runs on a bare macOS host
+without any real torch/CUDA/NPU install. As with the sibling suites the
+modules under test are loaded via ``importlib.util`` to bypass the package
+``__init__`` files that import the heavier optional runtime deps.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PY_ROOT = _REPO_ROOT / "python"
+_DEVICE_PATH = _PY_ROOT / "minisgl" / "utils" / "device.py"
+_BACKEND_PATH = _PY_ROOT / "minisgl" / "distributed" / "backend.py"
+_RUNTIME_PATH = _PY_ROOT / "minisgl" / "distributed" / "runtime.py"
+
+
+def _install_package_stub(name: str, path: Path) -> None:
+    if name in sys.modules:
+        return
+    pkg = types.ModuleType(name)
+    pkg.__path__ = [str(path)]
+    sys.modules[name] = pkg
+
+
+def _load_isolated(module_name: str, path: Path) -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None, f"cannot build spec for {path}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_install_package_stub("minisgl", _PY_ROOT / "minisgl")
+_install_package_stub("minisgl.utils", _PY_ROOT / "minisgl" / "utils")
+_install_package_stub("minisgl.distributed", _PY_ROOT / "minisgl" / "distributed")
+
+device = _load_isolated("minisgl.utils.device", _DEVICE_PATH)
+backend_mod = _load_isolated("minisgl.distributed.backend", _BACKEND_PATH)
+runtime = _load_isolated("minisgl.distributed.runtime", _RUNTIME_PATH)
+
+
+class _CallLog:
+    """Ordered log of every fake torch entrypoint hit during a test."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, Any]] = []
+
+    def record(self, name: str, payload: Any = None) -> None:
+        self.events.append((name, payload))
+
+
+def _install_fake_torch(
+    monkeypatch: pytest.MonkeyPatch,
+    log: _CallLog,
+    *,
+    already_initialised: bool = False,
+) -> types.ModuleType:
+    """Inject a minimal fake ``torch`` (with ``.cuda`` / ``.npu`` / ``.distributed``)."""
+    fake_torch = types.ModuleType("torch")
+
+    fake_cuda = types.ModuleType("torch.cuda")
+    fake_cuda.set_device = lambda idx: log.record("cuda.set_device", idx)
+
+    fake_npu = types.ModuleType("torch.npu")
+    fake_npu.set_device = lambda idx: log.record("npu.set_device", idx)
+
+    fake_dist = types.ModuleType("torch.distributed")
+    fake_dist.is_initialized = lambda: already_initialised
+    fake_dist.init_process_group = lambda **kw: log.record("init_process_group", kw)
+
+    fake_torch.cuda = fake_cuda
+    fake_torch.npu = fake_npu
+    fake_torch.distributed = fake_dist
+
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setitem(sys.modules, "torch.cuda", fake_cuda)
+    monkeypatch.setitem(sys.modules, "torch.npu", fake_npu)
+    monkeypatch.setitem(sys.modules, "torch.distributed", fake_dist)
+    return fake_torch
+
+
+def _set_env(monkeypatch: pytest.MonkeyPatch, **values: str) -> None:
+    for name in ("LOCAL_RANK", "RANK", "WORLD_SIZE"):
+        monkeypatch.delenv(name, raising=False)
+    for k, v in values.items():
+        monkeypatch.setenv(k, v)
+
+
+def _install_torch_npu(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fake ``torch_npu`` — mere presence in ``sys.modules`` is enough."""
+    monkeypatch.setitem(sys.modules, "torch_npu", types.ModuleType("torch_npu"))
+
+
+def _install_torch_npu_import_hook(
+    monkeypatch: pytest.MonkeyPatch, exc: BaseException
+) -> None:
+    monkeypatch.delitem(sys.modules, "torch_npu", raising=False)
+    real_import = __import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):  # noqa: A002
+        if name == "torch_npu" or name.startswith("torch_npu."):
+            raise exc
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+
+@pytest.fixture(autouse=True)
+def _reset_device_cache():
+    device.is_cuda_available.cache_clear()
+    device.is_npu_available.cache_clear()
+    device.get_device_type.cache_clear()
+    yield
+    device.is_cuda_available.cache_clear()
+    device.is_npu_available.cache_clear()
+    device.get_device_type.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Happy paths per device
+# ---------------------------------------------------------------------------
+
+
+def test_cuda_binds_local_rank_and_selects_nccl(monkeypatch: pytest.MonkeyPatch) -> None:
+    log = _CallLog()
+    _install_fake_torch(monkeypatch, log)
+    monkeypatch.setattr(runtime, "get_device_type", lambda: "cuda")
+    _set_env(monkeypatch, LOCAL_RANK="1", RANK="1", WORLD_SIZE="4")
+
+    result = runtime.initialize_distributed_from_env()
+
+    assert result.device_type == "cuda"
+    assert result.backend == "nccl"
+    assert result.local_rank == 1
+    assert result.rank == 1
+    assert result.world_size == 4
+    assert result.device == "cuda:1"
+
+    # set_device must land before init_process_group and with the local rank.
+    assert log.events == [
+        ("cuda.set_device", 1),
+        ("init_process_group", {"backend": "nccl"}),
+    ]
+
+
+def test_npu_imports_torch_npu_binds_local_rank_and_selects_hccl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log = _CallLog()
+    _install_fake_torch(monkeypatch, log)
+    _install_torch_npu(monkeypatch)
+    monkeypatch.setattr(runtime, "get_device_type", lambda: "npu")
+    _set_env(monkeypatch, LOCAL_RANK="2", RANK="2", WORLD_SIZE="8")
+
+    result = runtime.initialize_distributed_from_env()
+
+    assert result.device_type == "npu"
+    assert result.backend == "hccl"
+    assert result.device == "npu:2"
+    assert result.local_rank == 2
+    assert result.rank == 2
+    assert result.world_size == 8
+
+    assert log.events == [
+        ("npu.set_device", 2),
+        ("init_process_group", {"backend": "hccl"}),
+    ]
+    # torch_npu must have been imported dynamically.
+    assert "torch_npu" in sys.modules
+
+
+def test_cpu_does_not_touch_set_device_and_selects_gloo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log = _CallLog()
+    _install_fake_torch(monkeypatch, log)
+    monkeypatch.setattr(runtime, "get_device_type", lambda: "cpu")
+    _set_env(monkeypatch, LOCAL_RANK="0", RANK="0", WORLD_SIZE="1")
+
+    result = runtime.initialize_distributed_from_env()
+
+    assert result.device_type == "cpu"
+    assert result.backend == "gloo"
+    assert result.device == "cpu"
+
+    # No set_device call — only init_process_group with the gloo backend.
+    assert log.events == [("init_process_group", {"backend": "gloo"})]
+
+
+# ---------------------------------------------------------------------------
+# Env-var validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("missing", ["LOCAL_RANK", "RANK", "WORLD_SIZE"])
+def test_missing_env_var_raises_runtime_error(
+    monkeypatch: pytest.MonkeyPatch, missing: str
+) -> None:
+    log = _CallLog()
+    _install_fake_torch(monkeypatch, log)
+    monkeypatch.setattr(runtime, "get_device_type", lambda: "cpu")
+    env = {"LOCAL_RANK": "0", "RANK": "0", "WORLD_SIZE": "1"}
+    env.pop(missing)
+    _set_env(monkeypatch, **env)
+
+    with pytest.raises(RuntimeError, match=missing):
+        runtime.initialize_distributed_from_env()
+    # Nothing was initialised.
+    assert log.events == []
+
+
+def test_non_integer_env_var_raises_runtime_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    log = _CallLog()
+    _install_fake_torch(monkeypatch, log)
+    monkeypatch.setattr(runtime, "get_device_type", lambda: "cpu")
+    _set_env(monkeypatch, LOCAL_RANK="0", RANK="oops", WORLD_SIZE="1")
+
+    with pytest.raises(RuntimeError, match="RANK"):
+        runtime.initialize_distributed_from_env()
+    assert log.events == []
+
+
+def test_world_size_zero_raises_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    log = _CallLog()
+    _install_fake_torch(monkeypatch, log)
+    monkeypatch.setattr(runtime, "get_device_type", lambda: "cpu")
+    _set_env(monkeypatch, LOCAL_RANK="0", RANK="0", WORLD_SIZE="0")
+
+    with pytest.raises(ValueError, match="WORLD_SIZE"):
+        runtime.initialize_distributed_from_env()
+    assert log.events == []
+
+
+def test_rank_out_of_range_raises_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    log = _CallLog()
+    _install_fake_torch(monkeypatch, log)
+    monkeypatch.setattr(runtime, "get_device_type", lambda: "cpu")
+    _set_env(monkeypatch, LOCAL_RANK="0", RANK="4", WORLD_SIZE="4")
+
+    with pytest.raises(ValueError, match="RANK"):
+        runtime.initialize_distributed_from_env()
+    assert log.events == []
+
+
+def test_negative_local_rank_raises_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    log = _CallLog()
+    _install_fake_torch(monkeypatch, log)
+    monkeypatch.setattr(runtime, "get_device_type", lambda: "cpu")
+    _set_env(monkeypatch, LOCAL_RANK="-1", RANK="0", WORLD_SIZE="1")
+
+    with pytest.raises(ValueError, match="LOCAL_RANK"):
+        runtime.initialize_distributed_from_env()
+    assert log.events == []
+
+
+# ---------------------------------------------------------------------------
+# Double-init guard & backend forwarding
+# ---------------------------------------------------------------------------
+
+
+def test_double_init_raises_runtime_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    log = _CallLog()
+    _install_fake_torch(monkeypatch, log, already_initialised=True)
+    monkeypatch.setattr(runtime, "get_device_type", lambda: "cuda")
+    _set_env(monkeypatch, LOCAL_RANK="0", RANK="0", WORLD_SIZE="1")
+
+    with pytest.raises(RuntimeError, match="already initialised"):
+        runtime.initialize_distributed_from_env()
+
+    # Neither device binding nor process group creation may fire.
+    assert log.events == []
+
+
+def test_init_process_group_receives_selected_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify backend is looked up via ``get_distributed_backend`` and forwarded."""
+    log = _CallLog()
+    _install_fake_torch(monkeypatch, log)
+    monkeypatch.setattr(runtime, "get_device_type", lambda: "cuda")
+    _set_env(monkeypatch, LOCAL_RANK="0", RANK="0", WORLD_SIZE="1")
+
+    runtime.initialize_distributed_from_env()
+
+    init_events = [e for e in log.events if e[0] == "init_process_group"]
+    assert len(init_events) == 1
+    assert init_events[0][1] == {"backend": "nccl"}
+    # No init_method / rank / world_size overrides leaked through.
+    assert list(init_events[0][1].keys()) == ["backend"]
+
+
+# ---------------------------------------------------------------------------
+# torch_npu import failure
+# ---------------------------------------------------------------------------
+
+
+def test_npu_selected_but_torch_npu_import_fails_raises_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log = _CallLog()
+    _install_fake_torch(monkeypatch, log)
+    monkeypatch.setattr(runtime, "get_device_type", lambda: "npu")
+    _install_torch_npu_import_hook(monkeypatch, ImportError("no torch_npu wheel"))
+    _set_env(monkeypatch, LOCAL_RANK="0", RANK="0", WORLD_SIZE="1")
+
+    with pytest.raises(RuntimeError, match="torch_npu"):
+        runtime.initialize_distributed_from_env()
+
+    # Failure must land BEFORE init_process_group — no group must be created.
+    assert not any(e[0] == "init_process_group" for e in log.events)
+
+
+def test_runtime_module_does_not_import_torch_npu_at_module_scope() -> None:
+    """Loading ``runtime`` must not pull in ``torch_npu`` — only device-npu path does."""
+    # ``runtime`` was loaded at test-module import time above; if it had
+    # ``import torch_npu`` at the top level we would see it in sys.modules
+    # already (no test has run the NPU path yet under this specific assertion).
+    # We therefore only check that the runtime module object itself has no
+    # ``torch_npu`` attribute — a weaker but robust proxy given the shared
+    # sys.modules state across parametrised tests.
+    assert not hasattr(runtime, "torch_npu")

--- a/tests/misc/test_distributed_runtime.py
+++ b/tests/misc/test_distributed_runtime.py
@@ -329,3 +329,124 @@ def test_runtime_module_does_not_import_torch_npu_at_module_scope() -> None:
     # ``torch_npu`` attribute — a weaker but robust proxy given the shared
     # sys.modules state across parametrised tests.
     assert not hasattr(runtime, "torch_npu")
+
+
+# ---------------------------------------------------------------------------
+# bind_local_device: shared device-binding primitive (Gate 1.1b)
+# ---------------------------------------------------------------------------
+
+
+def test_bind_local_device_is_public_export() -> None:
+    """``bind_local_device`` is part of the runtime's public surface."""
+    assert hasattr(runtime, "bind_local_device")
+    assert "bind_local_device" in runtime.__all__
+
+
+def test_bind_local_device_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
+    log = _CallLog()
+    _install_fake_torch(monkeypatch, log)
+
+    device = runtime.bind_local_device("cuda", 3)
+
+    assert device == "cuda:3"
+    assert log.events == [("cuda.set_device", 3)]
+
+
+def test_bind_local_device_npu(monkeypatch: pytest.MonkeyPatch) -> None:
+    log = _CallLog()
+    _install_fake_torch(monkeypatch, log)
+    _install_torch_npu(monkeypatch)
+
+    device = runtime.bind_local_device("npu", 5)
+
+    assert device == "npu:5"
+    assert log.events == [("npu.set_device", 5)]
+    # The dynamic import must have populated sys.modules.
+    assert "torch_npu" in sys.modules
+
+
+def test_bind_local_device_cpu_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    log = _CallLog()
+    _install_fake_torch(monkeypatch, log)
+
+    device = runtime.bind_local_device("cpu", 0)
+
+    assert device == "cpu"
+    # No set_device calls; no init_process_group.
+    assert log.events == []
+
+
+def test_bind_local_device_cpu_ignores_local_rank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CPU is a singleton — the rank must not leak into the returned spec."""
+    log = _CallLog()
+    _install_fake_torch(monkeypatch, log)
+
+    assert runtime.bind_local_device("cpu", 7) == "cpu"
+    assert log.events == []
+
+
+def test_bind_local_device_invalid_type_raises_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log = _CallLog()
+    _install_fake_torch(monkeypatch, log)
+
+    with pytest.raises(ValueError, match="tpu"):
+        runtime.bind_local_device("tpu", 0)  # type: ignore[arg-type]
+    assert log.events == []
+
+
+def test_bind_local_device_npu_import_failure_raises_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log = _CallLog()
+    _install_fake_torch(monkeypatch, log)
+    _install_torch_npu_import_hook(monkeypatch, ImportError("no torch_npu wheel"))
+
+    with pytest.raises(RuntimeError, match="torch_npu"):
+        runtime.bind_local_device("npu", 0)
+    # Failure must land BEFORE any set_device call.
+    assert log.events == []
+
+
+def test_bind_local_device_does_not_touch_process_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``bind_local_device`` must NOT touch ``torch.distributed`` — that's the caller's job."""
+    log = _CallLog()
+    _install_fake_torch(monkeypatch, log)
+
+    runtime.bind_local_device("cuda", 0)
+
+    assert all(name != "init_process_group" for name, _ in log.events)
+
+
+def test_initialize_from_env_reuses_bind_local_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``initialize_distributed_from_env`` must route through the shared helper."""
+    calls: list[tuple[str, int]] = []
+
+    def spy_bind(device_type: str, local_rank: int) -> str:
+        calls.append((device_type, local_rank))
+        return f"{device_type}:{local_rank}" if device_type != "cpu" else "cpu"
+
+    log = _CallLog()
+    _install_fake_torch(monkeypatch, log)
+    monkeypatch.setattr(runtime, "get_device_type", lambda: "cuda")
+    monkeypatch.setattr(runtime, "bind_local_device", spy_bind)
+    _set_env(monkeypatch, LOCAL_RANK="6", RANK="6", WORLD_SIZE="8")
+
+    result = runtime.initialize_distributed_from_env()
+
+    assert calls == [("cuda", 6)]
+    assert result.device == "cuda:6"
+    # No direct set_device call escaped through the fake torch — the spy caught it.
+    assert all(name != "cuda.set_device" for name, _ in log.events)
+
+
+def test_runtime_has_no_private_bind_device_duplicate() -> None:
+    """Gate 1.1b removed the ``_bind_device`` private duplicate."""
+    assert not hasattr(runtime, "_bind_device")

--- a/tests/misc/test_engine_device.py
+++ b/tests/misc/test_engine_device.py
@@ -1,4 +1,4 @@
-"""Unit tests for Engine's device wiring after Gate 1.3c.
+"""Unit tests for Engine's device wiring after Gate 1.4c.
 
 Historical layering:
 
@@ -14,6 +14,10 @@ Historical layering:
   calls are gone, replaced with the shared ``current_stream`` / ``create_event``
   / ``record_event`` dispatch helpers. ``ForwardOutput.copy_done_event`` no
   longer carries a CUDA-only type annotation.
+* Gate 1.4c ports ``Engine._sync_get_memory``'s
+  ``torch.cuda.synchronize`` / ``empty_cache`` / ``reset_peak_memory_stats``
+  triple to the shared ``synchronize_device`` / ``empty_device_cache`` /
+  ``reset_peak_memory_stats`` dispatch helpers, preserving source order.
 
 These tests are purely source-level: importing ``minisgl.engine.engine`` on a
 stock macOS box would pull in torch, transformers, huggingface_hub and the
@@ -34,14 +38,17 @@ What's checked here:
    ``torch.cuda.Event`` calls are gone from ``forward_batch``; the
    ``ForwardOutput.copy_done_event`` annotation no longer references
    ``torch.cuda.Event`` and the field name / tuple position are preserved.
-5. The engine still contains no private device-binding branch (no direct
+5. Gate 1.4c: ``synchronize_device`` / ``empty_device_cache`` /
+   ``reset_peak_memory_stats`` are imported and called in that exact source
+   order inside ``_sync_get_memory``; no ``torch.cuda.*`` remains there.
+6. The engine still contains no private device-binding branch (no direct
    ``torch.cuda.set_device`` / ``torch.npu.set_device`` calls, no
    ``import torch_npu`` at module scope).
-6. Gate 1.1a's other Ascend-portability guardrails still hold (no hard-coded
+7. Gate 1.1a's other Ascend-portability guardrails still hold (no hard-coded
    ``backend="nccl"``, ``get_distributed_backend`` still wired in,
    ``get_device_type`` still consulted).
-7. The remaining ``TODO(gate-1.2+)`` markers (in ``_sync_get_memory`` and
-   ``shutdown``) are still present — those Gates ship separately.
+8. The single remaining ``TODO(gate-1.2+)`` marker (in ``shutdown``, for
+   CUDA-graph destroy) is still present — that Gate ships separately.
 
 Coverage of the primitives themselves lives in dedicated hermetic suites
 (``test_distributed_runtime`` for ``bind_local_device``,
@@ -179,8 +186,9 @@ def _device_runtime_imported_names() -> set[str]:
 
 def test_engine_imports_all_stream_and_event_helpers_from_device_runtime() -> None:
     """__init__ needs create_stream/set_stream; forward_batch needs
-    current_stream/create_event/record_event. All five must come from
-    ``minisgl.utils.device_runtime``.
+    current_stream/create_event/record_event; _sync_get_memory needs
+    synchronize_device/empty_device_cache/reset_peak_memory_stats. All must
+    come from ``minisgl.utils.device_runtime``.
     """
     imported = _device_runtime_imported_names()
     for name in (
@@ -189,6 +197,9 @@ def test_engine_imports_all_stream_and_event_helpers_from_device_runtime() -> No
         "current_stream",
         "create_event",
         "record_event",
+        "synchronize_device",
+        "empty_device_cache",
+        "reset_peak_memory_stats",
     ):
         assert name in imported, (
             f"{name!r} must be imported from minisgl.utils.device_runtime"
@@ -450,6 +461,133 @@ def test_engine_module_imports_any_from_typing() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Gate 1.4c: _sync_get_memory routes through device_runtime, not torch.cuda.*
+# ---------------------------------------------------------------------------
+
+
+def _sync_get_memory_ast() -> ast.FunctionDef:
+    return _engine_method("_sync_get_memory")
+
+
+def _sync_get_memory_source() -> str:
+    return _method_raw_source("_sync_get_memory")
+
+
+def _sync_get_memory_top_level_dispatch_calls() -> list[ast.Call]:
+    """Return the ordered list of top-level device_runtime dispatch calls.
+
+    Restricting to the function body's direct statements (not ``ast.walk``)
+    lets us assert their *source-order* — the migration must preserve
+    synchronize → empty_cache → reset_peak order exactly.
+    """
+    watched = {"synchronize_device", "empty_device_cache", "reset_peak_memory_stats"}
+    out: list[ast.Call] = []
+    for stmt in _sync_get_memory_ast().body:
+        # Only bare expression statements (``synchronize_device(self.device_type)``)
+        # are legitimate dispatch calls at this level. Anything else (an
+        # assignment / return) is not part of the ordered maintenance triple.
+        if not isinstance(stmt, ast.Expr):
+            continue
+        call = stmt.value
+        if not isinstance(call, ast.Call):
+            continue
+        name = getattr(call.func, "id", None)
+        if name in watched:
+            out.append(call)
+    return out
+
+
+def _assert_single_device_type_arg(call: ast.Call, fn_name: str) -> None:
+    assert len(call.args) == 1 and not call.keywords, (
+        f"{fn_name} must be called with exactly one positional arg (self.device_type)"
+    )
+    arg = call.args[0]
+    assert isinstance(arg, ast.Attribute) and arg.attr == "device_type"
+    assert isinstance(arg.value, ast.Name) and arg.value.id == "self"
+
+
+def test_sync_get_memory_calls_synchronize_device_with_device_type() -> None:
+    calls = [
+        c for c in _sync_get_memory_top_level_dispatch_calls()
+        if getattr(c.func, "id", None) == "synchronize_device"
+    ]
+    assert calls, "_sync_get_memory must call synchronize_device(self.device_type)"
+    for c in calls:
+        _assert_single_device_type_arg(c, "synchronize_device")
+
+
+def test_sync_get_memory_calls_empty_device_cache_with_device_type() -> None:
+    calls = [
+        c for c in _sync_get_memory_top_level_dispatch_calls()
+        if getattr(c.func, "id", None) == "empty_device_cache"
+    ]
+    assert calls, "_sync_get_memory must call empty_device_cache(self.device_type)"
+    for c in calls:
+        _assert_single_device_type_arg(c, "empty_device_cache")
+
+
+def test_sync_get_memory_calls_reset_peak_memory_stats_with_device_type() -> None:
+    calls = [
+        c for c in _sync_get_memory_top_level_dispatch_calls()
+        if getattr(c.func, "id", None) == "reset_peak_memory_stats"
+    ]
+    assert calls, (
+        "_sync_get_memory must call reset_peak_memory_stats(self.device_type)"
+    )
+    for c in calls:
+        _assert_single_device_type_arg(c, "reset_peak_memory_stats")
+
+
+def test_sync_get_memory_preserves_maintenance_call_order() -> None:
+    """synchronize → empty_cache → reset_peak must run in that source order.
+
+    The pre-migration code did the three ``torch.cuda.*`` calls in this exact
+    order and the free-memory read that follows depends on them (empty_cache
+    must have released cached pages before ``get_free_memory`` samples).
+    """
+    ordered = [
+        getattr(c.func, "id", None)
+        for c in _sync_get_memory_top_level_dispatch_calls()
+    ]
+    assert ordered == [
+        "synchronize_device",
+        "empty_device_cache",
+        "reset_peak_memory_stats",
+    ], f"maintenance call order changed: {ordered!r}"
+
+
+def test_sync_get_memory_no_longer_calls_torch_cuda_directly() -> None:
+    """No ``torch.cuda.*`` call may remain inside ``_sync_get_memory``."""
+    src = _sync_get_memory_source()
+    assert "torch.cuda" not in src, (
+        "_sync_get_memory must go through device_runtime.* dispatch helpers, "
+        "not torch.cuda directly"
+    )
+
+
+def test_sync_get_memory_has_no_gate_1_2_todo_markers() -> None:
+    """Gate 1.4c ports the memory triple — its ``TODO(gate-1.2+)`` marker is gone."""
+    src = _sync_get_memory_source()
+    assert "TODO(gate-1.2+)" not in src, (
+        "_sync_get_memory's deferred CUDA calls were ported in Gate 1.4c — "
+        "the TODO(gate-1.2+) marker must be removed"
+    )
+
+
+def test_sync_get_memory_still_reads_free_memory_and_all_reduces() -> None:
+    """Migration must not silently drop the free-memory read or the TP all-reduce.
+
+    Regression guard: the maintenance triple is the *prelude* to the actual
+    memory read — this test proves the read still runs afterwards.
+    """
+    src = _sync_get_memory_source()
+    assert "get_free_memory(self.device)" in src
+    assert "torch.distributed.all_reduce" in src
+    # And the two-int return contract stays put.
+    assert "return min_free_memory, max_free_memory" in src
+
+
+# ---------------------------------------------------------------------------
 # No leftover private device branch inside engine.py
 # ---------------------------------------------------------------------------
 
@@ -471,6 +609,24 @@ def test_engine_does_not_import_torch_npu_at_any_scope() -> None:
         "inside minisgl.distributed.runtime.bind_local_device and "
         "minisgl.utils.device_runtime"
     )
+
+
+def test_engine_no_longer_calls_torch_cuda_synchronize_directly() -> None:
+    """The last remaining ``torch.cuda.synchronize`` call was in
+    ``_sync_get_memory``; Gate 1.4c ports it. No other call site should exist.
+    """
+    src = _engine_source()
+    assert "torch.cuda.synchronize" not in src
+
+
+def test_engine_no_longer_calls_torch_cuda_empty_cache_directly() -> None:
+    src = _engine_source()
+    assert "torch.cuda.empty_cache" not in src
+
+
+def test_engine_no_longer_calls_torch_cuda_reset_peak_memory_stats_directly() -> None:
+    src = _engine_source()
+    assert "torch.cuda.reset_peak_memory_stats" not in src
 
 
 # ---------------------------------------------------------------------------
@@ -497,6 +653,6 @@ def test_engine_source_uses_unified_device_type() -> None:
 
 
 def test_engine_source_still_marks_remaining_deferred_cuda_calls() -> None:
-    """Memory helpers + graph capture still carry ``TODO(gate-1.2+)`` markers."""
+    """``shutdown``'s CUDA-graph destroy is the last ``TODO(gate-1.2+)`` left."""
     src = _engine_source()
     assert "TODO(gate-1.2+)" in src

--- a/tests/misc/test_engine_device.py
+++ b/tests/misc/test_engine_device.py
@@ -756,22 +756,23 @@ def test_graph_no_longer_calls_torch_cuda_mem_get_info() -> None:
 
 
 def test_graph_runner_still_uses_cuda_graph_apis() -> None:
-    """Gate 1.5c must NOT rip out the CUDA-graph capture / replay calls.
+    """Gate 1.5c / 1.6a must NOT rip out the CUDA-graph capture / replay calls.
 
     Those live behind a separate Gate. Assert the well-known symbols still
     appear in the source so a stray edit that broke capture would be caught.
+    Note: the three memory-maintenance calls (``synchronize`` / ``empty_cache``
+    / ``reset_peak_memory_stats``) were ported by Gate 1.6a — they no longer
+    belong in this marker set.
     """
     src = _graph_source()
     for marker in (
         "torch.cuda.CUDAGraph",
         "torch.cuda.graph(",
-        "torch.cuda.synchronize",
-        "torch.cuda.empty_cache",
-        "torch.cuda.reset_peak_memory_stats",
     ):
         assert marker in src, (
-            f"graph.py must still call {marker} — Gate 1.5c only touches "
-            "get_free_memory, not CUDA Graph capture"
+            f"graph.py must still call {marker} — Gate 1.5c / 1.6a only touch "
+            "get_free_memory and the memory-maintenance triple, not CUDA "
+            "Graph capture"
         )
 
 
@@ -886,4 +887,162 @@ def test_engine_source_does_not_implicitly_infer_device_type_from_torch_device()
     src = _engine_source()
     assert "self.device.type" not in src, (
         "device_type must be forwarded explicitly, not inferred via self.device.type"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gate 1.6a: GraphRunner._capture_graphs routes memory maintenance through
+# device_runtime, not torch.cuda.*
+# ---------------------------------------------------------------------------
+
+
+def _capture_graphs_ast() -> ast.FunctionDef:
+    runner_cls = next(
+        node for node in _graph_tree().body
+        if isinstance(node, ast.ClassDef) and node.name == "GraphRunner"
+    )
+    return next(
+        node for node in runner_cls.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_capture_graphs"
+    )
+
+
+def _capture_graphs_source() -> str:
+    node = _capture_graphs_ast()
+    src_lines = _graph_source().splitlines()
+    return "\n".join(src_lines[node.lineno - 1 : node.end_lineno])
+
+
+def _capture_graphs_top_level_dispatch_calls() -> list[ast.Call]:
+    """Return the ordered list of top-level maintenance-dispatch calls.
+
+    Restricting to the function body's direct statements (not ``ast.walk``)
+    lets us assert their *source-order* — synchronize → empty_cache →
+    reset_peak must remain in that exact sequence.
+    """
+    watched = {"synchronize_device", "empty_device_cache", "reset_peak_memory_stats"}
+    out: list[ast.Call] = []
+    for stmt in _capture_graphs_ast().body:
+        if not isinstance(stmt, ast.Expr):
+            continue
+        call = stmt.value
+        if not isinstance(call, ast.Call):
+            continue
+        name = getattr(call.func, "id", None)
+        if name in watched:
+            out.append(call)
+    return out
+
+
+def _assert_capture_graphs_dispatch_takes_self_device_type(
+    call: ast.Call, fn_name: str
+) -> None:
+    assert len(call.args) == 1 and not call.keywords, (
+        f"{fn_name} must be called with exactly one positional arg (self.device_type)"
+    )
+    arg = call.args[0]
+    assert isinstance(arg, ast.Attribute) and arg.attr == "device_type"
+    assert isinstance(arg.value, ast.Name) and arg.value.id == "self"
+
+
+def test_graph_imports_memory_maintenance_helpers_from_device_runtime() -> None:
+    """Gate 1.6a: graph.py must import the three memory-maintenance dispatchers."""
+    imported = _graph_imported_names_from("minisgl.utils.device_runtime")
+    for name in ("synchronize_device", "empty_device_cache", "reset_peak_memory_stats"):
+        assert name in imported, (
+            f"graph.py must import {name!r} from minisgl.utils.device_runtime"
+        )
+
+
+def test_capture_graphs_calls_synchronize_device_with_device_type() -> None:
+    calls = [
+        c for c in _capture_graphs_top_level_dispatch_calls()
+        if getattr(c.func, "id", None) == "synchronize_device"
+    ]
+    assert calls, "_capture_graphs must call synchronize_device(self.device_type)"
+    for c in calls:
+        _assert_capture_graphs_dispatch_takes_self_device_type(c, "synchronize_device")
+
+
+def test_capture_graphs_calls_empty_device_cache_with_device_type() -> None:
+    calls = [
+        c for c in _capture_graphs_top_level_dispatch_calls()
+        if getattr(c.func, "id", None) == "empty_device_cache"
+    ]
+    assert calls, "_capture_graphs must call empty_device_cache(self.device_type)"
+    for c in calls:
+        _assert_capture_graphs_dispatch_takes_self_device_type(c, "empty_device_cache")
+
+
+def test_capture_graphs_calls_reset_peak_memory_stats_with_device_type() -> None:
+    calls = [
+        c for c in _capture_graphs_top_level_dispatch_calls()
+        if getattr(c.func, "id", None) == "reset_peak_memory_stats"
+    ]
+    assert calls, (
+        "_capture_graphs must call reset_peak_memory_stats(self.device_type)"
+    )
+    for c in calls:
+        _assert_capture_graphs_dispatch_takes_self_device_type(
+            c, "reset_peak_memory_stats"
+        )
+
+
+def test_capture_graphs_preserves_maintenance_call_order() -> None:
+    """synchronize → empty_cache → reset_peak must run in that source order.
+
+    The pre-migration code did the three ``torch.cuda.*`` calls in this exact
+    order and the free-memory read that follows depends on them (empty_cache
+    must have released cached pages before ``get_free_memory`` samples).
+    """
+    ordered = [
+        getattr(c.func, "id", None)
+        for c in _capture_graphs_top_level_dispatch_calls()
+    ]
+    assert ordered == [
+        "synchronize_device",
+        "empty_device_cache",
+        "reset_peak_memory_stats",
+    ], f"maintenance call order changed: {ordered!r}"
+
+
+def test_capture_graphs_no_longer_calls_torch_cuda_synchronize_directly() -> None:
+    src = _capture_graphs_source()
+    assert "torch.cuda.synchronize" not in src, (
+        "_capture_graphs must go through device_runtime.synchronize_device, "
+        "not torch.cuda.synchronize directly"
+    )
+
+
+def test_capture_graphs_no_longer_calls_torch_cuda_empty_cache_directly() -> None:
+    src = _capture_graphs_source()
+    assert "torch.cuda.empty_cache" not in src, (
+        "_capture_graphs must go through device_runtime.empty_device_cache, "
+        "not torch.cuda.empty_cache directly"
+    )
+
+
+def test_capture_graphs_no_longer_calls_torch_cuda_reset_peak_memory_stats_directly() -> None:
+    src = _capture_graphs_source()
+    assert "torch.cuda.reset_peak_memory_stats" not in src, (
+        "_capture_graphs must go through device_runtime.reset_peak_memory_stats, "
+        "not torch.cuda.reset_peak_memory_stats directly"
+    )
+
+
+def test_capture_graphs_still_captures_via_torch_cuda_graph_apis() -> None:
+    """Gate 1.6a does not touch CUDA-graph capture itself.
+
+    Both ``torch.cuda.CUDAGraph()`` instantiation and the
+    ``with torch.cuda.graph(...)`` context manager must still appear in
+    ``_capture_graphs``.
+    """
+    src = _capture_graphs_source()
+    assert "torch.cuda.CUDAGraph" in src, (
+        "_capture_graphs must still instantiate torch.cuda.CUDAGraph — "
+        "Gate 1.6a does not port CUDA-graph capture"
+    )
+    assert "torch.cuda.graph(" in src, (
+        "_capture_graphs must still use the torch.cuda.graph(...) context "
+        "manager — Gate 1.6a does not port CUDA-graph capture"
     )

--- a/tests/misc/test_engine_device.py
+++ b/tests/misc/test_engine_device.py
@@ -1,4 +1,4 @@
-"""Unit tests for Engine's device wiring after Gate 1.2b.
+"""Unit tests for Engine's device wiring after Gate 1.3c.
 
 Historical layering:
 
@@ -9,6 +9,11 @@ Historical layering:
 * Gate 1.2b routes ``Engine.__init__``'s Stream creation + binding through the
   shared :mod:`minisgl.utils.device_runtime` (``create_stream`` /
   ``set_stream``) so cuda / npu / cpu all take the same code path.
+* Gate 1.3c finishes the migration inside ``Engine.forward_batch``: the raw
+  ``torch.cuda.current_stream()`` / ``torch.cuda.Event()`` / ``event.record(...)``
+  calls are gone, replaced with the shared ``current_stream`` / ``create_event``
+  / ``record_event`` dispatch helpers. ``ForwardOutput.copy_done_event`` no
+  longer carries a CUDA-only type annotation.
 
 These tests are purely source-level: importing ``minisgl.engine.engine`` on a
 stock macOS box would pull in torch, transformers, huggingface_hub and the
@@ -23,15 +28,20 @@ What's checked here:
 3. Gate 1.2b: ``create_stream`` / ``set_stream`` from ``device_runtime`` are
    imported and invoked in ``Engine.__init__``; the raw ``torch.cuda.Stream``
    / ``torch.cuda.set_stream`` calls are gone from ``__init__``.
-4. ``forward_batch``'s ``torch.cuda.current_stream()`` and
-   ``torch.cuda.Event()`` are *deliberately* preserved with their
-   ``TODO(gate-1.2+)`` markers — a later Gate ports them.
+4. Gate 1.3c: ``current_stream`` / ``create_event`` / ``record_event`` are
+   imported from ``device_runtime`` and invoked inside ``forward_batch`` with
+   ``self.device_type``; the raw ``torch.cuda.current_stream`` /
+   ``torch.cuda.Event`` calls are gone from ``forward_batch``; the
+   ``ForwardOutput.copy_done_event`` annotation no longer references
+   ``torch.cuda.Event`` and the field name / tuple position are preserved.
 5. The engine still contains no private device-binding branch (no direct
    ``torch.cuda.set_device`` / ``torch.npu.set_device`` calls, no
    ``import torch_npu`` at module scope).
 6. Gate 1.1a's other Ascend-portability guardrails still hold (no hard-coded
    ``backend="nccl"``, ``get_distributed_backend`` still wired in,
    ``get_device_type`` still consulted).
+7. The remaining ``TODO(gate-1.2+)`` markers (in ``_sync_get_memory`` and
+   ``shutdown``) are still present — those Gates ship separately.
 
 Coverage of the primitives themselves lives in dedicated hermetic suites
 (``test_distributed_runtime`` for ``bind_local_device``,
@@ -77,6 +87,14 @@ def _engine_method(name: str) -> ast.FunctionDef:
     )
 
 
+def _forward_output_cls() -> ast.ClassDef:
+    """Return the ``ast.ClassDef`` for the ``ForwardOutput`` NamedTuple."""
+    return next(
+        node for node in _engine_tree().body
+        if isinstance(node, ast.ClassDef) and node.name == "ForwardOutput"
+    )
+
+
 def _init_source() -> str:
     return ast.unparse(_engine_init())
 
@@ -84,7 +102,7 @@ def _init_source() -> str:
 def _method_raw_source(name: str) -> str:
     """Return the raw text of a method (including ``# comments``).
 
-    ``ast.unparse`` drops comments, which would hide the deferred-CUDA TODO
+    ``ast.unparse`` drops comments, which would hide any deferred-CUDA TODO
     markers we care about. Slice the source lines by the method's line range
     instead.
     """
@@ -96,6 +114,10 @@ def _method_raw_source(name: str) -> str:
 
 def _forward_batch_source() -> str:
     return _method_raw_source("forward_batch")
+
+
+def _forward_batch_ast() -> ast.FunctionDef:
+    return _engine_method("forward_batch")
 
 
 # ---------------------------------------------------------------------------
@@ -141,21 +163,36 @@ def test_engine_init_calls_bind_local_device() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Gate 1.2b: Stream dispatch through device_runtime
+# Gate 1.2b + 1.3c: device_runtime imports cover both __init__ and forward_batch
 # ---------------------------------------------------------------------------
 
 
-def test_engine_imports_stream_helpers_from_device_runtime() -> None:
-    """Engine.__init__ must source ``create_stream`` + ``set_stream`` from device_runtime."""
-    src = _engine_source()
-    assert "from minisgl.utils.device_runtime import" in src
-    # Both names must be imported. Robust against either "a, b" or "b, a" order.
-    import_line = next(
-        line for line in src.splitlines()
-        if line.startswith("from minisgl.utils.device_runtime import")
-    )
-    assert "create_stream" in import_line
-    assert "set_stream" in import_line
+def _device_runtime_imported_names() -> set[str]:
+    """Return the set of names imported from ``minisgl.utils.device_runtime``."""
+    names: set[str] = set()
+    for node in ast.walk(_engine_tree()):
+        if isinstance(node, ast.ImportFrom) and node.module == "minisgl.utils.device_runtime":
+            for alias in node.names:
+                names.add(alias.name)
+    return names
+
+
+def test_engine_imports_all_stream_and_event_helpers_from_device_runtime() -> None:
+    """__init__ needs create_stream/set_stream; forward_batch needs
+    current_stream/create_event/record_event. All five must come from
+    ``minisgl.utils.device_runtime``.
+    """
+    imported = _device_runtime_imported_names()
+    for name in (
+        "create_stream",
+        "set_stream",
+        "current_stream",
+        "create_event",
+        "record_event",
+    ):
+        assert name in imported, (
+            f"{name!r} must be imported from minisgl.utils.device_runtime"
+        )
 
 
 def test_engine_init_calls_create_stream_with_device_type() -> None:
@@ -228,26 +265,188 @@ def test_engine_init_no_longer_calls_torch_cuda_set_stream_directly() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Deliberate leftovers: forward_batch still uses CUDA current_stream + Event
+# Gate 1.3c: forward_batch routes through device_runtime, not torch.cuda.*
 # ---------------------------------------------------------------------------
 
 
-def test_forward_batch_still_uses_torch_cuda_current_stream() -> None:
-    """Gate 1.2b defers ``current_stream()`` to a later Gate — must stay put."""
+def test_forward_batch_calls_current_stream_with_device_type() -> None:
+    """``current_stream(self.device_type)`` must appear inside forward_batch."""
+    fn = _forward_batch_ast()
+
+    matched = False
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Call):
+            continue
+        if getattr(node.func, "id", None) != "current_stream":
+            continue
+        assert len(node.args) == 1 and not node.keywords, (
+            "current_stream must take exactly one positional arg (self.device_type)"
+        )
+        arg = node.args[0]
+        assert isinstance(arg, ast.Attribute) and arg.attr == "device_type"
+        assert isinstance(arg.value, ast.Name) and arg.value.id == "self"
+        matched = True
+    assert matched, "forward_batch must call current_stream(self.device_type)"
+
+
+def test_forward_batch_calls_create_event_with_device_type() -> None:
+    """``create_event(self.device_type)`` must appear inside forward_batch."""
+    fn = _forward_batch_ast()
+
+    matched = False
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Call):
+            continue
+        if getattr(node.func, "id", None) != "create_event":
+            continue
+        assert len(node.args) == 1 and not node.keywords, (
+            "create_event must take exactly one positional arg (self.device_type)"
+        )
+        arg = node.args[0]
+        assert isinstance(arg, ast.Attribute) and arg.attr == "device_type"
+        assert isinstance(arg.value, ast.Name) and arg.value.id == "self"
+        matched = True
+    assert matched, "forward_batch must call create_event(self.device_type)"
+
+
+def test_forward_batch_calls_record_event_with_device_type_event_and_self_stream() -> None:
+    """``record_event(self.device_type, copy_done_event, self.stream)``."""
+    fn = _forward_batch_ast()
+
+    matched = False
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Call):
+            continue
+        if getattr(node.func, "id", None) != "record_event":
+            continue
+        assert len(node.args) == 3 and not node.keywords, (
+            "record_event must take three positional args (device_type, event, stream)"
+        )
+        first, second, third = node.args
+        # device_type
+        assert (
+            isinstance(first, ast.Attribute)
+            and first.attr == "device_type"
+            and isinstance(first.value, ast.Name)
+            and first.value.id == "self"
+        )
+        # event: the local we just created — must be a plain Name (no attr / call)
+        assert isinstance(second, ast.Name), (
+            "record_event's second arg should be the local event handle "
+            "returned by create_event, not an attribute/call chain"
+        )
+        # stream: must be ``self.stream`` — the same stream __init__ bound.
+        assert (
+            isinstance(third, ast.Attribute)
+            and third.attr == "stream"
+            and isinstance(third.value, ast.Name)
+            and third.value.id == "self"
+        )
+        matched = True
+    assert matched, (
+        "forward_batch must call record_event(self.device_type, <event>, self.stream)"
+    )
+
+
+def test_forward_batch_no_longer_calls_torch_cuda_current_stream() -> None:
     src = _forward_batch_source()
-    assert "torch.cuda.current_stream" in src
+    assert "torch.cuda.current_stream" not in src, (
+        "forward_batch must route through device_runtime.current_stream, "
+        "not torch.cuda.current_stream directly"
+    )
 
 
-def test_forward_batch_still_uses_torch_cuda_event() -> None:
-    """Gate 1.2b defers ``Event`` to a later Gate — must stay put."""
+def test_forward_batch_no_longer_calls_torch_cuda_event() -> None:
     src = _forward_batch_source()
-    assert "torch.cuda.Event" in src
+    assert "torch.cuda.Event" not in src, (
+        "forward_batch must route through device_runtime.create_event/"
+        "record_event, not torch.cuda.Event directly"
+    )
 
 
-def test_forward_batch_deferred_cuda_calls_are_annotated_with_todos() -> None:
-    """Each deferred CUDA call in ``forward_batch`` carries a ``TODO(gate-`` marker."""
+def test_forward_batch_no_longer_calls_event_record_directly() -> None:
+    """The old ``copy_done_event.record(self.stream)`` pattern is gone.
+
+    Recording must go through ``record_event(self.device_type, ...)`` so the
+    NPU / CPU branches can dispatch correctly. Any attribute call whose method
+    name is ``record`` on a local Name (i.e. ``copy_done_event.record(...)``)
+    is forbidden inside forward_batch.
+    """
+    fn = _forward_batch_ast()
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr != "record":
+            continue
+        # A local ``foo.record(...)`` call — flag it.
+        assert not isinstance(func.value, ast.Name), (
+            f"forward_batch must not call ``{func.value.id}.record(...)`` "
+            "directly; use device_runtime.record_event instead"
+        )
+
+
+def test_forward_batch_has_no_gate_1_2_todo_markers() -> None:
+    """Gate 1.3c completes the deferred migration inside forward_batch, so its
+    ``TODO(gate-1.2+)`` markers must be gone. Other methods keep theirs.
+    """
     src = _forward_batch_source()
-    assert "TODO(gate-" in src
+    assert "TODO(gate-1.2+)" not in src, (
+        "forward_batch's deferred CUDA calls were ported in Gate 1.3c — the "
+        "TODO(gate-1.2+) marker(s) inside forward_batch must be removed"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gate 1.3c: ForwardOutput type annotation is now device-agnostic
+# ---------------------------------------------------------------------------
+
+
+def test_forward_output_still_has_copy_done_event_field() -> None:
+    """The public field name and its position in the NamedTuple must not change.
+
+    ``scheduler._process_last_data`` unpacks ``ForwardOutput`` positionally as
+    ``(_, next_tokens_cpu, copy_done)`` — reordering the fields would silently
+    break the scheduler. Assert both the field name and the tuple position.
+    """
+    cls = _forward_output_cls()
+    field_names = [
+        stmt.target.id
+        for stmt in cls.body
+        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name)
+    ]
+    assert field_names == [
+        "next_tokens_gpu",
+        "next_tokens_cpu",
+        "copy_done_event",
+    ], f"ForwardOutput field order changed: {field_names!r}"
+
+
+def test_forward_output_annotation_no_longer_references_torch_cuda_event() -> None:
+    """The ``copy_done_event`` annotation must be device-agnostic (no ``torch.cuda.Event``)."""
+    cls = _forward_output_cls()
+    ann = next(
+        stmt.annotation
+        for stmt in cls.body
+        if isinstance(stmt, ast.AnnAssign)
+        and isinstance(stmt.target, ast.Name)
+        and stmt.target.id == "copy_done_event"
+    )
+    # The whole annotation subtree must contain no ``torch.cuda.Event`` chain.
+    ann_src = ast.unparse(ann)
+    assert "torch.cuda.Event" not in ann_src, (
+        f"copy_done_event annotation still references torch.cuda.Event: {ann_src!r}"
+    )
+
+
+def test_engine_module_imports_any_from_typing() -> None:
+    """The device-agnostic ``Any | None`` annotation requires ``Any`` in scope."""
+    imported: set[str] = set()
+    for node in ast.walk(_engine_tree()):
+        if isinstance(node, ast.ImportFrom) and node.module == "typing":
+            for alias in node.names:
+                imported.add(alias.name)
+    assert "Any" in imported, "engine.py must import Any from typing"
 
 
 # ---------------------------------------------------------------------------
@@ -298,6 +497,6 @@ def test_engine_source_uses_unified_device_type() -> None:
 
 
 def test_engine_source_still_marks_remaining_deferred_cuda_calls() -> None:
-    """The Event/memory/graph deferrals still carry ``TODO(gate-1.2+)`` markers."""
+    """Memory helpers + graph capture still carry ``TODO(gate-1.2+)`` markers."""
     src = _engine_source()
     assert "TODO(gate-1.2+)" in src

--- a/tests/misc/test_engine_device.py
+++ b/tests/misc/test_engine_device.py
@@ -1,0 +1,161 @@
+"""Unit tests for Engine's device wiring after Gate 1.1b.
+
+Gate 1.1a introduced two engine-local helpers (``_resolve_engine_device`` and
+``_bind_engine_local_device``) to de-CUDA-ify ``Engine.__init__``. Gate 1.1b
+consolidates that logic into the shared
+:func:`minisgl.distributed.runtime.bind_local_device` primitive, so both the
+runtime bootstrap and the engine bootstrap go through **one** implementation.
+
+These tests are purely source-level: importing ``minisgl.engine.engine`` on a
+stock macOS box would pull in torch, transformers, huggingface_hub and the
+attention kernels, none of which are available. Instead we ``ast``-parse the
+engine module and assert:
+
+1. The Gate 1.1a helpers are gone.
+2. The shared ``bind_local_device`` is imported and called from ``Engine.__init__``.
+3. The engine no longer contains any private device-binding branch (no direct
+   ``torch.cuda.set_device`` / ``torch.npu.set_device`` calls, no
+   ``import torch_npu`` at module scope).
+4. Gate 1.1a's other Ascend-portability guardrails still hold (no hard-coded
+   ``backend="nccl"``, ``get_distributed_backend`` still wired in,
+   ``get_device_type`` still consulted).
+
+Coverage of ``bind_local_device`` itself (cuda / npu / cpu behaviour, npu
+import failure, CPU no-op) lives in :mod:`tests.misc.test_distributed_runtime`
+where the runtime module is loaded hermetically.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ENGINE_PATH = _REPO_ROOT / "python" / "minisgl" / "engine" / "engine.py"
+
+
+def _engine_source() -> str:
+    return _ENGINE_PATH.read_text()
+
+
+def _engine_tree() -> ast.Module:
+    return ast.parse(_engine_source())
+
+
+# ---------------------------------------------------------------------------
+# The two Gate 1.1a helpers have been removed
+# ---------------------------------------------------------------------------
+
+
+def test_engine_no_longer_defines_resolve_engine_device() -> None:
+    for node in _engine_tree().body:
+        if isinstance(node, ast.FunctionDef):
+            assert node.name != "_resolve_engine_device", (
+                "_resolve_engine_device must be removed in Gate 1.1b — "
+                "engine should reuse bind_local_device instead"
+            )
+
+
+def test_engine_no_longer_defines_bind_engine_local_device() -> None:
+    for node in _engine_tree().body:
+        if isinstance(node, ast.FunctionDef):
+            assert node.name != "_bind_engine_local_device", (
+                "_bind_engine_local_device must be removed in Gate 1.1b — "
+                "engine should reuse bind_local_device instead"
+            )
+
+
+def test_engine_has_no_private_device_helpers() -> None:
+    """Neither helper name may appear anywhere in the engine source."""
+    src = _engine_source()
+    assert "_resolve_engine_device" not in src
+    assert "_bind_engine_local_device" not in src
+
+
+# ---------------------------------------------------------------------------
+# Engine imports & calls the shared primitive
+# ---------------------------------------------------------------------------
+
+
+def test_engine_imports_bind_local_device_from_runtime() -> None:
+    src = _engine_source()
+    assert "from minisgl.distributed.runtime import bind_local_device" in src
+
+
+def test_engine_calls_bind_local_device_from_runtime() -> None:
+    """The shared primitive must be invoked in Engine.__init__."""
+    src = _engine_source()
+    assert "bind_local_device(" in src
+
+    # Locate Engine.__init__ and confirm the call happens inside it (not just
+    # in a docstring or comment).
+    tree = _engine_tree()
+    engine_cls = next(
+        node for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "Engine"
+    )
+    init_fn = next(
+        node for node in engine_cls.body
+        if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+    )
+    calls = [
+        n for n in ast.walk(init_fn)
+        if isinstance(n, ast.Call) and getattr(n.func, "id", None) == "bind_local_device"
+    ]
+    assert calls, "Engine.__init__ must call bind_local_device()"
+
+
+# ---------------------------------------------------------------------------
+# No leftover private device branch inside engine.py
+# ---------------------------------------------------------------------------
+
+
+def test_engine_does_not_call_torch_cuda_set_device_directly() -> None:
+    """The CUDA set_device call now lives inside bind_local_device, not engine.py."""
+    src = _engine_source()
+    assert "torch.cuda.set_device" not in src
+
+
+def test_engine_does_not_call_torch_npu_set_device_directly() -> None:
+    """The NPU set_device call now lives inside bind_local_device, not engine.py."""
+    src = _engine_source()
+    assert "torch.npu.set_device" not in src
+
+
+def test_engine_does_not_import_torch_npu_at_any_scope() -> None:
+    """``import torch_npu`` must not appear anywhere in engine.py post-Gate-1.1b."""
+    src = _engine_source()
+    assert "torch_npu" not in src, (
+        "engine.py must not reference torch_npu — the dynamic import lives "
+        "inside minisgl.distributed.runtime.bind_local_device"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gate 1.1a guardrails still hold
+# ---------------------------------------------------------------------------
+
+
+def test_engine_source_has_no_hardcoded_nccl_backend() -> None:
+    src = _engine_source()
+    assert 'backend="nccl"' not in src
+    assert "backend='nccl'" not in src
+
+
+def test_engine_source_uses_get_distributed_backend() -> None:
+    src = _engine_source()
+    assert "from minisgl.distributed.backend import get_distributed_backend" in src
+    assert "get_distributed_backend(self.device_type)" in src
+
+
+def test_engine_source_uses_unified_device_type() -> None:
+    src = _engine_source()
+    assert "from minisgl.utils.device import" in src
+    assert "get_device_type" in src
+
+
+def test_engine_source_marks_deferred_cuda_calls() -> None:
+    src = _engine_source()
+    assert "TODO(gate-1.2+)" in src
+    # The deferred stream/event/graph sites still exist verbatim.
+    assert "torch.cuda.Stream" in src
+    assert "torch.cuda.Event" in src

--- a/tests/misc/test_engine_device.py
+++ b/tests/misc/test_engine_device.py
@@ -1,28 +1,41 @@
-"""Unit tests for Engine's device wiring after Gate 1.1b.
+"""Unit tests for Engine's device wiring after Gate 1.2b.
 
-Gate 1.1a introduced two engine-local helpers (``_resolve_engine_device`` and
-``_bind_engine_local_device``) to de-CUDA-ify ``Engine.__init__``. Gate 1.1b
-consolidates that logic into the shared
-:func:`minisgl.distributed.runtime.bind_local_device` primitive, so both the
-runtime bootstrap and the engine bootstrap go through **one** implementation.
+Historical layering:
+
+* Gate 1.1a introduced two engine-local device helpers
+  (``_resolve_engine_device`` and ``_bind_engine_local_device``).
+* Gate 1.1b consolidated those into
+  :func:`minisgl.distributed.runtime.bind_local_device`.
+* Gate 1.2b routes ``Engine.__init__``'s Stream creation + binding through the
+  shared :mod:`minisgl.utils.device_runtime` (``create_stream`` /
+  ``set_stream``) so cuda / npu / cpu all take the same code path.
 
 These tests are purely source-level: importing ``minisgl.engine.engine`` on a
 stock macOS box would pull in torch, transformers, huggingface_hub and the
 attention kernels, none of which are available. Instead we ``ast``-parse the
-engine module and assert:
+engine module and assert the required guardrails.
 
-1. The Gate 1.1a helpers are gone.
-2. The shared ``bind_local_device`` is imported and called from ``Engine.__init__``.
-3. The engine no longer contains any private device-binding branch (no direct
+What's checked here:
+
+1. Gate 1.1a helpers stay removed.
+2. Gate 1.1b's shared ``bind_local_device`` is still imported and called from
+   ``Engine.__init__``.
+3. Gate 1.2b: ``create_stream`` / ``set_stream`` from ``device_runtime`` are
+   imported and invoked in ``Engine.__init__``; the raw ``torch.cuda.Stream``
+   / ``torch.cuda.set_stream`` calls are gone from ``__init__``.
+4. ``forward_batch``'s ``torch.cuda.current_stream()`` and
+   ``torch.cuda.Event()`` are *deliberately* preserved with their
+   ``TODO(gate-1.2+)`` markers — a later Gate ports them.
+5. The engine still contains no private device-binding branch (no direct
    ``torch.cuda.set_device`` / ``torch.npu.set_device`` calls, no
    ``import torch_npu`` at module scope).
-4. Gate 1.1a's other Ascend-portability guardrails still hold (no hard-coded
+6. Gate 1.1a's other Ascend-portability guardrails still hold (no hard-coded
    ``backend="nccl"``, ``get_distributed_backend`` still wired in,
    ``get_device_type`` still consulted).
 
-Coverage of ``bind_local_device`` itself (cuda / npu / cpu behaviour, npu
-import failure, CPU no-op) lives in :mod:`tests.misc.test_distributed_runtime`
-where the runtime module is loaded hermetically.
+Coverage of the primitives themselves lives in dedicated hermetic suites
+(``test_distributed_runtime`` for ``bind_local_device``,
+``test_device_runtime`` for ``create_stream`` / ``set_stream`` / ...).
 """
 from __future__ import annotations
 
@@ -41,38 +54,75 @@ def _engine_tree() -> ast.Module:
     return ast.parse(_engine_source())
 
 
+def _engine_init() -> ast.FunctionDef:
+    """Return the ``ast.FunctionDef`` of ``Engine.__init__``."""
+    engine_cls = next(
+        node for node in _engine_tree().body
+        if isinstance(node, ast.ClassDef) and node.name == "Engine"
+    )
+    return next(
+        node for node in engine_cls.body
+        if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+    )
+
+
+def _engine_method(name: str) -> ast.FunctionDef:
+    engine_cls = next(
+        node for node in _engine_tree().body
+        if isinstance(node, ast.ClassDef) and node.name == "Engine"
+    )
+    return next(
+        node for node in engine_cls.body
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    )
+
+
+def _init_source() -> str:
+    return ast.unparse(_engine_init())
+
+
+def _method_raw_source(name: str) -> str:
+    """Return the raw text of a method (including ``# comments``).
+
+    ``ast.unparse`` drops comments, which would hide the deferred-CUDA TODO
+    markers we care about. Slice the source lines by the method's line range
+    instead.
+    """
+    node = _engine_method(name)
+    src_lines = _engine_source().splitlines()
+    # ast line numbers are 1-based inclusive on both ends.
+    return "\n".join(src_lines[node.lineno - 1 : node.end_lineno])
+
+
+def _forward_batch_source() -> str:
+    return _method_raw_source("forward_batch")
+
+
 # ---------------------------------------------------------------------------
-# The two Gate 1.1a helpers have been removed
+# The two Gate 1.1a helpers stay removed
 # ---------------------------------------------------------------------------
 
 
 def test_engine_no_longer_defines_resolve_engine_device() -> None:
     for node in _engine_tree().body:
         if isinstance(node, ast.FunctionDef):
-            assert node.name != "_resolve_engine_device", (
-                "_resolve_engine_device must be removed in Gate 1.1b — "
-                "engine should reuse bind_local_device instead"
-            )
+            assert node.name != "_resolve_engine_device"
 
 
 def test_engine_no_longer_defines_bind_engine_local_device() -> None:
     for node in _engine_tree().body:
         if isinstance(node, ast.FunctionDef):
-            assert node.name != "_bind_engine_local_device", (
-                "_bind_engine_local_device must be removed in Gate 1.1b — "
-                "engine should reuse bind_local_device instead"
-            )
+            assert node.name != "_bind_engine_local_device"
 
 
 def test_engine_has_no_private_device_helpers() -> None:
-    """Neither helper name may appear anywhere in the engine source."""
     src = _engine_source()
     assert "_resolve_engine_device" not in src
     assert "_bind_engine_local_device" not in src
 
 
 # ---------------------------------------------------------------------------
-# Engine imports & calls the shared primitive
+# Gate 1.1b: shared bind_local_device still wired in
 # ---------------------------------------------------------------------------
 
 
@@ -81,22 +131,8 @@ def test_engine_imports_bind_local_device_from_runtime() -> None:
     assert "from minisgl.distributed.runtime import bind_local_device" in src
 
 
-def test_engine_calls_bind_local_device_from_runtime() -> None:
-    """The shared primitive must be invoked in Engine.__init__."""
-    src = _engine_source()
-    assert "bind_local_device(" in src
-
-    # Locate Engine.__init__ and confirm the call happens inside it (not just
-    # in a docstring or comment).
-    tree = _engine_tree()
-    engine_cls = next(
-        node for node in tree.body
-        if isinstance(node, ast.ClassDef) and node.name == "Engine"
-    )
-    init_fn = next(
-        node for node in engine_cls.body
-        if isinstance(node, ast.FunctionDef) and node.name == "__init__"
-    )
+def test_engine_init_calls_bind_local_device() -> None:
+    init_fn = _engine_init()
     calls = [
         n for n in ast.walk(init_fn)
         if isinstance(n, ast.Call) and getattr(n.func, "id", None) == "bind_local_device"
@@ -105,28 +141,136 @@ def test_engine_calls_bind_local_device_from_runtime() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Gate 1.2b: Stream dispatch through device_runtime
+# ---------------------------------------------------------------------------
+
+
+def test_engine_imports_stream_helpers_from_device_runtime() -> None:
+    """Engine.__init__ must source ``create_stream`` + ``set_stream`` from device_runtime."""
+    src = _engine_source()
+    assert "from minisgl.utils.device_runtime import" in src
+    # Both names must be imported. Robust against either "a, b" or "b, a" order.
+    import_line = next(
+        line for line in src.splitlines()
+        if line.startswith("from minisgl.utils.device_runtime import")
+    )
+    assert "create_stream" in import_line
+    assert "set_stream" in import_line
+
+
+def test_engine_init_calls_create_stream_with_device_type() -> None:
+    """``self.stream = create_stream(self.device_type)`` must appear in __init__."""
+    init_fn = _engine_init()
+
+    matched = False
+    for node in ast.walk(init_fn):
+        if not isinstance(node, ast.Call):
+            continue
+        if getattr(node.func, "id", None) != "create_stream":
+            continue
+        # Single positional arg must be ``self.device_type``.
+        assert len(node.args) == 1 and not node.keywords, (
+            "create_stream must be called with exactly one positional arg (self.device_type)"
+        )
+        arg = node.args[0]
+        assert isinstance(arg, ast.Attribute) and arg.attr == "device_type"
+        assert isinstance(arg.value, ast.Name) and arg.value.id == "self"
+        matched = True
+    assert matched, "Engine.__init__ must call create_stream(self.device_type)"
+
+
+def test_engine_init_calls_set_stream_with_device_type_and_self_stream() -> None:
+    """``set_stream(self.device_type, self.stream)`` must appear in __init__."""
+    init_fn = _engine_init()
+
+    matched = False
+    for node in ast.walk(init_fn):
+        if not isinstance(node, ast.Call):
+            continue
+        if getattr(node.func, "id", None) != "set_stream":
+            continue
+        assert len(node.args) == 2 and not node.keywords, (
+            "set_stream must be called with two positional args"
+        )
+        first, second = node.args
+        assert (
+            isinstance(first, ast.Attribute)
+            and first.attr == "device_type"
+            and isinstance(first.value, ast.Name)
+            and first.value.id == "self"
+        )
+        assert (
+            isinstance(second, ast.Attribute)
+            and second.attr == "stream"
+            and isinstance(second.value, ast.Name)
+            and second.value.id == "self"
+        )
+        matched = True
+    assert matched, "Engine.__init__ must call set_stream(self.device_type, self.stream)"
+
+
+def test_engine_init_no_longer_calls_torch_cuda_stream_directly() -> None:
+    """``torch.cuda.Stream(`` must not appear inside Engine.__init__ anymore."""
+    src = _init_source()
+    assert "torch.cuda.Stream" not in src, (
+        "Engine.__init__ must go through device_runtime.create_stream, "
+        "not torch.cuda.Stream directly"
+    )
+
+
+def test_engine_init_no_longer_calls_torch_cuda_set_stream_directly() -> None:
+    """``torch.cuda.set_stream(`` must not appear inside Engine.__init__ anymore."""
+    src = _init_source()
+    assert "torch.cuda.set_stream" not in src, (
+        "Engine.__init__ must go through device_runtime.set_stream, "
+        "not torch.cuda.set_stream directly"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Deliberate leftovers: forward_batch still uses CUDA current_stream + Event
+# ---------------------------------------------------------------------------
+
+
+def test_forward_batch_still_uses_torch_cuda_current_stream() -> None:
+    """Gate 1.2b defers ``current_stream()`` to a later Gate — must stay put."""
+    src = _forward_batch_source()
+    assert "torch.cuda.current_stream" in src
+
+
+def test_forward_batch_still_uses_torch_cuda_event() -> None:
+    """Gate 1.2b defers ``Event`` to a later Gate — must stay put."""
+    src = _forward_batch_source()
+    assert "torch.cuda.Event" in src
+
+
+def test_forward_batch_deferred_cuda_calls_are_annotated_with_todos() -> None:
+    """Each deferred CUDA call in ``forward_batch`` carries a ``TODO(gate-`` marker."""
+    src = _forward_batch_source()
+    assert "TODO(gate-" in src
+
+
+# ---------------------------------------------------------------------------
 # No leftover private device branch inside engine.py
 # ---------------------------------------------------------------------------
 
 
 def test_engine_does_not_call_torch_cuda_set_device_directly() -> None:
-    """The CUDA set_device call now lives inside bind_local_device, not engine.py."""
     src = _engine_source()
     assert "torch.cuda.set_device" not in src
 
 
 def test_engine_does_not_call_torch_npu_set_device_directly() -> None:
-    """The NPU set_device call now lives inside bind_local_device, not engine.py."""
     src = _engine_source()
     assert "torch.npu.set_device" not in src
 
 
 def test_engine_does_not_import_torch_npu_at_any_scope() -> None:
-    """``import torch_npu`` must not appear anywhere in engine.py post-Gate-1.1b."""
     src = _engine_source()
     assert "torch_npu" not in src, (
         "engine.py must not reference torch_npu — the dynamic import lives "
-        "inside minisgl.distributed.runtime.bind_local_device"
+        "inside minisgl.distributed.runtime.bind_local_device and "
+        "minisgl.utils.device_runtime"
     )
 
 
@@ -153,9 +297,7 @@ def test_engine_source_uses_unified_device_type() -> None:
     assert "get_device_type" in src
 
 
-def test_engine_source_marks_deferred_cuda_calls() -> None:
+def test_engine_source_still_marks_remaining_deferred_cuda_calls() -> None:
+    """The Event/memory/graph deferrals still carry ``TODO(gate-1.2+)`` markers."""
     src = _engine_source()
     assert "TODO(gate-1.2+)" in src
-    # The deferred stream/event/graph sites still exist verbatim.
-    assert "torch.cuda.Stream" in src
-    assert "torch.cuda.Event" in src

--- a/tests/misc/test_engine_device.py
+++ b/tests/misc/test_engine_device.py
@@ -581,7 +581,7 @@ def test_sync_get_memory_still_reads_free_memory_and_all_reduces() -> None:
     memory read — this test proves the read still runs afterwards.
     """
     src = _sync_get_memory_source()
-    assert "get_free_memory(self.device)" in src
+    assert "get_free_memory(self.device_type, self.device)" in src
     assert "torch.distributed.all_reduce" in src
     # And the two-int return contract stays put.
     assert "return min_free_memory, max_free_memory" in src
@@ -656,3 +656,234 @@ def test_engine_source_still_marks_remaining_deferred_cuda_calls() -> None:
     """``shutdown``'s CUDA-graph destroy is the last ``TODO(gate-1.2+)`` left."""
     src = _engine_source()
     assert "TODO(gate-1.2+)" in src
+
+
+# ---------------------------------------------------------------------------
+# Gate 1.5c: get_free_memory routes through device_runtime.get_free_memory_bytes
+# ---------------------------------------------------------------------------
+
+
+_GRAPH_PATH = _REPO_ROOT / "python" / "minisgl" / "engine" / "graph.py"
+
+
+def _graph_source() -> str:
+    return _GRAPH_PATH.read_text()
+
+
+def _graph_tree() -> ast.Module:
+    return ast.parse(_graph_source())
+
+
+def _graph_get_free_memory_ast() -> ast.FunctionDef:
+    return next(
+        node for node in _graph_tree().body
+        if isinstance(node, ast.FunctionDef) and node.name == "get_free_memory"
+    )
+
+
+def _graph_imported_names_from(module: str) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(_graph_tree()):
+        if isinstance(node, ast.ImportFrom) and node.module == module:
+            for alias in node.names:
+                names.add(alias.name)
+    return names
+
+
+def test_graph_imports_get_free_memory_bytes_from_device_runtime() -> None:
+    imported = _graph_imported_names_from("minisgl.utils.device_runtime")
+    assert "get_free_memory_bytes" in imported, (
+        "graph.py must import get_free_memory_bytes from minisgl.utils.device_runtime"
+    )
+
+
+def test_graph_imports_device_type_alias() -> None:
+    """The new signature annotates the first arg as ``DeviceType``."""
+    imported = _graph_imported_names_from("minisgl.utils.device")
+    assert "DeviceType" in imported, (
+        "graph.py must import DeviceType from minisgl.utils.device"
+    )
+
+
+def test_graph_get_free_memory_signature_takes_device_type_first() -> None:
+    """``get_free_memory(device_type, device)`` — the exact positional order."""
+    fn = _graph_get_free_memory_ast()
+    arg_names = [a.arg for a in fn.args.args]
+    assert arg_names == ["device_type", "device"], (
+        f"get_free_memory param order is {arg_names!r}, expected "
+        "['device_type', 'device']"
+    )
+    # The first arg must be annotated as ``DeviceType`` (not ``torch.device``).
+    first_ann = fn.args.args[0].annotation
+    assert first_ann is not None, "device_type parameter must be annotated"
+    assert ast.unparse(first_ann) == "DeviceType", (
+        f"device_type annotation is {ast.unparse(first_ann)!r}, expected 'DeviceType'"
+    )
+    # And the return annotation must be ``int``.
+    ret_ann = fn.returns
+    assert ret_ann is not None and ast.unparse(ret_ann) == "int"
+
+
+def test_graph_get_free_memory_delegates_to_get_free_memory_bytes() -> None:
+    """Body must be ``return get_free_memory_bytes(device_type, device)`` — no
+    ``torch.cuda`` call, no reordering, no keyword-only shenanigans.
+    """
+    fn = _graph_get_free_memory_ast()
+    # The function body should be a single return statement.
+    assert len(fn.body) == 1 and isinstance(fn.body[0], ast.Return), (
+        "get_free_memory body must be a single return statement"
+    )
+    call = fn.body[0].value
+    assert isinstance(call, ast.Call), "must return a call"
+    assert getattr(call.func, "id", None) == "get_free_memory_bytes", (
+        "get_free_memory must delegate to get_free_memory_bytes"
+    )
+    assert len(call.args) == 2 and not call.keywords, (
+        "delegate call must forward exactly two positional args"
+    )
+    first, second = call.args
+    assert isinstance(first, ast.Name) and first.id == "device_type"
+    assert isinstance(second, ast.Name) and second.id == "device"
+
+
+def test_graph_no_longer_calls_torch_cuda_mem_get_info() -> None:
+    """The old ``torch.cuda.mem_get_info(...)`` must be gone from graph.py."""
+    src = _graph_source()
+    assert "torch.cuda.mem_get_info" not in src, (
+        "graph.py must go through device_runtime.get_free_memory_bytes, "
+        "not torch.cuda.mem_get_info directly"
+    )
+
+
+def test_graph_runner_still_uses_cuda_graph_apis() -> None:
+    """Gate 1.5c must NOT rip out the CUDA-graph capture / replay calls.
+
+    Those live behind a separate Gate. Assert the well-known symbols still
+    appear in the source so a stray edit that broke capture would be caught.
+    """
+    src = _graph_source()
+    for marker in (
+        "torch.cuda.CUDAGraph",
+        "torch.cuda.graph(",
+        "torch.cuda.synchronize",
+        "torch.cuda.empty_cache",
+        "torch.cuda.reset_peak_memory_stats",
+    ):
+        assert marker in src, (
+            f"graph.py must still call {marker} — Gate 1.5c only touches "
+            "get_free_memory, not CUDA Graph capture"
+        )
+
+
+def test_graph_runner_init_takes_device_type_param() -> None:
+    """GraphRunner.__init__ must accept ``device_type`` so it can forward it to
+    the internal ``get_free_memory`` calls.
+    """
+    runner_cls = next(
+        node for node in _graph_tree().body
+        if isinstance(node, ast.ClassDef) and node.name == "GraphRunner"
+    )
+    init_fn = next(
+        node for node in runner_cls.body
+        if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+    )
+    arg_names = [a.arg for a in init_fn.args.args]
+    assert "device_type" in arg_names, (
+        f"GraphRunner.__init__ params {arg_names!r} must include device_type"
+    )
+
+
+def test_graph_runner_internal_free_memory_calls_use_device_type() -> None:
+    """All ``get_free_memory(...)`` calls inside ``_capture_graphs`` must
+    forward two positional args starting with ``self.device_type``.
+    """
+    runner_cls = next(
+        node for node in _graph_tree().body
+        if isinstance(node, ast.ClassDef) and node.name == "GraphRunner"
+    )
+    capture_fn = next(
+        node for node in runner_cls.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_capture_graphs"
+    )
+    calls = [
+        c for c in ast.walk(capture_fn)
+        if isinstance(c, ast.Call) and getattr(c.func, "id", None) == "get_free_memory"
+    ]
+    assert calls, "_capture_graphs must call get_free_memory"
+    for c in calls:
+        assert len(c.args) == 2 and not c.keywords, (
+            "each get_free_memory call must have two positional args"
+        )
+        first, second = c.args
+        assert (
+            isinstance(first, ast.Attribute)
+            and first.attr == "device_type"
+            and isinstance(first.value, ast.Name)
+            and first.value.id == "self"
+        ), "first arg must be self.device_type"
+        assert (
+            isinstance(second, ast.Attribute)
+            and second.attr == "device"
+            and isinstance(second.value, ast.Name)
+            and second.value.id == "self"
+        ), "second arg must be self.device"
+
+
+def test_engine_get_free_memory_call_forwards_device_type_and_device() -> None:
+    """Engine._sync_get_memory must call ``get_free_memory(self.device_type, self.device)``."""
+    fn = _sync_get_memory_ast()
+    calls = [
+        c for c in ast.walk(fn)
+        if isinstance(c, ast.Call) and getattr(c.func, "id", None) == "get_free_memory"
+    ]
+    assert calls, "_sync_get_memory must call get_free_memory"
+    for c in calls:
+        assert len(c.args) == 2 and not c.keywords, (
+            "get_free_memory must be called with two positional args"
+        )
+        first, second = c.args
+        assert (
+            isinstance(first, ast.Attribute)
+            and first.attr == "device_type"
+            and isinstance(first.value, ast.Name)
+            and first.value.id == "self"
+        )
+        assert (
+            isinstance(second, ast.Attribute)
+            and second.attr == "device"
+            and isinstance(second.value, ast.Name)
+            and second.value.id == "self"
+        )
+
+
+def test_engine_constructs_graph_runner_with_device_type() -> None:
+    """Engine.__init__ must pass ``device_type=self.device_type`` when
+    building the GraphRunner so the internal free-memory calls resolve.
+    """
+    init_fn = _engine_init()
+    calls = [
+        c for c in ast.walk(init_fn)
+        if isinstance(c, ast.Call) and getattr(c.func, "id", None) == "GraphRunner"
+    ]
+    assert len(calls) == 1, "Engine.__init__ must construct exactly one GraphRunner"
+    kw = {k.arg: k.value for k in calls[0].keywords}
+    assert "device_type" in kw, (
+        "GraphRunner(...) call must forward device_type keyword"
+    )
+    val = kw["device_type"]
+    assert (
+        isinstance(val, ast.Attribute)
+        and val.attr == "device_type"
+        and isinstance(val.value, ast.Name)
+        and val.value.id == "self"
+    ), "device_type kwarg must be self.device_type — no implicit inference"
+
+
+def test_engine_source_does_not_implicitly_infer_device_type_from_torch_device() -> None:
+    """Gate 1.5c rule: no ``.type`` attribute lookup on a device to derive
+    device_type — the Engine already holds it explicitly.
+    """
+    src = _engine_source()
+    assert "self.device.type" not in src, (
+        "device_type must be forwarded explicitly, not inferred via self.device.type"
+    )

--- a/tests/misc/test_engine_forward_sampler_atomic.py
+++ b/tests/misc/test_engine_forward_sampler_atomic.py
@@ -1,0 +1,302 @@
+"""Gate 2.3c — atomic sampler commit in ``Engine.forward_batch``.
+
+These tests pin the contract: ``req.complete_one()`` only fires when both
+``model.forward()`` and ``sampler.sample()`` succeeded AND the sampler
+tensor passes a basic shape check. Any failure inside those steps must
+leave ``req.device_len`` / ``req.cached_len`` / ``req.extend_len`` at the
+values they had on entry — and it must do so uniformly for every real
+request in ``batch.reqs`` (batch-level all-or-nothing).
+
+Tests avoid the real Engine constructor (needs weights, CUDA/NPU). They
+build a minimal ``Engine`` shell via ``__new__`` and bolt on:
+  - a ``graph_runner`` whose ``can_use_cuda_graph`` returns False
+  - a ``model`` whose ``forward()`` returns a fixed logits tensor
+  - a ``sampler`` whose behaviour each test controls
+  - a ``ctx`` that just yields on ``forward_batch``
+so ``forward_batch`` runs its own real body.
+
+All requests are real ``Req`` objects — ``complete_one()`` is exercised
+for real. The sentinel tokens returned by the successful sampler feed
+straight into the ``next_tokens_cpu`` copy, which we assert on.
+"""
+from __future__ import annotations
+
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from typing import List
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PYTHON_ROOT = _REPO_ROOT / "python"
+
+
+def _ensure_python_root_on_path() -> None:
+    p = str(_PYTHON_ROOT)
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+
+def _purge_minisgl_from_sys_modules() -> None:
+    for name in list(sys.modules):
+        if name == "minisgl" or name.startswith("minisgl."):
+            del sys.modules[name]
+
+
+# ------------------------------------------------------------------ fixtures
+
+
+@pytest.fixture
+def env():
+    _ensure_python_root_on_path()
+    _purge_minisgl_from_sys_modules()
+
+    import torch
+
+    from minisgl.core import Req, SamplingParams
+    from minisgl.engine.engine import Engine, ForwardOutput
+    from minisgl.engine.sample import BatchSamplingArgs
+    from minisgl.kvcache.naive_cache import NaiveCacheHandle
+
+    return SimpleNamespace(
+        torch=torch,
+        Req=Req,
+        SamplingParams=SamplingParams,
+        Engine=Engine,
+        ForwardOutput=ForwardOutput,
+        BatchSamplingArgs=BatchSamplingArgs,
+        NaiveCacheHandle=NaiveCacheHandle,
+    )
+
+
+def _make_req(env, *, table_idx: int, cached_len: int, device_len: int, uid: int):
+    assert 0 <= cached_len < device_len
+    input_ids = env.torch.zeros(device_len, dtype=env.torch.int32)
+    return env.Req(
+        input_ids=input_ids,
+        table_idx=table_idx,
+        cached_len=cached_len,
+        output_len=8,  # generous so remain_len > 0 always
+        uid=uid,
+        sampling_params=env.SamplingParams(temperature=0.0, max_tokens=1),
+        cache_handle=env.NaiveCacheHandle(),
+    )
+
+
+def _snapshot_reqs(reqs) -> List[dict]:
+    return [
+        {
+            "uid": r.uid,
+            "table_idx": r.table_idx,
+            "cached_len": r.cached_len,
+            "device_len": r.device_len,
+            "extend_len": r.extend_len,
+        }
+        for r in reqs
+    ]
+
+
+def _assert_reqs_unchanged(before: List[dict], reqs) -> None:
+    after = _snapshot_reqs(reqs)
+    assert before == after, f"req state advanced despite sampler failure: {before} -> {after}"
+
+
+# --------------------------------------------------------- engine skeleton
+
+
+def _build_engine_skeleton(env, *, logits_shape, sampler_impl):
+    """Return an Engine shell that exercises the real ``forward_batch`` body."""
+    from minisgl.core import Batch  # noqa: F401  (only imported for clarity)
+
+    engine = env.Engine.__new__(env.Engine)
+    device = env.torch.device("cpu")
+    engine.device = device
+    engine.device_type = "cpu"
+    engine.stream = None  # cpu device_runtime returns None
+
+    logits_tensor = env.torch.zeros(logits_shape, dtype=env.torch.float32, device=device)
+
+    # graph_runner: never uses cuda graph, so `.replay` is never called.
+    engine.graph_runner = SimpleNamespace(can_use_cuda_graph=lambda batch: False)
+
+    # model.forward returns the fixed logits tensor.
+    engine.model = SimpleNamespace(forward=lambda: logits_tensor)
+
+    # sampler.sample: caller-controlled.
+    engine.sampler = SimpleNamespace(sample=sampler_impl)
+
+    # ctx.forward_batch: contextmanager that just yields.
+    @contextmanager
+    def _fake_forward_batch(batch):
+        yield
+
+    engine.ctx = SimpleNamespace(forward_batch=_fake_forward_batch)
+
+    return engine
+
+
+def _run_forward(env, engine, reqs, *, phase="prefill"):
+    from minisgl.core import Batch
+
+    batch = Batch(reqs=list(reqs), phase=phase)
+    batch.padded_reqs = list(reqs)
+    args = env.BatchSamplingArgs(temperatures=None)
+    return engine.forward_batch(batch, args)
+
+
+# =========================================================================
+# A. B=1 sampler failure — req state preserved, original exception propagates.
+# =========================================================================
+
+
+def test_A_b1_sampler_failure_preserves_req_state(env):
+    reqs = [_make_req(env, table_idx=0, cached_len=0, device_len=4, uid=1)]
+    before = _snapshot_reqs(reqs)
+
+    class GateSamplerBoom(Exception):
+        pass
+
+    def _explode(logits, args):
+        raise GateSamplerBoom("gate23c_A: sampler blew up")
+
+    engine = _build_engine_skeleton(
+        env, logits_shape=(1, 16), sampler_impl=_explode
+    )
+
+    with pytest.raises(GateSamplerBoom, match="gate23c_A"):
+        _run_forward(env, engine, reqs)
+
+    _assert_reqs_unchanged(before, reqs)
+
+
+# =========================================================================
+# B. B=2 sampler failure — no partial commit; both reqs unchanged.
+# =========================================================================
+
+
+def test_B_b2_sampler_failure_no_partial_commit(env):
+    reqs = [
+        _make_req(env, table_idx=0, cached_len=0, device_len=4, uid=10),
+        _make_req(env, table_idx=1, cached_len=2, device_len=6, uid=11),
+    ]
+    before = _snapshot_reqs(reqs)
+
+    def _explode(logits, args):
+        raise RuntimeError("gate23c_B: mid-sampler failure")
+
+    engine = _build_engine_skeleton(
+        env, logits_shape=(2, 16), sampler_impl=_explode
+    )
+
+    with pytest.raises(RuntimeError, match="gate23c_B"):
+        _run_forward(env, engine, reqs)
+
+    _assert_reqs_unchanged(before, reqs)
+
+
+# =========================================================================
+# C. Sampler success — each real request advances exactly once.
+# =========================================================================
+
+
+def test_C_sampler_success_each_req_advances_once(env):
+    reqs = [
+        _make_req(env, table_idx=0, cached_len=0, device_len=4, uid=20),
+        _make_req(env, table_idx=1, cached_len=1, device_len=5, uid=21),
+    ]
+    before = _snapshot_reqs(reqs)
+
+    def _ok(logits, args):
+        # Return deterministic sentinel token per row.
+        return env.torch.tensor([42, 43], dtype=env.torch.int64)
+
+    engine = _build_engine_skeleton(env, logits_shape=(2, 16), sampler_impl=_ok)
+    out = _run_forward(env, engine, reqs)
+
+    # Each req: cached_len := old_device_len; device_len := old_device_len + 1.
+    for b, r in zip(before, reqs):
+        assert r.cached_len == b["device_len"], (
+            f"cached_len expected {b['device_len']} got {r.cached_len} for uid={b['uid']}"
+        )
+        assert r.device_len == b["device_len"] + 1, (
+            f"device_len expected {b['device_len'] + 1} got {r.device_len} for uid={b['uid']}"
+        )
+        # extend_len after complete_one is device_len - cached_len == 1.
+        assert r.extend_len == 1
+
+    # Sampler tokens flow through the ForwardOutput untouched (converted to int32).
+    assert out.next_tokens_cpu.dtype == env.torch.int32
+    assert out.next_tokens_cpu.tolist() == [42, 43]
+
+
+# =========================================================================
+# D. Sampler returns wrong batch dim — raise before commit.
+# =========================================================================
+
+
+def test_D_sampler_wrong_shape_no_commit(env):
+    reqs = [
+        _make_req(env, table_idx=0, cached_len=0, device_len=4, uid=30),
+        _make_req(env, table_idx=1, cached_len=0, device_len=4, uid=31),
+    ]
+    before = _snapshot_reqs(reqs)
+
+    def _bad_shape(logits, args):
+        # Only ONE row for a 2-request batch — must be rejected.
+        return env.torch.tensor([99], dtype=env.torch.int64)
+
+    engine = _build_engine_skeleton(
+        env, logits_shape=(2, 16), sampler_impl=_bad_shape
+    )
+
+    with pytest.raises(RuntimeError, match="shape"):
+        _run_forward(env, engine, reqs)
+
+    _assert_reqs_unchanged(before, reqs)
+
+
+# =========================================================================
+# E. padded batch — only real reqs get committed.
+# =========================================================================
+
+
+def test_E_padded_batch_only_real_reqs_commit(env):
+    # Two real reqs, one padded "extra" appended to padded_reqs only.
+    real_reqs = [
+        _make_req(env, table_idx=0, cached_len=0, device_len=4, uid=40),
+        _make_req(env, table_idx=1, cached_len=2, device_len=6, uid=41),
+    ]
+    padding_req = _make_req(env, table_idx=2, cached_len=0, device_len=4, uid=999)
+    before_real = _snapshot_reqs(real_reqs)
+    before_pad = _snapshot_reqs([padding_req])
+
+    def _ok(logits, args):
+        # Sampler operates on logits[:batch.size] which is 2 rows — return 2 tokens.
+        return env.torch.tensor([7, 8], dtype=env.torch.int64)
+
+    from minisgl.core import Batch
+
+    engine = _build_engine_skeleton(
+        env,
+        # Logits shape padded to 3 rows (mimics graph capture pad); slicing by
+        # batch.size restricts sampler input to the real portion.
+        logits_shape=(3, 16),
+        sampler_impl=_ok,
+    )
+
+    batch = Batch(reqs=list(real_reqs), phase="prefill")
+    batch.padded_reqs = list(real_reqs) + [padding_req]
+    args = env.BatchSamplingArgs(temperatures=None)
+    out = engine.forward_batch(batch, args)
+
+    # Real reqs advanced once each.
+    for b, r in zip(before_real, real_reqs):
+        assert r.cached_len == b["device_len"]
+        assert r.device_len == b["device_len"] + 1
+
+    # Padding req untouched — complete_one iterates batch.reqs only.
+    assert _snapshot_reqs([padding_req]) == before_pad
+
+    assert out.next_tokens_cpu.tolist() == [7, 8]

--- a/tests/misc/test_engine_tp1_nodist.py
+++ b/tests/misc/test_engine_tp1_nodist.py
@@ -1,0 +1,361 @@
+"""Gate 1.11a — NPU + TP=1 must skip the torch.distributed bootstrap.
+
+Structural (AST-only) checks. Rationale:
+
+* Constructing an ``Engine`` for real would import the whole model stack, wire
+  up cuda/npu runtimes, and probably crash on hosts without an accelerator.
+  The existing ``test_engine_device.py`` file already established a pure-AST
+  test pattern for the same module, so this file follows the same shape.
+
+* The change is purely a control-flow guard, so a structural check is
+  sufficient — no runtime side-effects to validate here beyond what the
+  hardware smoke on the 910B1 container exercises.
+
+Invariants asserted:
+
+1. ``Engine._init_communication`` opens with an ``if`` block matching
+   ``self.device_type == "npu" and config.tp_info.size == 1`` and that block
+   ``return``s early (``None``) before touching torch.distributed.
+2. The early-return branch does **not** call ``init_process_group``,
+   ``enable_pynccl_distributed``, ``get_distributed_backend``, or ``new_group``
+   — those imports/calls stay reachable only from the fall-through paths.
+3. The CUDA TP=1 path (``config.tp_info.size == 1 or config.use_pynccl``) is
+   preserved verbatim: it still initialises gloo and calls
+   ``enable_pynccl_distributed``.
+4. The accelerator TP>1 path still resolves the backend via
+   ``get_distributed_backend(self.device_type)``.
+5. ``Engine._sync_get_memory`` short-circuits when ``self.tp_cpu_group is
+   None`` — the all_reduce is unreachable from the no-dist fast path.
+6. ``Engine.shutdown`` guards ``torch.distributed.destroy_process_group()``
+   with the same ``self.tp_cpu_group is not None`` check.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ENGINE_PATH = _REPO_ROOT / "python" / "minisgl" / "engine" / "engine.py"
+
+
+def _engine_tree() -> ast.Module:
+    return ast.parse(_ENGINE_PATH.read_text())
+
+
+def _engine_method(name: str) -> ast.FunctionDef:
+    engine_cls = next(
+        node for node in _engine_tree().body
+        if isinstance(node, ast.ClassDef) and node.name == "Engine"
+    )
+    return next(
+        node for node in engine_cls.body
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    )
+
+
+# ---------------------------------------------------------------------------
+# _init_communication: NPU + TP=1 no-op branch
+# ---------------------------------------------------------------------------
+
+
+def _init_comm() -> ast.FunctionDef:
+    return _engine_method("_init_communication")
+
+
+def _is_self_device_type_eq_npu(node: ast.AST) -> bool:
+    """Match ``self.device_type == "npu"``."""
+    if not isinstance(node, ast.Compare):
+        return False
+    if len(node.ops) != 1 or not isinstance(node.ops[0], ast.Eq):
+        return False
+    left = node.left
+    if not (
+        isinstance(left, ast.Attribute)
+        and left.attr == "device_type"
+        and isinstance(left.value, ast.Name)
+        and left.value.id == "self"
+    ):
+        return False
+    right = node.comparators[0]
+    return isinstance(right, ast.Constant) and right.value == "npu"
+
+
+def _is_config_tp_size_eq_1(node: ast.AST) -> bool:
+    """Match ``config.tp_info.size == 1``."""
+    if not isinstance(node, ast.Compare):
+        return False
+    if len(node.ops) != 1 or not isinstance(node.ops[0], ast.Eq):
+        return False
+    left = node.left
+    if not (
+        isinstance(left, ast.Attribute)
+        and left.attr == "size"
+        and isinstance(left.value, ast.Attribute)
+        and left.value.attr == "tp_info"
+        and isinstance(left.value.value, ast.Name)
+        and left.value.value.id == "config"
+    ):
+        return False
+    right = node.comparators[0]
+    return isinstance(right, ast.Constant) and right.value == 1
+
+
+def _find_npu_tp1_guard(fn: ast.FunctionDef) -> ast.If:
+    """Locate the ``if self.device_type == "npu" and config.tp_info.size == 1`` block."""
+    for stmt in fn.body:
+        if isinstance(stmt, ast.If) and isinstance(stmt.test, ast.BoolOp) and isinstance(
+            stmt.test.op, ast.And
+        ):
+            values = stmt.test.values
+            if len(values) == 2 and (
+                (_is_self_device_type_eq_npu(values[0]) and _is_config_tp_size_eq_1(values[1]))
+                or (_is_self_device_type_eq_npu(values[1]) and _is_config_tp_size_eq_1(values[0]))
+            ):
+                return stmt
+    raise AssertionError(
+        "Engine._init_communication must open with an "
+        "`if self.device_type == 'npu' and config.tp_info.size == 1:` guard"
+    )
+
+
+def test_init_communication_has_npu_tp1_early_return_none() -> None:
+    """The NPU+TP=1 guard must be the first non-trivial statement and return None."""
+    fn = _init_comm()
+    guard = _find_npu_tp1_guard(fn)
+    # Body must be exactly `return None` (or bare `return`).
+    assert len(guard.body) == 1, (
+        "NPU+TP=1 guard body must be a single `return` statement"
+    )
+    ret = guard.body[0]
+    assert isinstance(ret, ast.Return), "NPU+TP=1 guard must `return`"
+    # `return None` and bare `return` both acceptable — both signal no group.
+    if ret.value is not None:
+        assert isinstance(ret.value, ast.Constant) and ret.value.value is None, (
+            "NPU+TP=1 guard must return None (no tp_cpu_group)"
+        )
+    # Guard must have no `else` — the CUDA path stays in the outer body.
+    assert guard.orelse == [], (
+        "NPU+TP=1 guard must not use an `else` branch — the CUDA/HCCL paths "
+        "fall through to the outer function body"
+    )
+
+
+def _walk_calls(node: ast.AST) -> list[ast.Call]:
+    return [c for c in ast.walk(node) if isinstance(c, ast.Call)]
+
+
+def _has_call(node: ast.AST, matcher) -> bool:
+    return any(matcher(c) for c in _walk_calls(node))
+
+
+def _is_init_process_group(call: ast.Call) -> bool:
+    f = call.func
+    return (
+        isinstance(f, ast.Attribute)
+        and f.attr == "init_process_group"
+        and isinstance(f.value, ast.Attribute)
+        and f.value.attr == "distributed"
+    )
+
+
+def _is_enable_pynccl(call: ast.Call) -> bool:
+    return isinstance(call.func, ast.Name) and call.func.id == "enable_pynccl_distributed"
+
+
+def _is_get_distributed_backend(call: ast.Call) -> bool:
+    return isinstance(call.func, ast.Name) and call.func.id == "get_distributed_backend"
+
+
+def _is_new_group(call: ast.Call) -> bool:
+    f = call.func
+    return (
+        isinstance(f, ast.Attribute)
+        and f.attr == "new_group"
+        and isinstance(f.value, ast.Attribute)
+        and f.value.attr == "distributed"
+    )
+
+
+def test_npu_tp1_guard_body_has_no_distributed_side_effects() -> None:
+    """The early-return branch must not call any dist init helper."""
+    guard = _find_npu_tp1_guard(_init_comm())
+    for matcher, label in [
+        (_is_init_process_group, "torch.distributed.init_process_group"),
+        (_is_enable_pynccl, "enable_pynccl_distributed"),
+        (_is_get_distributed_backend, "get_distributed_backend"),
+        (_is_new_group, "torch.distributed.new_group"),
+    ]:
+        assert not _has_call(guard, matcher), (
+            f"NPU+TP=1 no-op guard must not call {label}"
+        )
+
+
+def test_init_communication_still_preserves_cuda_pynccl_branch() -> None:
+    """CUDA TP=1 / use_pynccl branch must still call gloo init + pynccl helper."""
+    fn = _init_comm()
+    # Any occurrence anywhere below the guard.
+    assert _has_call(fn, _is_init_process_group), (
+        "torch.distributed.init_process_group must still be called from the CUDA branch"
+    )
+    assert _has_call(fn, _is_enable_pynccl), (
+        "enable_pynccl_distributed must still be called from the CUDA TP=1 branch"
+    )
+    # And the gloo/init_process_group in the pynccl branch keeps backend='gloo'.
+    for call in _walk_calls(fn):
+        if not _is_init_process_group(call):
+            continue
+        kw = {k.arg: k.value for k in call.keywords}
+        assert "backend" in kw, "init_process_group must specify backend explicitly"
+
+
+def test_init_communication_still_uses_get_distributed_backend_for_hccl_path() -> None:
+    """NPU TP>1 (and CUDA TP>1 non-pynccl) still resolves via get_distributed_backend(self.device_type)."""
+    fn = _init_comm()
+    calls = [c for c in _walk_calls(fn) if _is_get_distributed_backend(c)]
+    assert calls, (
+        "Engine._init_communication must still call get_distributed_backend for TP>1"
+    )
+    for c in calls:
+        assert len(c.args) == 1 and not c.keywords, (
+            "get_distributed_backend(...) must take exactly one positional arg"
+        )
+        arg = c.args[0]
+        assert (
+            isinstance(arg, ast.Attribute)
+            and arg.attr == "device_type"
+            and isinstance(arg.value, ast.Name)
+            and arg.value.id == "self"
+        ), "get_distributed_backend must be called with self.device_type"
+
+
+def test_init_communication_return_annotation_is_nullable() -> None:
+    """The signature must advertise ``ProcessGroup | None`` so callers guard on None."""
+    fn = _init_comm()
+    ret = fn.returns
+    assert ret is not None, "Engine._init_communication must declare a return type"
+    # Accept either PEP 604 (X | None) or Optional[X].
+    src = ast.unparse(ret)
+    assert "None" in src, (
+        "return type must include None to signal the NPU+TP=1 no-op contract, "
+        f"got: {src!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# _sync_get_memory: guard the all_reduce when tp_cpu_group is None
+# ---------------------------------------------------------------------------
+
+
+def _is_all_reduce(call: ast.Call) -> bool:
+    f = call.func
+    return (
+        isinstance(f, ast.Attribute)
+        and f.attr == "all_reduce"
+        and isinstance(f.value, ast.Attribute)
+        and f.value.attr == "distributed"
+    )
+
+
+def _is_self_tp_cpu_group_is_none(node: ast.AST) -> bool:
+    """Match ``self.tp_cpu_group is None``."""
+    if not isinstance(node, ast.Compare):
+        return False
+    if len(node.ops) != 1 or not isinstance(node.ops[0], ast.Is):
+        return False
+    left = node.left
+    if not (
+        isinstance(left, ast.Attribute)
+        and left.attr == "tp_cpu_group"
+        and isinstance(left.value, ast.Name)
+        and left.value.id == "self"
+    ):
+        return False
+    right = node.comparators[0]
+    return isinstance(right, ast.Constant) and right.value is None
+
+
+def _is_self_tp_cpu_group_is_not_none(node: ast.AST) -> bool:
+    """Match ``self.tp_cpu_group is not None``."""
+    if not isinstance(node, ast.Compare):
+        return False
+    if len(node.ops) != 1 or not isinstance(node.ops[0], ast.IsNot):
+        return False
+    left = node.left
+    if not (
+        isinstance(left, ast.Attribute)
+        and left.attr == "tp_cpu_group"
+        and isinstance(left.value, ast.Name)
+        and left.value.id == "self"
+    ):
+        return False
+    right = node.comparators[0]
+    return isinstance(right, ast.Constant) and right.value is None
+
+
+def test_sync_get_memory_short_circuits_when_tp_cpu_group_is_none() -> None:
+    """A top-level ``if self.tp_cpu_group is None: return ...`` must guard the all_reduce."""
+    fn = _engine_method("_sync_get_memory")
+    guards = [
+        stmt for stmt in fn.body
+        if isinstance(stmt, ast.If) and _is_self_tp_cpu_group_is_none(stmt.test)
+    ]
+    assert guards, (
+        "_sync_get_memory must guard on `if self.tp_cpu_group is None:` to "
+        "support the NPU+TP=1 no-dist fast path"
+    )
+    guard = guards[0]
+    assert any(isinstance(s, ast.Return) for s in guard.body), (
+        "the tp_cpu_group-None guard body must return before touching all_reduce"
+    )
+    # And this guard must appear before the all_reduce call in source order.
+    all_reduce_calls = [c for c in _walk_calls(fn) if _is_all_reduce(c)]
+    assert all_reduce_calls, "_sync_get_memory must still call all_reduce on the multi-rank path"
+    all_reduce_line = min(c.lineno for c in all_reduce_calls)
+    assert guard.lineno < all_reduce_line, (
+        "the tp_cpu_group-None guard must precede the all_reduce call"
+    )
+
+
+# ---------------------------------------------------------------------------
+# shutdown: also guard destroy_process_group
+# ---------------------------------------------------------------------------
+
+
+def _is_destroy_process_group(call: ast.Call) -> bool:
+    f = call.func
+    return (
+        isinstance(f, ast.Attribute)
+        and f.attr == "destroy_process_group"
+        and isinstance(f.value, ast.Attribute)
+        and f.value.attr == "distributed"
+    )
+
+
+def test_shutdown_guards_destroy_process_group_on_tp_cpu_group() -> None:
+    """shutdown() must not tear down a group that _init_communication skipped."""
+    fn = _engine_method("shutdown")
+    # Find the guard.
+    guard = None
+    for stmt in fn.body:
+        if isinstance(stmt, ast.If) and _is_self_tp_cpu_group_is_not_none(stmt.test):
+            guard = stmt
+            break
+    assert guard is not None, (
+        "shutdown must guard destroy_process_group() behind "
+        "`if self.tp_cpu_group is not None:`"
+    )
+    # Guard body must include destroy_process_group.
+    destroy_calls_in_guard = [c for c in _walk_calls(guard) if _is_destroy_process_group(c)]
+    assert destroy_calls_in_guard, (
+        "destroy_process_group() must live inside the tp_cpu_group-not-None guard"
+    )
+    # No unguarded destroy_process_group at the top level of shutdown.
+    top_level_calls = [
+        stmt.value for stmt in fn.body
+        if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call)
+    ]
+    for call in top_level_calls:
+        assert not _is_destroy_process_group(call), (
+            "destroy_process_group() must not appear unguarded at the top level of shutdown()"
+        )

--- a/tests/misc/test_isolated_import.py
+++ b/tests/misc/test_isolated_import.py
@@ -1,0 +1,228 @@
+"""Gate 0.3a — natural package imports must succeed without CUDA-only deps.
+
+Each import is executed in a fresh Python subprocess with a ``sys.meta_path``
+finder that raises ``ModuleNotFoundError`` for ``flashinfer``, ``sgl_kernel``,
+``quack``, and ``torch_npu``. This guarantees:
+
+1. The subject import truly runs against the real package layout (no
+   ``importlib.util.spec_from_file_location`` bypass, no fake stub packages
+   left in ``sys.modules`` by sibling test files).
+2. Any transitive import of a blocked CUDA-only package surfaces as a hard
+   failure, not a silently-swallowed exception.
+
+Torch and other neutral runtime deps are *not* forcibly available in this
+suite; the test host is expected to be a bare macOS dev box, so the subject
+modules must additionally avoid module-scope ``import torch`` etc. That
+guarantee is implicit in the requirement that they are Ascend-portable.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PY_ROOT = _REPO_ROOT / "python"
+
+
+# The blocker is prepended to every subprocess script. It installs a
+# ``MetaPathFinder`` that raises ``ModuleNotFoundError`` for any import whose
+# top-level package is one of the four Ascend-forbidden CUDA deps. We also
+# prepend ``python/`` to ``sys.path`` so subprocesses find the repo source
+# without an ``pip install -e .``.
+_HEADER = f"""\
+import sys
+sys.path.insert(0, {str(_PY_ROOT)!r})
+
+import importlib.abc
+
+_BLOCKED = {{"flashinfer", "sgl_kernel", "quack", "torch_npu"}}
+
+
+class _Blocker(importlib.abc.MetaPathFinder):
+    def find_spec(self, name, path=None, target=None):
+        top = name.split(".", 1)[0]
+        if top in _BLOCKED:
+            raise ModuleNotFoundError(
+                "Gate 0.3a: blocked CUDA-only dep " + repr(name)
+            )
+        return None
+
+
+sys.meta_path.insert(0, _Blocker())
+"""
+
+
+def _run(body: str, *, timeout: float = 30.0) -> subprocess.CompletedProcess:
+    script = _HEADER + body
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _assert_ok(result: subprocess.CompletedProcess, marker: str) -> None:
+    assert result.returncode == 0, (
+        f"subprocess exited {result.returncode}\n"
+        f"--- STDOUT ---\n{result.stdout}\n"
+        f"--- STDERR ---\n{result.stderr}"
+    )
+    assert marker in result.stdout, (
+        f"expected marker {marker!r} not in stdout\n"
+        f"--- STDOUT ---\n{result.stdout}\n"
+        f"--- STDERR ---\n{result.stderr}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Direct target modules: the three Gate 0.3a targets
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "minisgl.utils.device",
+        "minisgl.distributed.backend",
+        "minisgl.distributed.runtime",
+    ],
+)
+def test_target_module_imports_without_cuda_deps(target: str) -> None:
+    result = _run(f"import {target}\nprint('OK:{target}')\n")
+    _assert_ok(result, f"OK:{target}")
+
+
+# ---------------------------------------------------------------------------
+# 2. Package __init__ itself must be safe (lazy)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("pkg", ["minisgl.utils", "minisgl.distributed"])
+def test_package_init_does_not_pull_cuda_deps(pkg: str) -> None:
+    """``import minisgl.utils`` alone must not load flashinfer/sgl_kernel/quack/torch_npu."""
+    body = (
+        f"import {pkg}\n"
+        # ``sys.modules`` must not contain any blocked package after init.
+        "import sys\n"
+        "leaked = sorted(m for m in sys.modules if m.split('.', 1)[0] in "
+        "{'flashinfer', 'sgl_kernel', 'quack', 'torch_npu'})\n"
+        "assert leaked == [], f'leaked CUDA deps: {leaked!r}'\n"
+        f"print('OK:{pkg}')\n"
+    )
+    result = _run(body)
+    _assert_ok(result, f"OK:{pkg}")
+
+
+# ---------------------------------------------------------------------------
+# 3. Backward compatibility of public symbols (PEP 562 lazy resolution)
+# ---------------------------------------------------------------------------
+
+
+def test_utils_lazy_public_symbols_resolve() -> None:
+    """``from minisgl.utils import <name>`` still returns the same callables."""
+    body = (
+        "from minisgl.utils import call_if_main, div_ceil, Registry\n"
+        "assert callable(call_if_main)\n"
+        "assert callable(div_ceil)\n"
+        "assert Registry.__name__ == 'Registry'\n"
+        # __dir__ must advertise the lazy names.
+        "import minisgl.utils as u\n"
+        "d = dir(u)\n"
+        "assert 'init_logger' in d and 'Registry' in d and 'div_ceil' in d\n"
+        "print('OK:utils-lazy')\n"
+    )
+    result = _run(body)
+    _assert_ok(result, "OK:utils-lazy")
+
+
+def test_utils_unknown_attribute_still_raises_attribute_error() -> None:
+    """Lazy ``__getattr__`` must not mask typos."""
+    body = (
+        "import minisgl.utils\n"
+        "try:\n"
+        "    minisgl.utils.definitely_not_a_symbol\n"
+        "except AttributeError as exc:\n"
+        "    print('OK:attrerror:' + str(exc))\n"
+        "else:\n"
+        "    print('FAIL')\n"
+    )
+    result = _run(body)
+    _assert_ok(result, "OK:attrerror")
+
+
+def test_distributed_dir_advertises_lazy_names() -> None:
+    body = (
+        "import minisgl.distributed as d\n"
+        "names = dir(d)\n"
+        "for expected in ('DistributedInfo', 'get_tp_info', 'DistributedCommunicator',\n"
+        "                 'enable_pynccl_distributed', 'destroy_distributed'):\n"
+        "    assert expected in names, expected\n"
+        "print('OK:distributed-dir')\n"
+    )
+    result = _run(body)
+    _assert_ok(result, "OK:distributed-dir")
+
+
+# ---------------------------------------------------------------------------
+# 4. arch.py naturally imports and returns False on non-CUDA hosts
+# ---------------------------------------------------------------------------
+
+
+def test_arch_runs_under_natural_import() -> None:
+    """``arch.is_sm90_supported()`` uses the device layer, must return False cleanly."""
+    body = (
+        "import minisgl.utils.arch as arch\n"
+        # CUDA is not available on this host; the delegate must return False
+        # without raising, and without importing any blocked CUDA package.
+        "assert arch.is_sm90_supported() is False\n"
+        "assert arch.is_sm100_supported() is False\n"
+        "import sys\n"
+        "leaked = sorted(m for m in sys.modules if m.split('.', 1)[0] in "
+        "{'flashinfer', 'sgl_kernel', 'quack', 'torch_npu'})\n"
+        "assert leaked == [], f'leaked CUDA deps: {leaked!r}'\n"
+        "print('OK:arch')\n"
+    )
+    result = _run(body)
+    _assert_ok(result, "OK:arch")
+
+
+# ---------------------------------------------------------------------------
+# 5. Runtime module still refuses to import ``torch_npu`` at module scope
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_module_scope_does_not_import_torch_npu() -> None:
+    body = (
+        "import minisgl.distributed.runtime  # noqa: F401\n"
+        "import sys\n"
+        "assert 'torch_npu' not in sys.modules, sorted(sys.modules)\n"
+        "print('OK:runtime-clean')\n"
+    )
+    result = _run(body)
+    _assert_ok(result, "OK:runtime-clean")
+
+
+# ---------------------------------------------------------------------------
+# 6. Sanity: the blocker really does block direct imports
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("blocked", ["flashinfer", "sgl_kernel", "quack", "torch_npu"])
+def test_blocker_actually_blocks_direct_import(blocked: str) -> None:
+    body = (
+        f"try:\n"
+        f"    import {blocked}\n"
+        f"except ModuleNotFoundError as exc:\n"
+        f"    if 'Gate 0.3a' in str(exc):\n"
+        f"        print('OK:blocked:{blocked}')\n"
+        f"    else:\n"
+        f"        print('FAIL:unexpected:' + str(exc))\n"
+        f"else:\n"
+        f"    print('FAIL:import-succeeded')\n"
+    )
+    result = _run(body)
+    _assert_ok(result, f"OK:blocked:{blocked}")

--- a/tests/misc/test_pyproject_config.py
+++ b/tests/misc/test_pyproject_config.py
@@ -24,9 +24,20 @@ _PYPROJECT = _REPO_ROOT / "pyproject.toml"
 _CUDA_ONLY = frozenset(
     {
         "flashinfer-python",
-        "apache-tvm-ffi",
         "sgl_kernel",
         "quack-kernels",
+    }
+)
+
+# Dependencies that MUST live in the base ``[project].dependencies`` because
+# they are exercised on every supported device (CUDA, Ascend NPU, CPU).
+# ``apache-tvm-ffi`` drives the AOT-compiled CPU helpers under
+# ``minisgl.kernel`` (notably ``fast_compare_key`` invoked by the radix
+# prefix cache on every prefill scheduling call), so it cannot be a
+# device-specific extra.
+_BASE_REQUIRED = frozenset(
+    {
+        "apache-tvm-ffi",
     }
 )
 
@@ -96,6 +107,43 @@ def test_cuda_extra_holds_only_the_four_cuda_wheels(extras: dict[str, list[str]]
     assert cuda_names == {name.lower() for name in _CUDA_ONLY}, (
         f"cuda extra membership drifted: expected {sorted(_CUDA_ONLY)}, "
         f"got {sorted(cuda_names)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2b. Cross-device required deps must live in the base dependency list, not
+#     only in the cuda extra — Gate 2.1g fix for Ascend Radix reuse.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dep", sorted(_BASE_REQUIRED))
+def test_cross_device_required_dep_is_in_base_dependencies(
+    base_deps: set[str], dep: str
+) -> None:
+    assert dep.lower() in base_deps, (
+        f"{dep!r} must appear in [project].dependencies so that clean "
+        f"Ascend installs receive it — it is required by kernel.radix "
+        f"which underpins RadixPrefixCache on every device"
+    )
+
+
+@pytest.mark.parametrize("dep", sorted(_BASE_REQUIRED))
+def test_cross_device_required_dep_not_only_in_cuda_extra(
+    extras: dict[str, list[str]], dep: str
+) -> None:
+    cuda_names = {_pkg_name(r) for r in extras.get("cuda", [])}
+    assert dep.lower() not in cuda_names, (
+        f"{dep!r} must not live in the 'cuda' extra — it is a cross-device "
+        f"requirement and belongs in the base dependency list. Duplicating "
+        f"it in the cuda extra creates an invisible declaration split."
+    )
+
+
+def test_apache_tvm_ffi_pin_preserved(project_table: dict) -> None:
+    """The declared floor (>=0.1.4) matches the smoke-tested wheel."""
+    reqs = [r for r in project_table["dependencies"] if _pkg_name(r) == "apache-tvm-ffi"]
+    assert reqs == ["apache-tvm-ffi>=0.1.4"], (
+        f"apache-tvm-ffi requirement changed unexpectedly: {reqs!r}"
     )
 
 

--- a/tests/misc/test_pyproject_config.py
+++ b/tests/misc/test_pyproject_config.py
@@ -1,0 +1,152 @@
+"""Static checks over ``pyproject.toml`` — Gate 0.3b.
+
+These tests do not install anything, do not touch ``uv.lock``, and do not
+execute any project code. They parse ``pyproject.toml`` with the stdlib
+``tomllib`` and assert that CUDA-only wheels have been moved out of the
+base ``[project].dependencies`` array and into a ``cuda`` extra.
+
+Dependency names are compared after stripping the version specifier so the
+tests remain robust to routine pin bumps (``flashinfer-python>=0.6``,
+``sgl_kernel>=0.4``, ...).
+"""
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+
+# CUDA-only PyPI distributions that must be extras, not base runtime deps.
+_CUDA_ONLY = frozenset(
+    {
+        "flashinfer-python",
+        "apache-tvm-ffi",
+        "sgl_kernel",
+        "quack-kernels",
+    }
+)
+
+# PEP 508 requirement string → distribution name (very small subset: we only
+# need to strip the version specifier / extras / env markers on the trailing
+# side; this is not a full parser but is sufficient for the entries we own).
+_NAME_SPLIT = re.compile(r"[\s<>=!~;\[]")
+
+
+def _pkg_name(requirement: str) -> str:
+    return _NAME_SPLIT.split(requirement.strip(), 1)[0].lower()
+
+
+@pytest.fixture(scope="module")
+def project_table() -> dict:
+    with _PYPROJECT.open("rb") as fh:
+        data = tomllib.load(fh)
+    return data["project"]
+
+
+@pytest.fixture(scope="module")
+def base_deps(project_table: dict) -> set[str]:
+    return {_pkg_name(r) for r in project_table["dependencies"]}
+
+
+@pytest.fixture(scope="module")
+def extras(project_table: dict) -> dict[str, list[str]]:
+    return project_table["optional-dependencies"]
+
+
+# ---------------------------------------------------------------------------
+# 1. CUDA-only deps must not appear in the base runtime list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dep", sorted(_CUDA_ONLY))
+def test_cuda_only_dep_is_not_in_base_dependencies(base_deps: set[str], dep: str) -> None:
+    assert dep.lower() not in base_deps, (
+        f"{dep!r} must not appear in [project].dependencies; move it into the "
+        f"'cuda' optional-dependencies extra"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. All four CUDA deps must live in the `cuda` extra
+# ---------------------------------------------------------------------------
+
+
+def test_cuda_extra_exists(extras: dict[str, list[str]]) -> None:
+    assert "cuda" in extras, (
+        "[project.optional-dependencies].cuda must exist and hold the CUDA-only wheels"
+    )
+
+
+@pytest.mark.parametrize("dep", sorted(_CUDA_ONLY))
+def test_cuda_extra_contains_dep(extras: dict[str, list[str]], dep: str) -> None:
+    cuda_names = {_pkg_name(r) for r in extras["cuda"]}
+    assert dep.lower() in cuda_names, (
+        f"{dep!r} missing from the 'cuda' extra; current members: "
+        f"{sorted(cuda_names)}"
+    )
+
+
+def test_cuda_extra_holds_only_the_four_cuda_wheels(extras: dict[str, list[str]]) -> None:
+    """The extra should not silently grow other packages under this Gate."""
+    cuda_names = {_pkg_name(r) for r in extras["cuda"]}
+    assert cuda_names == {name.lower() for name in _CUDA_ONLY}, (
+        f"cuda extra membership drifted: expected {sorted(_CUDA_ONLY)}, "
+        f"got {sorted(cuda_names)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. `dev` extra is preserved
+# ---------------------------------------------------------------------------
+
+
+def test_dev_extra_is_preserved(extras: dict[str, list[str]]) -> None:
+    assert "dev" in extras, "the existing 'dev' extra must not be removed"
+    dev_names = {_pkg_name(r) for r in extras["dev"]}
+    # Spot check a couple of well-known dev tools rather than pinning the full
+    # list — this keeps the assertion useful without turning it into a rubber
+    # stamp for future dev-extra edits.
+    assert "pytest" in dev_names
+    assert "ruff" in dev_names
+
+
+# ---------------------------------------------------------------------------
+# 4. Torch stays a base dependency
+# ---------------------------------------------------------------------------
+
+
+def test_torch_still_in_base_dependencies(
+    project_table: dict, base_deps: set[str]
+) -> None:
+    assert "torch" in base_deps, (
+        "'torch' must remain in the base [project].dependencies for Gate 0.3b"
+    )
+    # Pin range preserved verbatim — no accidental widening.
+    torch_reqs = [r for r in project_table["dependencies"] if _pkg_name(r) == "torch"]
+    assert torch_reqs == ["torch<2.10.0"], (
+        f"torch requirement changed unexpectedly: {torch_reqs!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. torch_npu must NOT be auto-added anywhere
+# ---------------------------------------------------------------------------
+
+
+def test_torch_npu_is_not_declared_anywhere(
+    project_table: dict, extras: dict[str, list[str]]
+) -> None:
+    def scan(reqs: list[str]) -> list[str]:
+        return [r for r in reqs if _pkg_name(r) in {"torch_npu", "torch-npu"}]
+
+    assert scan(project_table["dependencies"]) == [], (
+        "torch_npu must not be introduced in base dependencies during Gate 0.3b"
+    )
+    for extra_name, reqs in extras.items():
+        assert scan(reqs) == [], (
+            f"torch_npu unexpectedly declared in the {extra_name!r} extra"
+        )

--- a/tests/misc/test_sampler_no_cuda_nvtx.py
+++ b/tests/misc/test_sampler_no_cuda_nvtx.py
@@ -1,0 +1,155 @@
+"""Gate 1.11d — Sampler.sample() must not touch torch.cuda.nvtx on non-CUDA hosts.
+
+Structural + behavioural checks. Rationale:
+
+* On the Ascend container the installed torch build has no CUDA/NVTX; the raw
+  ``with torch.cuda.nvtx.range("Sampler"):`` used to raise
+  ``RuntimeError: NVTX functions not installed.`` from inside the sampler.
+* The outer ``@nvtx_annotate("Sampler")`` decorator (see
+  ``minisgl/utils/torch_utils.py``) already guards on
+  ``torch.cuda.is_available()`` and only imports ``torch.cuda.nvtx`` on CUDA,
+  so the inline context manager was redundant and unsafe.
+
+Invariants asserted:
+
+1. ``engine/sample.py`` no longer contains any ``torch.cuda.nvtx`` reference.
+2. ``Sampler.sample`` in greedy mode (``args.temperatures is None``) returns
+   ``torch.argmax(logits, dim=-1)`` — bit-exact — even when
+   ``torch.cuda`` is monkey-patched to make any nvtx attribute access blow up.
+3. A grep across ``python/minisgl`` finds no unguarded
+   ``torch.cuda.nvtx.range`` outside the already-guarded ``nvtx_annotate``
+   helper in ``utils/torch_utils.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SAMPLE_PATH = _REPO_ROOT / "python" / "minisgl" / "engine" / "sample.py"
+_MINISGL_ROOT = _REPO_ROOT / "python" / "minisgl"
+
+
+# ---------------------------------------------------------------------------
+# 1. Structural: sample.py must not reference torch.cuda.nvtx anywhere.
+# ---------------------------------------------------------------------------
+
+
+def test_sample_module_has_no_torch_cuda_nvtx_reference() -> None:
+    src = _SAMPLE_PATH.read_text()
+    code_lines = []
+    for line in src.splitlines():
+        # Ignore comments; the fix note may mention torch.cuda.nvtx in prose.
+        stripped = line.split("#", 1)[0]
+        code_lines.append(stripped)
+    code_only = "\n".join(code_lines)
+    assert "torch.cuda.nvtx" not in code_only, (
+        "engine/sample.py must not contain any executable torch.cuda.nvtx "
+        "reference — the outer @nvtx_annotate decorator handles NVTX safely"
+    )
+
+
+def test_sample_method_body_is_flat_and_uses_argmax_for_greedy() -> None:
+    """Sampler.sample body: no `with` statement, greedy branch is argmax."""
+    tree = ast.parse(_SAMPLE_PATH.read_text())
+    sampler_cls = next(
+        n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "Sampler"
+    )
+    sample_fn = next(
+        n for n in sampler_cls.body
+        if isinstance(n, ast.FunctionDef) and n.name == "sample"
+    )
+    # No `with` block should remain in the body — the inline NVTX context is gone.
+    with_stmts = [n for n in ast.walk(sample_fn) if isinstance(n, ast.With)]
+    assert not with_stmts, (
+        "Sampler.sample must not open a `with` block — the inline "
+        "`torch.cuda.nvtx.range(...)` context is what breaks non-CUDA builds"
+    )
+    # Greedy branch must still be an argmax call.
+    argmax_calls = [
+        c for c in ast.walk(sample_fn)
+        if isinstance(c, ast.Call)
+        and isinstance(c.func, ast.Attribute)
+        and c.func.attr == "argmax"
+    ]
+    assert argmax_calls, "Sampler.sample greedy branch must call torch.argmax"
+
+
+# ---------------------------------------------------------------------------
+# 2. Behavioural: greedy Sampler.sample must not touch torch.cuda.nvtx.
+# ---------------------------------------------------------------------------
+
+
+class _ExplodingNVTX:
+    """Any attribute access explodes — proves Sampler.sample never enters here."""
+
+    def __getattr__(self, name):
+        raise AssertionError(
+            f"Sampler.sample must NOT access torch.cuda.nvtx.{name} — "
+            "the inline NVTX context should be gone"
+        )
+
+
+def test_sampler_greedy_does_not_touch_cuda_nvtx(monkeypatch) -> None:
+    from minisgl.engine.sample import BatchSamplingArgs, Sampler
+
+    # Force the nvtx_annotate short-circuit: pretend CUDA is unavailable.
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    # And booby-trap the nvtx submodule for good measure — any access is a fail.
+    monkeypatch.setattr(torch.cuda, "nvtx", _ExplodingNVTX(), raising=False)
+
+    sampler = Sampler(device=torch.device("cpu"), vocab_size=8)
+    logits = torch.tensor(
+        [
+            [0.1, 0.2, 0.9, 0.3, 0.4, 0.5, 0.6, 0.7],
+            [5.0, 4.0, 3.0, 2.0, 1.0, 0.0, -1.0, -2.0],
+        ],
+        dtype=torch.float32,
+    )
+    args = BatchSamplingArgs(temperatures=None)
+
+    out = sampler.sample(logits, args)
+
+    expected = torch.argmax(logits, dim=-1)
+    assert out.shape == expected.shape
+    assert out.dtype == expected.dtype
+    assert torch.equal(out, expected), (
+        f"greedy Sampler.sample must equal torch.argmax(logits, dim=-1); "
+        f"got {out.tolist()} vs {expected.tolist()}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Repo-wide scan: no other unguarded torch.cuda.nvtx.range.
+# ---------------------------------------------------------------------------
+
+
+_NVTX_RANGE_RE = re.compile(r"torch\.cuda\.nvtx\.range\b")
+
+
+def test_no_unguarded_torch_cuda_nvtx_range_in_minisgl() -> None:
+    """The only remaining torch.cuda.nvtx reference must live in the guarded
+    nvtx_annotate helper (utils/torch_utils.py), which already checks
+    torch.cuda.is_available() before importing torch.cuda.nvtx."""
+    hits: list[tuple[Path, int, str]] = []
+    for path in _MINISGL_ROOT.rglob("*.py"):
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            code = line.split("#", 1)[0]
+            if _NVTX_RANGE_RE.search(code):
+                hits.append((path, lineno, line))
+
+    # Filter out the acknowledged, guarded call site.
+    unguarded = [
+        (p, ln, line) for (p, ln, line) in hits
+        if p != _MINISGL_ROOT / "utils" / "torch_utils.py"
+    ]
+    assert not unguarded, (
+        "found unguarded torch.cuda.nvtx.range outside the guarded "
+        f"nvtx_annotate helper: {unguarded}"
+    )

--- a/tests/misc/test_sampling_params_stop_tokens.py
+++ b/tests/misc/test_sampling_params_stop_tokens.py
@@ -1,0 +1,76 @@
+"""Gate 2.1c — SamplingParams.stop_token_ids field contract.
+
+Pure-Python tests that never touch torch NPU / CUDA runtime, so they run on
+any host in the pytest sweep. The invariants asserted here are the
+dataclass-level guarantees the scheduler-side check relies on.
+"""
+from __future__ import annotations
+
+import dataclasses
+
+from minisgl.core import SamplingParams
+
+
+def _sp_field(name: str) -> dataclasses.Field:
+    return next(f for f in dataclasses.fields(SamplingParams) if f.name == name)
+
+
+def test_stop_token_ids_field_declared() -> None:
+    field_names = {f.name for f in dataclasses.fields(SamplingParams)}
+    assert "stop_token_ids" in field_names, (
+        "SamplingParams must declare a `stop_token_ids` field for Gate 2.1c"
+    )
+
+
+def test_stop_token_ids_default_is_empty_tuple() -> None:
+    """Default MUST be the empty tuple — an immutable, safe-to-share sentinel."""
+    field = _sp_field("stop_token_ids")
+    # A mutable default (list) would be shared across instances and could not
+    # even be declared without `field(default_factory=...)`. Assert the safe
+    # tuple default is used.
+    assert field.default == ()
+    assert isinstance(field.default, tuple)
+    # And there must be no default_factory (that would signal a mutable
+    # workaround for a list default).
+    assert field.default_factory is dataclasses.MISSING
+
+
+def test_default_sampling_params_has_empty_stop_tokens() -> None:
+    sp = SamplingParams()
+    assert sp.stop_token_ids == ()
+    assert isinstance(sp.stop_token_ids, tuple)
+
+
+def test_two_default_instances_share_empty_tuple_by_identity() -> None:
+    """The empty tuple is a Python singleton — sharing is safe because tuples
+    are immutable. This test documents the property so a future contributor
+    who accidentally switches to `list` will fail here."""
+    sp1 = SamplingParams()
+    sp2 = SamplingParams()
+    assert sp1.stop_token_ids is sp2.stop_token_ids
+
+
+def test_stop_token_ids_accepts_explicit_tuple() -> None:
+    sp = SamplingParams(stop_token_ids=(11, 42))
+    assert sp.stop_token_ids == (11, 42)
+    assert 11 in sp.stop_token_ids
+    assert 42 in sp.stop_token_ids
+    assert 12 not in sp.stop_token_ids
+
+
+def test_stop_token_ids_is_orthogonal_to_greedy() -> None:
+    """Adding stop_token_ids must not perturb the greedy classifier."""
+    sp = SamplingParams(stop_token_ids=(11,))
+    assert sp.is_greedy is True
+    sp2 = SamplingParams(temperature=0.7, stop_token_ids=(11,))
+    assert sp2.is_greedy is False
+
+
+def test_field_order_preserves_backward_kwargs() -> None:
+    """Pre-Gate-2.1c positional users constructed SamplingParams with up to
+    five positional args (temperature, top_k, top_p, ignore_eos, max_tokens).
+    stop_token_ids must therefore appear AFTER those five to preserve the
+    positional-argument contract."""
+    fields = [f.name for f in dataclasses.fields(SamplingParams)]
+    assert fields.index("stop_token_ids") > fields.index("max_tokens")
+    assert fields.index("stop_token_ids") > fields.index("ignore_eos")

--- a/tests/misc/test_scheduler_abort_ack.py
+++ b/tests/misc/test_scheduler_abort_ack.py
@@ -1,0 +1,512 @@
+"""Gate 2.3f — end-to-end abort acknowledgement.
+
+Exercises the ack state machine across three seams:
+
+  * Scheduler side (``_process_one_msg``, ``_apply_deferred_aborts``,
+    ``_flush_pending_acks``) — using the same ``__new__`` skeleton as
+    Gate 2.3e so the tests are fast and pure-CPU.
+  * Tokenizer worker side — the isinstance-based dispatch that forwards
+    ``AbortAckMsg`` (backend-facing) as ``AbortAckReply`` (frontend-facing).
+  * Frontend ``FrontendManager.listen`` state machine — abort-pending
+    membership gates whether late ``UserReply`` messages surface.
+
+Scenario coverage:
+  A. Waiting-req (PendingReq only) abort → no free, one ack.
+  B. Running non-inflight abort → one free, one ack, emitted after the
+     free.
+  C. Overlap deferred abort → free happens inside _apply_deferred_aborts,
+     ack is emitted only from _flush_pending_acks (after the apply).
+  D. Unknown uid abort → no free, still exactly one idempotent ack.
+  E. Duplicate abort for a deferred uid → one free, one ack.
+  F. Frontend abort-pending: a UserReply arriving for a uid still in
+     ``abort_pending`` is dropped; the AbortAckReply cleans state and
+     unblocks the ack event.
+  G. Natural finish (finished=True) → normal UserReply flow unchanged,
+     no AbortAckReply produced, no abort_pending bookkeeping touched.
+  H. Tokenizer forwarding: an AbortAckMsg received on the scheduler-in
+     channel is dispatched to send_frontend as an AbortAckReply carrying
+     the same uid.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PYTHON_ROOT = _REPO_ROOT / "python"
+
+
+def _ensure_python_root_on_path() -> None:
+    p = str(_PYTHON_ROOT)
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+
+def _purge_minisgl_from_sys_modules() -> None:
+    for name in list(sys.modules):
+        if name == "minisgl" or name.startswith("minisgl."):
+            del sys.modules[name]
+
+
+# --------------------------------------------------------------------- fixtures
+
+
+@pytest.fixture
+def sched_env():
+    _ensure_python_root_on_path()
+    _purge_minisgl_from_sys_modules()
+
+    import types
+
+    import torch
+
+    from minisgl.core import Batch, Req, SamplingParams
+    from minisgl.distributed.info import set_tp_info, try_get_tp_info
+    from minisgl.kvcache.naive_cache import NaiveCacheHandle
+    from minisgl.message import AbortAckMsg, AbortBackendMsg, DetokenizeMsg
+    from minisgl.scheduler.cache import CacheManager
+    from minisgl.scheduler.decode import DecodeManager
+    from minisgl.scheduler.prefill import ChunkedReq, PrefillManager
+    from minisgl.scheduler.scheduler import Scheduler
+    from minisgl.scheduler.table import TableManager
+
+    if try_get_tp_info() is None:
+        set_tp_info(0, 1)
+
+    page_size = 4
+    num_pages = 8
+    max_running = 4
+    page_table = torch.zeros((max_running, num_pages * page_size), dtype=torch.int32)
+
+    tm = TableManager(max_running, page_table)
+    cm = CacheManager(num_pages, page_size, page_table, type="naive")
+    dm = DecodeManager(page_size)
+    pm = PrefillManager(cache_manager=cm, table_manager=tm, decode_manager=dm)
+
+    sched = Scheduler.__new__(Scheduler)
+    sched.cache_manager = cm
+    sched.table_manager = tm
+    sched.decode_manager = dm
+    sched.prefill_manager = pm
+    sched.finished_reqs = set()
+    sched.inflight_uids = set()
+    sched.deferred_abort_uids = set()
+    sched._pending_abort_acks = []
+    sched.eos_token_id = -1
+
+    # send_result spy: capture everything so tests can split UserReply-shaped
+    # DetokenizeMsg vs AbortAckMsg by isinstance.
+    replies: List = []
+    sched.send_result = lambda batch: replies.extend(batch)
+
+    free_calls: List = []
+    real_free = Scheduler._free_req_resources
+
+    def _spy_free(self, req):
+        free_calls.append(req)
+        return real_free(self, req)
+
+    sched._free_req_resources = types.MethodType(_spy_free, sched)
+
+    return {
+        "torch": torch,
+        "sched": sched,
+        "cm": cm,
+        "tm": tm,
+        "dm": dm,
+        "pm": pm,
+        "page_table": page_table,
+        "page_size": page_size,
+        "num_pages": num_pages,
+        "Req": Req,
+        "ChunkedReq": ChunkedReq,
+        "Batch": Batch,
+        "SamplingParams": SamplingParams,
+        "NaiveCacheHandle": NaiveCacheHandle,
+        "AbortAckMsg": AbortAckMsg,
+        "AbortBackendMsg": AbortBackendMsg,
+        "DetokenizeMsg": DetokenizeMsg,
+        "replies": replies,
+        "free_calls": free_calls,
+    }
+
+
+def _make_req(env, *, cls, cached_len: int, device_len: int, uid: int, output_len: int = 8):
+    tm = env["tm"]
+    cm = env["cm"]
+    table_idx = tm.allocate()
+    reqs = [
+        cls(
+            input_ids=env["torch"].zeros(device_len, dtype=env["torch"].int32),
+            table_idx=table_idx,
+            cached_len=cached_len,
+            output_len=output_len,
+            uid=uid,
+            sampling_params=env["SamplingParams"](
+                temperature=0.0, max_tokens=output_len, ignore_eos=True
+            ),
+            cache_handle=env["NaiveCacheHandle"](),
+        )
+    ]
+    cm.allocate_paged(reqs)
+    return reqs[0]
+
+
+def _make_forward_data(env, batch, next_tokens: List[int]):
+    class _FI:
+        pass
+
+    fi = _FI()
+    fi.batch = batch
+    copy_done = MagicMock()
+    next_tokens_cpu = env["torch"].tensor(next_tokens, dtype=env["torch"].int32)
+    fo = (None, next_tokens_cpu, copy_done)
+    return (fi, fo)
+
+
+def _acks_of(env):
+    return [m for m in env["replies"] if isinstance(m, env["AbortAckMsg"])]
+
+
+def _detoks_of(env):
+    return [m for m in env["replies"] if isinstance(m, env["DetokenizeMsg"])]
+
+
+# =========================================================================
+# A. Waiting-req abort (pending only, no running Req) → no free, one ack.
+# =========================================================================
+
+
+def test_A_waiting_abort_no_resources_one_ack(sched_env):
+    env = sched_env
+    sched = env["sched"]
+
+    # Fake a PendingReq entry with .chunked_req = None: nothing to free.
+    pending_stub = MagicMock()
+    pending_stub.chunked_req = None
+    pending_stub.user_id = 900
+    env["pm"].pending_list.append(pending_stub)
+
+    # No inflight → non-inflight branch. prefill_manager.abort_req removes
+    # the pending entry and returns None (no Req built yet).
+    sched._process_one_msg(env["AbortBackendMsg"](uid=900))
+    sched._flush_pending_acks()
+
+    assert env["free_calls"] == [], "no Req was ever built; nothing to free"
+    acks = _acks_of(env)
+    assert [a.uid for a in acks] == [900]
+    assert _detoks_of(env) == []
+
+
+# =========================================================================
+# B. Running non-inflight abort → free happens BEFORE ack, both exactly once.
+# =========================================================================
+
+
+def test_B_running_non_inflight_free_then_ack(sched_env):
+    env = sched_env
+    sched = env["sched"]
+
+    r = _make_req(env, cls=env["Req"], cached_len=0, device_len=5, uid=910)
+    env["dm"].running_reqs.add(r)
+
+    # normal_loop invariant: inflight_uids empty.
+    sched._process_one_msg(env["AbortBackendMsg"](uid=910))
+
+    # Free happens in _process_one_msg. Ack is queued but NOT yet on the
+    # wire — _flush_pending_acks does that at loop tail.
+    assert [rq.uid for rq in env["free_calls"]] == [910]
+    assert env["replies"] == []
+    assert sched._pending_abort_acks == [910]
+
+    sched._flush_pending_acks()
+
+    acks = _acks_of(env)
+    assert [a.uid for a in acks] == [910]
+    # Free precedes ack on the caller's timeline — the spy list recorded
+    # the free before the send_result invocation that produced the ack.
+    assert sched._pending_abort_acks == []
+
+
+# =========================================================================
+# C. Overlap deferred abort → apply frees, then flush emits the ack.
+# =========================================================================
+
+
+def test_C_overlap_deferred_ack_after_apply(sched_env):
+    env = sched_env
+    sched = env["sched"]
+
+    r = _make_req(env, cls=env["Req"], cached_len=0, device_len=5, uid=920, output_len=4)
+    env["dm"].running_reqs.add(r)
+    sched.inflight_uids = {920}
+
+    sched._process_one_msg(env["AbortBackendMsg"](uid=920))
+
+    # Fence branch: nothing freed, no ack pending yet — the ack is only
+    # produced from _apply_deferred_aborts.
+    assert env["free_calls"] == []
+    assert sched._pending_abort_acks == []
+    assert sched.deferred_abort_uids == {920}
+
+    batch = env["Batch"](reqs=[r], phase="decode")
+    fd = _make_forward_data(env, batch, next_tokens=[7])
+    sched._process_last_data(fd)
+
+    # Still no ack — _process_last_data does not touch the ack queue.
+    assert env["free_calls"] == []
+    assert sched._pending_abort_acks == []
+    assert _detoks_of(env) == []
+
+    sched._apply_deferred_aborts(fd)
+
+    # Now the free + ack-queue append happened. Flush publishes the ack.
+    assert [rq.uid for rq in env["free_calls"]] == [920]
+    assert sched._pending_abort_acks == [920]
+
+    sched._flush_pending_acks()
+
+    acks = _acks_of(env)
+    assert [a.uid for a in acks] == [920]
+    assert sched.deferred_abort_uids == set()
+
+
+# =========================================================================
+# D. Unknown uid → idempotent ack, no free.
+# =========================================================================
+
+
+def test_D_unknown_uid_idempotent_ack(sched_env):
+    env = sched_env
+    sched = env["sched"]
+
+    # Nothing scheduled — abort a uid the scheduler has never seen.
+    sched._process_one_msg(env["AbortBackendMsg"](uid=42))
+    sched._flush_pending_acks()
+
+    assert env["free_calls"] == []
+    acks = _acks_of(env)
+    assert [a.uid for a in acks] == [42], "unknown uid must still receive one ack"
+
+
+# =========================================================================
+# E. Duplicate abort on a deferred uid → single free, single ack.
+# =========================================================================
+
+
+def test_E_duplicate_abort_single_free_single_ack(sched_env):
+    env = sched_env
+    sched = env["sched"]
+
+    r = _make_req(env, cls=env["Req"], cached_len=0, device_len=5, uid=930, output_len=4)
+    env["dm"].running_reqs.add(r)
+    sched.inflight_uids = {930}
+
+    sched._process_one_msg(env["AbortBackendMsg"](uid=930))
+    sched._process_one_msg(env["AbortBackendMsg"](uid=930))
+
+    assert sched.deferred_abort_uids == {930}
+    assert env["free_calls"] == []
+    assert sched._pending_abort_acks == []
+
+    batch = env["Batch"](reqs=[r], phase="decode")
+    fd = _make_forward_data(env, batch, next_tokens=[7])
+    sched._process_last_data(fd)
+    sched._apply_deferred_aborts(fd)
+    sched._flush_pending_acks()
+
+    # id()-dedup inside _apply_deferred_aborts collapses to one free; the
+    # ack queue mirrors that (append happens inside the same dedup block).
+    assert [rq.uid for rq in env["free_calls"]] == [930]
+    acks = _acks_of(env)
+    assert [a.uid for a in acks] == [930]
+    assert sched.deferred_abort_uids == set()
+    assert sched._pending_abort_acks == []
+
+
+# =========================================================================
+# F. Frontend abort-pending: late UserReply dropped, AbortAckReply cleans up.
+# =========================================================================
+
+
+def test_F_frontend_abort_pending_drops_late_userreply(sched_env):
+    _ensure_python_root_on_path()
+
+    # api_server pulls in prompt_toolkit / fastapi / uvicorn / starlette at
+    # module import time. None of those are needed for the FrontendManager
+    # state machine we are exercising; stub them so the import succeeds in
+    # a lightweight container. The stubs only need to satisfy `from X import
+    # Y` — attribute access resolves to a MagicMock-shaped ModuleType child.
+    import types as _t
+
+    def _fake_module(name: str, attrs: dict | None = None):
+        if name in sys.modules:
+            return sys.modules[name]
+        mod = _t.ModuleType(name)
+        for k, v in (attrs or {}).items():
+            setattr(mod, k, v)
+        sys.modules[name] = mod
+        return mod
+
+    _fake_module("prompt_toolkit", {"PromptSession": MagicMock()})
+    _fake_module("prompt_toolkit.completion", {"WordCompleter": MagicMock()})
+    _fake_module("uvicorn", {"run": MagicMock()})
+    _fake_module("fastapi", {"FastAPI": MagicMock(), "Request": MagicMock()})
+    _fake_module("fastapi.responses", {"StreamingResponse": MagicMock()})
+    _fake_module("starlette", {})
+    _fake_module("starlette.background", {"BackgroundTask": MagicMock()})
+    # pydantic is a real dep but if the environment lacks it, stub as well.
+    if "pydantic" not in sys.modules:
+        class _BM:
+            def __init__(self, **kw):
+                for k, v in kw.items():
+                    setattr(self, k, v)
+
+        def _Field(**kw):
+            return kw.get("default") or (kw.get("default_factory") and kw["default_factory"]())
+
+        _fake_module("pydantic", {"BaseModel": _BM, "Field": _Field})
+
+    from minisgl.message import AbortAckReply, BatchFrontendMsg, UserReply
+    from minisgl.server.api_server import FrontendManager, _unwrap_msg
+
+    fm = FrontendManager.__new__(FrontendManager)
+    fm.config = None
+    fm.send_tokenizer = None
+    fm.recv_tokenizer = None
+    fm.uid_counter = 0
+    fm.initialized = True
+    fm.ack_map = {}
+    fm.event_map = {}
+    fm.abort_pending = set()
+    fm.abort_pending_events = {}
+
+    uid = 555
+    fm.ack_map[uid] = []
+    fm.event_map[uid] = asyncio.Event()
+    fm.abort_pending.add(uid)
+    fm.abort_pending_events[uid] = asyncio.Event()
+
+    async def _drive():
+        # inbound 1: late UserReply — abort_pending gate must drop it.
+        late = UserReply(uid=uid, incremental_output="ghost", finished=False)
+        # Directly exercise the listen() dispatch decision.
+        assert late.uid in fm.ack_map
+        assert late.uid in fm.abort_pending, "abort_pending must gate late replies"
+        # Simulate the drop (no append).
+        assert fm.ack_map[uid] == []
+
+        # inbound 2: AbortAckReply — cleanup + event fire.
+        ack = AbortAckReply(uid=uid)
+        fm.abort_pending.discard(ack.uid)
+        fm.ack_map.pop(ack.uid, None)
+        ev = fm.event_map.pop(ack.uid, None)
+        if ev is not None:
+            ev.set()
+        pending_ev = fm.abort_pending_events.pop(ack.uid, None)
+        if pending_ev is not None:
+            pending_ev.set()
+
+        assert uid not in fm.ack_map
+        assert uid not in fm.event_map
+        assert uid not in fm.abort_pending
+        assert uid not in fm.abort_pending_events
+
+        # Duplicate ack — strict no-op, no KeyError.
+        dup = AbortAckReply(uid=uid)
+        fm.abort_pending.discard(dup.uid)
+        fm.ack_map.pop(dup.uid, None)
+        _ = fm.event_map.pop(dup.uid, None)
+        _ = fm.abort_pending_events.pop(dup.uid, None)
+
+    asyncio.run(_drive())
+
+    # _unwrap_msg must let a BatchFrontendMsg holding mixed UserReply +
+    # AbortAckReply through without dropping any child.
+    batch = BatchFrontendMsg(
+        data=[UserReply(uid=1, incremental_output="a", finished=False), AbortAckReply(uid=2)]
+    )
+    out = _unwrap_msg(batch)
+    kinds = [type(m).__name__ for m in out]
+    assert kinds == ["UserReply", "AbortAckReply"], kinds
+
+
+# =========================================================================
+# G. Natural finish — no ack path touched, UserReply flow unchanged.
+# =========================================================================
+
+
+def test_G_natural_finish_no_ack(sched_env):
+    env = sched_env
+    sched = env["sched"]
+
+    r = _make_req(env, cls=env["Req"], cached_len=0, device_len=5, uid=940, output_len=4)
+    # ignore_eos is True in the helper, so EOS won't finish this req. Use an
+    # explicit stop token so _process_last_data flips finished=True on our
+    # chosen next_token. This is the natural-finish code path — no abort
+    # bookkeeping is touched anywhere along the way.
+    r.sampling_params.stop_token_ids = (7,)
+    env["dm"].running_reqs.add(r)
+
+    batch = env["Batch"](reqs=[r], phase="decode")
+    fd = _make_forward_data(env, batch, next_tokens=[7])
+    sched._process_last_data(fd)
+    sched._apply_deferred_aborts(fd)
+    sched._flush_pending_acks()
+
+    # One DetokenizeMsg emitted, finished=True; no AbortAckMsg anywhere.
+    detoks = _detoks_of(env)
+    assert len(detoks) == 1
+    assert detoks[0].uid == 940
+    assert detoks[0].finished is True
+    assert _acks_of(env) == []
+    assert sched._pending_abort_acks == []
+    assert sched.deferred_abort_uids == set()
+
+
+# =========================================================================
+# H. Tokenizer forwarding: AbortAckMsg → AbortAckReply on send_frontend.
+# =========================================================================
+
+
+def test_H_tokenizer_forwards_abort_ack_to_frontend(sched_env):
+    _ensure_python_root_on_path()
+
+    from minisgl.message import (
+        AbortAckMsg,
+        AbortAckReply,
+        BatchFrontendMsg,
+    )
+
+    # Simulate the interior of tokenize_worker's dispatch. We construct the
+    # exact partitioning + build code and verify the frontend-facing artifact.
+    pending_msg = [AbortAckMsg(uid=11), AbortAckMsg(uid=22)]
+
+    abort_ack_msg = [m for m in pending_msg if isinstance(m, AbortAckMsg)]
+    assert len(abort_ack_msg) == 2
+
+    batch_output = BatchFrontendMsg(
+        data=[AbortAckReply(uid=msg.uid) for msg in abort_ack_msg]
+    )
+    if len(batch_output.data) == 1:
+        batch_output = batch_output.data[0]
+
+    assert isinstance(batch_output, BatchFrontendMsg)
+    uids = [r.uid for r in batch_output.data]
+    assert uids == [11, 22]
+    assert all(isinstance(r, AbortAckReply) for r in batch_output.data)
+
+    # Single-item collapse path — must yield a bare AbortAckReply, not a
+    # BatchFrontendMsg with one child (the tokenizer server takes this fast
+    # path to match the other dispatch branches).
+    single = [AbortAckMsg(uid=99)]
+    bo = BatchFrontendMsg(data=[AbortAckReply(uid=m.uid) for m in single])
+    if len(bo.data) == 1:
+        bo = bo.data[0]
+    assert isinstance(bo, AbortAckReply)
+    assert bo.uid == 99

--- a/tests/misc/test_scheduler_device_backend.py
+++ b/tests/misc/test_scheduler_device_backend.py
@@ -1,0 +1,323 @@
+"""Gate 1.11g — Scheduler stream lifecycle must route through device_runtime.
+
+Structural + behavioural checks on ``minisgl.scheduler.scheduler``:
+
+1. The module must not contain any executable ``torch.cuda.Stream``,
+   ``torch.cuda.stream``, ``torch.cuda.set_stream``, ``torch.cuda.current_stream``,
+   or ``torch.cuda.synchronize`` reference. All stream/synchronize primitives
+   must be sourced from ``minisgl.utils.device_runtime``.
+2. The module must import ``create_stream``, ``set_stream``, ``current_stream``,
+   ``stream_context``, and ``synchronize_device`` from ``minisgl.utils.device_runtime``.
+3. ``Scheduler.__init__`` on NPU never accesses ``torch.cuda.Stream`` or
+   ``torch.cuda.set_stream`` — we booby-trap them and drive init through a stub
+   Engine to prove the NPU branch is taken.
+4. ``Scheduler.shutdown`` calls ``synchronize_device`` with the engine's
+   ``device_type``, not raw ``torch.cuda.synchronize``.
+5. The CUDA branch remains structurally intact (device_runtime still dispatches
+   to ``torch.cuda.Stream`` etc. when ``device_type=="cuda"``).
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+import types
+from pathlib import Path
+from typing import Any, List, Tuple
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCHEDULER_PATH = _REPO_ROOT / "python" / "minisgl" / "scheduler" / "scheduler.py"
+
+
+def _purge_minisgl_from_sys_modules() -> None:
+    """Some earlier tests (test_device_runtime) install stub ``minisgl.utils``
+    package objects into ``sys.modules`` at import time to avoid loading heavy
+    optional deps. Those stubs shadow the real package for later imports in
+    the same session, breaking ``from minisgl.utils import cached_load_hf_config``
+    inside ``minisgl.engine.config``. We evict every ``minisgl*`` entry so the
+    behavioural tests below get a clean re-import.
+    """
+    for name in list(sys.modules):
+        if name == "minisgl" or name.startswith("minisgl."):
+            del sys.modules[name]
+
+
+# ---------------------------------------------------------------------------
+# 1. Structural: scheduler.py must not contain any raw torch.cuda stream call.
+# ---------------------------------------------------------------------------
+
+
+_FORBIDDEN_PATTERNS = [
+    r"torch\.cuda\.Stream\b",
+    r"torch\.cuda\.stream\b",
+    r"torch\.cuda\.set_stream\b",
+    r"torch\.cuda\.current_stream\b",
+    r"torch\.cuda\.synchronize\b",
+]
+
+
+def test_scheduler_source_has_no_raw_torch_cuda_stream_calls() -> None:
+    src = _SCHEDULER_PATH.read_text()
+    # Strip comments so prose about torch.cuda.* is not counted.
+    code_only = "\n".join(line.split("#", 1)[0] for line in src.splitlines())
+    for pattern in _FORBIDDEN_PATTERNS:
+        assert not re.search(pattern, code_only), (
+            f"scheduler.py must not contain executable {pattern!r} — "
+            "route through minisgl.utils.device_runtime instead"
+        )
+
+
+def test_scheduler_imports_device_runtime_helpers() -> None:
+    tree = ast.parse(_SCHEDULER_PATH.read_text())
+    imported: dict[str, set[str]] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            imported.setdefault(node.module, set()).update(
+                alias.name for alias in node.names
+            )
+    dr_imports = imported.get("minisgl.utils.device_runtime", set())
+    for name in ("create_stream", "set_stream", "current_stream",
+                 "stream_context", "synchronize_device"):
+        assert name in dr_imports, (
+            f"scheduler.py must import {name!r} from "
+            f"minisgl.utils.device_runtime; got {dr_imports}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. Behavioural: Scheduler.__init__ on NPU never touches torch.cuda stream API.
+# ---------------------------------------------------------------------------
+
+
+class _StreamCtx:
+    """Fake StreamContext returned by torch.{cuda,npu}.stream(s)."""
+
+    def __init__(self, stream: Any) -> None:
+        self.stream = stream
+
+    def __enter__(self) -> "_StreamCtx":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+class _ExplodingCudaStream:
+    """Sentinel for torch.cuda.Stream — any call blows up."""
+
+    def __call__(self, *args, **kwargs) -> None:
+        raise AssertionError(
+            "Scheduler.__init__ must NOT call torch.cuda.Stream on a non-CUDA host"
+        )
+
+
+def _make_stub_engine(monkeypatch: pytest.MonkeyPatch, device_type: str) -> Any:
+    """Build a minimal object that quacks like ``minisgl.engine.Engine`` for
+    Scheduler.__init__. Only the fields Scheduler actually touches are populated.
+    """
+    import torch
+
+    engine = MagicMock()
+    engine.device_type = device_type
+    engine.device = torch.device("cpu")  # only stored, never used for CUDA ops here
+    # Use a plain sentinel object as the engine's stream — dispatch tests don't
+    # need a real backend stream, only that stream_context receives THIS object.
+    engine.stream = object()
+    engine.num_pages = 16
+    engine.page_table = torch.zeros((4, 16), dtype=torch.int32)
+    engine.tp_cpu_group = None
+
+    # Scheduler's constructor calls `Engine(config)` which resolves via
+    # `from minisgl.engine import Engine`. Patch that lookup to return a factory
+    # that yields our stub, ignoring the SchedulerConfig arg.
+    def _fake_engine_ctor(_config):
+        return engine
+
+    from minisgl import engine as engine_pkg
+
+    monkeypatch.setattr(engine_pkg, "Engine", _fake_engine_ctor, raising=True)
+    return engine
+
+
+def _make_stub_config() -> Any:
+    """Minimal SchedulerConfig stand-in — Scheduler only reads a few fields
+    after Engine construction returns."""
+    cfg = MagicMock()
+    cfg.max_running_req = 4
+    cfg.page_size = 16
+    cfg.cache_type = "radix"
+    cfg.max_extend_tokens = 8192
+    cfg.model_path = "unused"
+    cfg.offline_mode = True
+    cfg.tp_info = MagicMock(rank=0, size=1, is_primary=lambda: True)
+    return cfg
+
+
+def test_npu_scheduler_init_never_touches_torch_cuda_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    torch = pytest.importorskip("torch")
+    _purge_minisgl_from_sys_modules()
+
+    # Patch remaining collaborators that Scheduler.__init__ pulls in.
+    import minisgl.utils.device_runtime as dr
+
+    calls: List[Tuple[str, Any]] = []
+
+    def _fake_create_stream(dt: str) -> Any:
+        calls.append(("create_stream", dt))
+        return object()
+
+    def _fake_set_stream(dt: str, s: Any) -> None:
+        calls.append(("set_stream", dt))
+
+    def _fake_stream_context(dt: str, s: Any) -> Any:
+        calls.append(("stream_context", dt))
+        return _StreamCtx(s)
+
+    monkeypatch.setattr(dr, "create_stream", _fake_create_stream)
+    monkeypatch.setattr(dr, "set_stream", _fake_set_stream)
+    monkeypatch.setattr(dr, "stream_context", _fake_stream_context)
+    # Also patch the names as imported into scheduler.py's module namespace.
+    import minisgl.scheduler.scheduler as sched_mod
+
+    monkeypatch.setattr(sched_mod, "create_stream", _fake_create_stream)
+    monkeypatch.setattr(sched_mod, "set_stream", _fake_set_stream)
+    monkeypatch.setattr(sched_mod, "stream_context", _fake_stream_context)
+
+    # Booby-trap the raw torch.cuda stream API so any accidental call fails hard.
+    monkeypatch.setattr(torch.cuda, "Stream", _ExplodingCudaStream(), raising=False)
+
+    def _explode_set_stream(_s: Any) -> None:
+        raise AssertionError("Scheduler.__init__ must NOT call torch.cuda.set_stream")
+
+    def _explode_current_stream() -> None:
+        raise AssertionError(
+            "Scheduler.__init__ must NOT call torch.cuda.current_stream"
+        )
+
+    monkeypatch.setattr(torch.cuda, "set_stream", _explode_set_stream, raising=False)
+    monkeypatch.setattr(
+        torch.cuda, "current_stream", _explode_current_stream, raising=False
+    )
+
+    # Skip heavy sub-managers by pre-patching their constructors.
+    monkeypatch.setattr(sched_mod, "TableManager", MagicMock())
+    monkeypatch.setattr(sched_mod, "CacheManager", MagicMock())
+    monkeypatch.setattr(sched_mod, "DecodeManager", MagicMock())
+    monkeypatch.setattr(sched_mod, "PrefillManager", MagicMock())
+    monkeypatch.setattr(sched_mod, "load_tokenizer", lambda _p: MagicMock(eos_token_id=0))
+
+    # Build the stub engine + config.
+    _make_stub_engine(monkeypatch, device_type="npu")
+    cfg = _make_stub_config()
+
+    scheduler = sched_mod.Scheduler(cfg)
+
+    # Exactly one create_stream, one stream_context, one set_stream — all with
+    # device_type == "npu". No touch of raw torch.cuda stream API.
+    call_names = [c[0] for c in calls]
+    assert call_names == ["create_stream", "stream_context", "set_stream"], call_names
+    for name, dt in calls:
+        assert dt == "npu", f"{name} routed with device_type={dt} instead of npu"
+    assert scheduler.device_type == "npu"
+
+
+def test_npu_scheduler_shutdown_routes_through_device_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    torch = pytest.importorskip("torch")
+    _purge_minisgl_from_sys_modules()
+
+    import minisgl.scheduler.scheduler as sched_mod
+    import minisgl.utils.device_runtime as dr
+
+    sync_calls: List[str] = []
+
+    def _fake_synchronize_device(dt: str) -> None:
+        sync_calls.append(dt)
+
+    monkeypatch.setattr(dr, "synchronize_device", _fake_synchronize_device)
+    monkeypatch.setattr(sched_mod, "synchronize_device", _fake_synchronize_device)
+
+    def _explode_cuda_synchronize(_d=None) -> None:
+        raise AssertionError(
+            "Scheduler.shutdown must NOT call torch.cuda.synchronize on a non-CUDA host"
+        )
+
+    monkeypatch.setattr(torch.cuda, "synchronize", _explode_cuda_synchronize, raising=False)
+
+    # Build a Scheduler skeleton — bypass __init__ so we only exercise shutdown.
+    scheduler = sched_mod.Scheduler.__new__(sched_mod.Scheduler)
+    scheduler.device_type = "npu"
+    scheduler.engine = MagicMock()
+    # Stub sync_all_ranks so we don't need a real ProcessGroup.
+    scheduler.sync_all_ranks = lambda: None  # type: ignore[method-assign]
+
+    scheduler.shutdown()
+
+    assert sync_calls == ["npu"], sync_calls
+    scheduler.engine.shutdown.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 3. CUDA branch preserved — device_runtime dispatches to torch.cuda.*.
+# ---------------------------------------------------------------------------
+
+
+def test_cuda_branch_still_reaches_torch_cuda_stream_via_device_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When device_type=='cuda', device_runtime dispatches to torch.cuda.*
+    exactly like before. This proves the refactor did not amputate the CUDA
+    path — it just moved it behind the dispatch helper."""
+    torch = pytest.importorskip("torch")
+    _purge_minisgl_from_sys_modules()
+
+    import minisgl.utils.device_runtime as dr
+
+    got: List[str] = []
+    orig_cuda_stream_cls = torch.cuda.Stream
+    orig_cuda_set_stream = torch.cuda.set_stream
+    orig_cuda_synchronize = torch.cuda.synchronize
+
+    def _fake_stream_ctor(*_a, **_kw) -> Any:
+        got.append("cuda.Stream")
+        return object()
+
+    def _fake_set_stream(_s: Any) -> None:
+        got.append("cuda.set_stream")
+
+    def _fake_synchronize(*_a, **_kw) -> None:
+        got.append("cuda.synchronize")
+
+    class _FakeStreamCtx:
+        def __init__(self, s: Any) -> None:
+            got.append("cuda.stream")
+
+        def __enter__(self) -> "_FakeStreamCtx":
+            return self
+
+        def __exit__(self, *_a) -> None:
+            return None
+
+    monkeypatch.setattr(torch.cuda, "Stream", _fake_stream_ctor, raising=False)
+    monkeypatch.setattr(torch.cuda, "set_stream", _fake_set_stream, raising=False)
+    monkeypatch.setattr(torch.cuda, "synchronize", _fake_synchronize, raising=False)
+    monkeypatch.setattr(torch.cuda, "stream", _FakeStreamCtx, raising=False)
+
+    try:
+        s = dr.create_stream("cuda")
+        dr.set_stream("cuda", s)
+        with dr.stream_context("cuda", s):
+            pass
+        dr.synchronize_device("cuda")
+    finally:
+        torch.cuda.Stream = orig_cuda_stream_cls  # type: ignore[assignment]
+        torch.cuda.set_stream = orig_cuda_set_stream  # type: ignore[assignment]
+        torch.cuda.synchronize = orig_cuda_synchronize  # type: ignore[assignment]
+
+    assert got == ["cuda.Stream", "cuda.set_stream", "cuda.stream", "cuda.synchronize"]

--- a/tests/misc/test_scheduler_overlap_abort_fence.py
+++ b/tests/misc/test_scheduler_overlap_abort_fence.py
@@ -1,0 +1,395 @@
+"""Gate 2.3e — Scheduler overlap-loop abort fence.
+
+Exercises the fence state machine on a bare-bones Scheduler skeleton
+built via ``__new__``. Uses real ``CacheManager`` / ``TableManager`` /
+``PrefillManager`` / ``DecodeManager`` / ``Req`` / ``ChunkedReq`` /
+``Batch``. The only mocks are:
+
+  * the outer IO seam (``send_result``, ``receive_msg``) — outside the
+    fence's scope,
+  * the device-side sampled-token stream (a plain CPU tensor + a
+    stub ``copy_done`` event) — same reason,
+  * ``_free_req_resources`` is wrapped by a spy that records every
+    invocation. The underlying allocator dance (table return + KV
+    ``cache_req``) is exercised end-to-end by Gate 2.3d's drain suite;
+    here we assert only that the fence produces the correct **number**
+    of frees per uid — that is what Gate 2.3e is responsible for.
+
+Scenario coverage:
+  A. Ordinary non-inflight abort → immediate free (fence is a no-op).
+  B. Inflight abort → resources alive until _process_last_data
+     completes; then _apply_deferred_aborts frees exactly once.
+  C. Deferred uid does not re-enter the next scheduled batch.
+  D. No stale DetokenizeMsg is emitted for the deferred uid.
+  E. Two abort msgs for the same inflight uid → still one free.
+  F. B=2 batch, one uid aborted mid-fence → the other keeps its token.
+  G. normal_loop code path (empty inflight_uids) is unaffected — the
+     abort msg takes the immediate-free branch.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PYTHON_ROOT = _REPO_ROOT / "python"
+
+
+def _ensure_python_root_on_path() -> None:
+    p = str(_PYTHON_ROOT)
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+
+def _purge_minisgl_from_sys_modules() -> None:
+    for name in list(sys.modules):
+        if name == "minisgl" or name.startswith("minisgl."):
+            del sys.modules[name]
+
+
+# --------------------------------------------------------------------- fixtures
+
+
+@pytest.fixture
+def sched_env():
+    _ensure_python_root_on_path()
+    _purge_minisgl_from_sys_modules()
+
+    import torch
+
+    from minisgl.core import Batch, Req, SamplingParams
+    from minisgl.distributed.info import set_tp_info, try_get_tp_info
+    from minisgl.kvcache.naive_cache import NaiveCacheHandle
+    from minisgl.message import AbortBackendMsg
+    from minisgl.scheduler.cache import CacheManager
+    from minisgl.scheduler.decode import DecodeManager
+    from minisgl.scheduler.prefill import ChunkedReq, PrefillManager
+    from minisgl.scheduler.scheduler import Scheduler
+    from minisgl.scheduler.table import TableManager
+
+    # logger.debug_rank0 (invoked from Scheduler._process_one_msg) requires
+    # tp_info to be initialised. Every fixture spin-up re-imports minisgl
+    # from scratch (see _purge_minisgl_from_sys_modules), so this call is
+    # always the first tp_info setter and safe.
+    if try_get_tp_info() is None:
+        set_tp_info(0, 1)
+
+    page_size = 4
+    num_pages = 8
+    max_running = 4
+    page_table = torch.zeros((max_running, num_pages * page_size), dtype=torch.int32)
+
+    tm = TableManager(max_running, page_table)
+    cm = CacheManager(num_pages, page_size, page_table, type="naive")
+    dm = DecodeManager(page_size)
+    pm = PrefillManager(cache_manager=cm, table_manager=tm, decode_manager=dm)
+
+    sched = Scheduler.__new__(Scheduler)
+    sched.cache_manager = cm
+    sched.table_manager = tm
+    sched.decode_manager = dm
+    sched.prefill_manager = pm
+    sched.finished_reqs = set()
+    sched.inflight_uids = set()
+    sched.deferred_abort_uids = set()
+    sched.eos_token_id = -1
+
+    # send_result spy: capture emitted DetokenizeMsgs.
+    replies: List = []
+    sched.send_result = lambda batch: replies.extend(batch)
+
+    # _free_req_resources spy: record every call so tests can assert per-req
+    # exact-once free semantics without depending on allocator arithmetic.
+    free_calls: List = []
+    real_free = Scheduler._free_req_resources
+
+    def _spy_free(self, req):
+        free_calls.append(req)
+        return real_free(self, req)
+
+    # Bind as a bound method on the instance so calls from any code path
+    # (immediate-free branch, _apply_deferred_aborts) route through the spy.
+    import types
+    sched._free_req_resources = types.MethodType(_spy_free, sched)
+
+    return {
+        "torch": torch,
+        "sched": sched,
+        "cm": cm,
+        "tm": tm,
+        "dm": dm,
+        "pm": pm,
+        "page_table": page_table,
+        "page_size": page_size,
+        "num_pages": num_pages,
+        "Req": Req,
+        "ChunkedReq": ChunkedReq,
+        "Batch": Batch,
+        "SamplingParams": SamplingParams,
+        "NaiveCacheHandle": NaiveCacheHandle,
+        "AbortBackendMsg": AbortBackendMsg,
+        "replies": replies,
+        "free_calls": free_calls,
+    }
+
+
+def _make_req(env, *, cls, cached_len: int, device_len: int, uid: int, output_len: int = 8):
+    tm = env["tm"]
+    cm = env["cm"]
+    table_idx = tm.allocate()
+    reqs = [
+        cls(
+            input_ids=env["torch"].zeros(device_len, dtype=env["torch"].int32),
+            table_idx=table_idx,
+            cached_len=cached_len,
+            output_len=output_len,
+            uid=uid,
+            sampling_params=env["SamplingParams"](
+                temperature=0.0, max_tokens=output_len, ignore_eos=True
+            ),
+            cache_handle=env["NaiveCacheHandle"](),
+        )
+    ]
+    cm.allocate_paged(reqs)
+    return reqs[0]
+
+
+def _make_forward_data(env, batch, next_tokens: List[int]):
+    """Build a ``ForwardData`` = (ForwardInput-lite, ForwardOutput-lite).
+
+    ``_process_last_data`` only reads ``last_data[0].batch`` and
+    ``last_data[1] = (_, next_tokens_cpu, copy_done)``. It does not
+    touch the other ForwardInput fields, so a plain object with a
+    ``.batch`` attribute is all the code sees.
+    """
+    class _FI:
+        pass
+
+    fi = _FI()
+    fi.batch = batch
+    copy_done = MagicMock()
+    next_tokens_cpu = env["torch"].tensor(next_tokens, dtype=env["torch"].int32)
+    fo = (None, next_tokens_cpu, copy_done)
+    return (fi, fo)
+
+
+# =========================================================================
+# A. Non-inflight abort → immediate free (fence branch NOT taken).
+# =========================================================================
+
+
+def test_A_non_inflight_abort_immediate_free(sched_env):
+    env = sched_env
+
+    r = _make_req(env, cls=env["Req"], cached_len=0, device_len=5, uid=1)
+    env["dm"].running_reqs.add(r)
+    assert env["sched"].inflight_uids == set()
+
+    env["sched"]._process_one_msg(env["AbortBackendMsg"](uid=1))
+
+    # Immediate-free branch fires: the req is out of running_reqs and
+    # _free_req_resources ran exactly once for its uid; no deferred state.
+    assert env["dm"].running_reqs == set()
+    assert env["sched"].deferred_abort_uids == set()
+    assert [rq.uid for rq in env["free_calls"]] == [1], (
+        f"immediate abort should free exactly once, got {env['free_calls']}"
+    )
+
+
+# =========================================================================
+# B. Inflight abort deferred; resources untouched until apply helper runs.
+# =========================================================================
+
+
+def test_B_inflight_abort_defers_then_frees_once(sched_env):
+    env = sched_env
+
+    r = _make_req(env, cls=env["Req"], cached_len=0, device_len=5, uid=42, output_len=4)
+    env["dm"].running_reqs.add(r)
+
+    # Simulate overlap_loop entry: this uid is in-flight (batch already
+    # forwarded, CPU-side post-process not yet done).
+    env["sched"].inflight_uids = {42}
+
+    env["sched"]._process_one_msg(env["AbortBackendMsg"](uid=42))
+
+    # Deferred: no free yet. Removed from decode_manager so it cannot
+    # re-enter the next batch.
+    assert env["sched"].deferred_abort_uids == {42}
+    assert env["dm"].running_reqs == set()
+    assert env["free_calls"] == [], "resources freed before last_data drained"
+
+    # Drive the fence tail: _process_last_data on the batch containing r.
+    batch = env["Batch"](reqs=[r], phase="decode")
+    fd = _make_forward_data(env, batch, next_tokens=[7])
+
+    env["sched"]._process_last_data(fd)
+
+    # No DetokenizeMsg for the deferred uid, no host-token append.
+    assert env["replies"] == []
+    assert len(r.input_ids) == 5, "append_host ran on a deferred-abort req"
+    # Still not freed.
+    assert env["free_calls"] == []
+
+    env["sched"]._apply_deferred_aborts(fd)
+
+    # Freed exactly once, deferred set cleared.
+    assert [rq.uid for rq in env["free_calls"]] == [42]
+    assert env["sched"].deferred_abort_uids == set()
+
+
+# =========================================================================
+# C. Deferred uid is not schedulable — running_reqs no longer holds it.
+# =========================================================================
+
+
+def test_C_deferred_uid_not_in_next_batch(sched_env):
+    env = sched_env
+
+    r_a = _make_req(env, cls=env["Req"], cached_len=0, device_len=5, uid=100)
+    r_b = _make_req(env, cls=env["Req"], cached_len=0, device_len=5, uid=101)
+    env["dm"].running_reqs.update([r_a, r_b])
+
+    env["sched"].inflight_uids = {100, 101}
+    env["sched"]._process_one_msg(env["AbortBackendMsg"](uid=100))
+
+    # uid 100 is out of the schedulable set; 101 remains. The next
+    # decode_manager.schedule_next_batch() (not called here) can therefore
+    # only pick 101.
+    running_uids = {rq.uid for rq in env["dm"].running_reqs}
+    assert running_uids == {101}
+    assert env["sched"].deferred_abort_uids == {100}
+    assert env["free_calls"] == []
+
+
+# =========================================================================
+# D. Stale DetokenizeMsg suppressed for the deferred uid; peer still replies.
+# =========================================================================
+
+
+def test_D_no_stale_detokenize_for_deferred(sched_env):
+    env = sched_env
+
+    r_ok = _make_req(env, cls=env["Req"], cached_len=0, device_len=5, uid=200, output_len=4)
+    r_abt = _make_req(env, cls=env["Req"], cached_len=0, device_len=5, uid=201, output_len=4)
+    env["dm"].running_reqs.update([r_ok, r_abt])
+
+    env["sched"].inflight_uids = {200, 201}
+    env["sched"]._process_one_msg(env["AbortBackendMsg"](uid=201))
+
+    batch = env["Batch"](reqs=[r_ok, r_abt], phase="decode")
+    fd = _make_forward_data(env, batch, next_tokens=[10, 20])
+
+    env["sched"]._process_last_data(fd)
+
+    reply_uids = [m.uid for m in env["replies"]]
+    assert reply_uids == [200], f"stale reply emitted: {reply_uids}"
+    # Surviving req got its token appended.
+    assert len(r_ok.input_ids) == 6
+    # Aborted req's host buffer must NOT be touched.
+    assert len(r_abt.input_ids) == 5
+
+    env["sched"]._apply_deferred_aborts(fd)
+
+    # Aborted uid freed exactly once. r_ok is still alive and was NOT freed
+    # here (its lifetime continues into the next tick).
+    assert [rq.uid for rq in env["free_calls"]] == [201]
+
+
+# =========================================================================
+# E. Two abort msgs for the same inflight uid → freed exactly once.
+# =========================================================================
+
+
+def test_E_duplicate_inflight_abort_single_free(sched_env):
+    env = sched_env
+
+    r = _make_req(env, cls=env["Req"], cached_len=0, device_len=5, uid=300, output_len=4)
+    env["dm"].running_reqs.add(r)
+    env["sched"].inflight_uids = {300}
+
+    env["sched"]._process_one_msg(env["AbortBackendMsg"](uid=300))
+    env["sched"]._process_one_msg(env["AbortBackendMsg"](uid=300))
+    # Set membership guarantees uniqueness — a repeat abort is idempotent.
+    assert env["sched"].deferred_abort_uids == {300}
+    # No free yet — still fenced.
+    assert env["free_calls"] == []
+
+    batch = env["Batch"](reqs=[r], phase="decode")
+    fd = _make_forward_data(env, batch, next_tokens=[9])
+
+    env["sched"]._process_last_data(fd)
+    env["sched"]._apply_deferred_aborts(fd)
+
+    # id-dedup inside _apply_deferred_aborts guarantees a single free
+    # even if the same Req were somehow to appear twice in batch.reqs.
+    assert [rq.uid for rq in env["free_calls"]] == [300]
+    # Sanity: no duplicate entries in table_free (would indicate double-free).
+    assert len(env["tm"]._free_slots) == len(set(env["tm"]._free_slots))
+
+
+# =========================================================================
+# F. B=2 batch — abort A only, B still gets its token and stays running.
+# =========================================================================
+
+
+def test_F_partial_abort_keeps_survivor(sched_env):
+    env = sched_env
+
+    r_a = _make_req(env, cls=env["Req"], cached_len=0, device_len=5, uid=400, output_len=4)
+    r_b = _make_req(env, cls=env["Req"], cached_len=0, device_len=6, uid=401, output_len=4)
+    env["dm"].running_reqs.update([r_a, r_b])
+    env["sched"].inflight_uids = {400, 401}
+
+    env["sched"]._process_one_msg(env["AbortBackendMsg"](uid=400))
+    # A removed from decode_manager; B remains.
+    assert {rq.uid for rq in env["dm"].running_reqs} == {401}
+
+    batch = env["Batch"](reqs=[r_a, r_b], phase="decode")
+    fd = _make_forward_data(env, batch, next_tokens=[999, 555])
+
+    env["sched"]._process_last_data(fd)
+
+    # Exactly one reply — for B, with token 555.
+    assert len(env["replies"]) == 1
+    assert env["replies"][0].uid == 401
+    assert env["replies"][0].next_token == 555
+    # B has device_len=6, output_len=4, so max_device_len=10 → remain_len is
+    # still positive after append_host; not finished.
+    assert env["replies"][0].finished is False
+    # B's host token buffer grew by exactly one.
+    assert len(r_b.input_ids) == 7
+    # A's host buffer untouched.
+    assert len(r_a.input_ids) == 5
+
+    env["sched"]._apply_deferred_aborts(fd)
+
+    # After apply: A is freed (once), B remains scheduled and unfreed.
+    assert [rq.uid for rq in env["free_calls"]] == [400]
+    assert {rq.uid for rq in env["dm"].running_reqs} == {401}
+    assert env["sched"].deferred_abort_uids == set()
+
+
+# =========================================================================
+# G. normal_loop path (empty inflight_uids) takes immediate-free branch.
+# =========================================================================
+
+
+def test_G_normal_loop_behavior_unchanged(sched_env):
+    env = sched_env
+
+    r = _make_req(env, cls=env["Req"], cached_len=0, device_len=5, uid=500)
+    env["dm"].running_reqs.add(r)
+    # normal_loop invariant: inflight_uids never populated.
+    assert env["sched"].inflight_uids == set()
+
+    env["sched"]._process_one_msg(env["AbortBackendMsg"](uid=500))
+
+    # Immediate-free branch: no deferred bookkeeping, req yanked, freed once.
+    assert env["sched"].deferred_abort_uids == set()
+    assert env["dm"].running_reqs == set()
+    assert [rq.uid for rq in env["free_calls"]] == [500]

--- a/tests/misc/test_scheduler_overlap_abort_fence.py
+++ b/tests/misc/test_scheduler_overlap_abort_fence.py
@@ -96,6 +96,12 @@ def sched_env():
     sched.finished_reqs = set()
     sched.inflight_uids = set()
     sched.deferred_abort_uids = set()
+    # Gate 2.3f: the abort-msg handler unconditionally appends the uid to
+    # this list when the non-inflight branch fires (immediate free) OR
+    # inside _apply_deferred_aborts. Gate 2.3e tests focus on the fence
+    # logic and ignore the ack queue, but the attribute must exist so the
+    # scheduler methods do not AttributeError.
+    sched._pending_abort_acks = []
     sched.eos_token_id = -1
 
     # send_result spy: capture emitted DetokenizeMsgs.

--- a/tests/misc/test_scheduler_prepare_batch_txn.py
+++ b/tests/misc/test_scheduler_prepare_batch_txn.py
@@ -1,0 +1,416 @@
+"""Gate 2.3b — transactional rollback for ``Scheduler._prepare_batch``.
+
+Every scenario in this file exercises the transaction boundary that Gate
+2.3b introduces around ``CacheManager.allocate_paged``: if any step
+between ``allocate_paged`` and the ``ForwardInput`` return raises, then
+the newly-allocated pages and the page_table slice writes performed by
+this call are rolled back — while pre-existing prefix / retained pages,
+cache handles, ``table_manager`` slots, and running/pending sets stay
+exactly as they were.
+
+Tests are hermetic: everything runs on CPU with the naive prefix cache.
+Real ``CacheManager`` + real ``allocate_paged`` + real ``_prepare_batch``
+are exercised. The only fakes are: engine.graph_runner.pad_batch (just
+copies ``batch.reqs`` into ``batch.padded_reqs``), engine.attn_backend
+(controls where the raise happens), engine.sampler (returns a sentinel).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Callable, List, Tuple
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PYTHON_ROOT = _REPO_ROOT / "python"
+
+
+def _ensure_python_root_on_path() -> None:
+    p = str(_PYTHON_ROOT)
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+
+def _purge_minisgl_from_sys_modules() -> None:
+    for name in list(sys.modules):
+        if name == "minisgl" or name.startswith("minisgl."):
+            del sys.modules[name]
+
+
+# --------------------------------------------------------------------- fixtures
+
+
+@pytest.fixture
+def cm_env():
+    """Build a real ``CacheManager`` + minimal collaborators on CPU."""
+    _ensure_python_root_on_path()
+    _purge_minisgl_from_sys_modules()
+
+    import torch
+
+    from minisgl.scheduler.cache import CacheManager
+    from minisgl.scheduler.table import TableManager
+
+    page_size = 4
+    num_pages = 8  # 8 * 4 = 32 token slots
+    max_running = 4
+    # page_table shape: [max_running, num_pages * page_size]; entries record the
+    # physical slot each logical token position maps to. Init to zeros so we
+    # can distinguish "still zero" from "written by allocate_paged".
+    page_table = torch.zeros((max_running, num_pages * page_size), dtype=torch.int32)
+
+    tm = TableManager(max_running, page_table)
+    # Naive prefix cache always reports cached_len=0 — perfect for tests that
+    # only need to exercise the allocation + rollback contract without
+    # entangling radix bookkeeping.
+    cm = CacheManager(num_pages, page_size, page_table, type="naive")
+
+    return {
+        "torch": torch,
+        "cm": cm,
+        "tm": tm,
+        "page_table": page_table,
+        "page_size": page_size,
+        "num_pages": num_pages,
+    }
+
+
+def _make_req(env, *, table_idx: int, cached_len: int, device_len: int, uid: int):
+    """Build a real ``Req`` that ``allocate_paged`` will happily consume."""
+    from minisgl.core import Req, SamplingParams
+    from minisgl.kvcache.naive_cache import NaiveCacheHandle
+
+    # NaiveCacheHandle carries the empty tensor plumbed in by NaivePrefixCache
+    # on construction; ``env['cm']`` already did that plumbing.
+    assert 0 <= cached_len < device_len
+    input_ids = env["torch"].zeros(device_len, dtype=env["torch"].int32)
+    output_len = 1  # any positive value satisfies Req's assert
+    return Req(
+        input_ids=input_ids,
+        table_idx=table_idx,
+        cached_len=cached_len,
+        output_len=output_len,
+        uid=uid,
+        sampling_params=SamplingParams(temperature=0.0, max_tokens=1),
+        cache_handle=NaiveCacheHandle(),
+    )
+
+
+def _snapshot(env) -> dict:
+    """Snapshot every allocator/page_table quantity we assert on."""
+    return {
+        "free_pages": int(len(env["cm"].free_slots)),
+        "available_size": int(env["cm"].available_size),
+        "free_slots_sorted": sorted(int(x) for x in env["cm"].free_slots.tolist()),
+        "table_free": sorted(env["tm"]._free_slots),
+        "page_table": env["page_table"].detach().cpu().clone(),
+    }
+
+
+def _assert_state_restored(before: dict, after: dict) -> None:
+    assert after["free_pages"] == before["free_pages"], (
+        f"free_pages leaked: {before['free_pages']} -> {after['free_pages']}"
+    )
+    assert after["available_size"] == before["available_size"], (
+        f"available_size drift: {before['available_size']} -> {after['available_size']}"
+    )
+    assert after["free_slots_sorted"] == before["free_slots_sorted"], (
+        f"free_slots contents drifted:\n  before={before['free_slots_sorted']}"
+        f"\n  after ={after['free_slots_sorted']}"
+    )
+    assert after["table_free"] == before["table_free"], (
+        f"table_manager free list drifted: {before['table_free']} vs {after['table_free']}"
+    )
+    import torch as _t
+
+    assert _t.equal(before["page_table"], after["page_table"]), (
+        "page_table not fully restored after rollback"
+    )
+
+
+# ---------------------------------------------------------- scheduler harness
+
+
+def _build_scheduler_skeleton(env, *, prepare_metadata: Callable[[object], None]):
+    """Instantiate ``Scheduler`` via ``__new__`` and bolt on just enough for
+    ``_prepare_batch`` to run end-to-end.
+    """
+    _ensure_python_root_on_path()
+
+    from minisgl.scheduler.scheduler import Scheduler
+
+    sched = Scheduler.__new__(Scheduler)
+    sched.cache_manager = env["cm"]
+    sched.table_manager = env["tm"]
+    sched.device = env["page_table"].device
+
+    engine = MagicMock()
+    engine.page_table = env["page_table"]
+
+    # graph_runner.pad_batch: copy reqs into padded_reqs (no cuda-graph padding).
+    def _pad_batch(batch):
+        batch.padded_reqs = list(batch.reqs)
+
+    engine.graph_runner.pad_batch = _pad_batch
+
+    engine.attn_backend.prepare_metadata = prepare_metadata
+
+    # Return a lightweight sentinel; _prepare_batch stores whatever it gets.
+    engine.sampler.prepare = lambda batch: ("sample_args_sentinel", batch.size)
+
+    sched.engine = engine
+    return sched
+
+
+def _new_prefill_batch(reqs):
+    from minisgl.core import Batch
+
+    return Batch(reqs=list(reqs), phase="prefill")
+
+
+# =========================================================================
+# A. No prefix — prepare_metadata raises after allocation succeeds
+# =========================================================================
+
+
+def test_A_no_prefix_rollback_restores_pages_and_page_table(cm_env):
+    """B=2 with cached_len=0, prepare_metadata raises → pages + slice both
+    restored, table_manager untouched, batch scratch cleared."""
+    env = cm_env
+    # Reserve two table rows via the real TableManager (mirror scheduler use).
+    ta = env["tm"].allocate()
+    tb = env["tm"].allocate()
+    reqs = [
+        _make_req(env, table_idx=ta, cached_len=0, device_len=5, uid=1),   # 2 pages
+        _make_req(env, table_idx=tb, cached_len=0, device_len=3, uid=2),   # 1 page
+    ]
+    before = _snapshot(env)
+
+    def _explode(batch):
+        raise RuntimeError("gate23b_A: injected failure inside prepare_metadata")
+
+    sched = _build_scheduler_skeleton(env, prepare_metadata=_explode)
+    batch = _new_prefill_batch(reqs)
+
+    with pytest.raises(RuntimeError, match="gate23b_A"):
+        sched._prepare_batch(batch)
+
+    after = _snapshot(env)
+    _assert_state_restored(before, after)
+
+    # Batch's scratch attrs must be scrubbed so a later scheduling round
+    # cannot accidentally reuse a stale positions / out_loc / metadata.
+    for attr in ("positions", "out_loc", "padded_reqs", "attn_metadata"):
+        assert attr not in batch.__dict__, f"batch.{attr} not cleared after rollback"
+
+    # table_manager slots must NOT have been freed — the reqs still own them.
+    assert ta not in env["tm"]._free_slots
+    assert tb not in env["tm"]._free_slots
+
+
+# =========================================================================
+# B. With retained prefix — only the new page is rolled back
+# =========================================================================
+
+
+def test_B_with_prefix_rollback_preserves_prefix_pages(cm_env):
+    """Simulate a request that already owns one retained/cached page. After
+    a failed allocation, only the newly-allocated page is returned; the
+    prefix page slot in page_table and free_slots is untouched."""
+    env = cm_env
+    ta = env["tm"].allocate()
+
+    # Simulate a prior prefix: consume physical page 3 by hand and write it
+    # into page_table[ta, 0:page_size]. This mirrors what a previous
+    # allocate_paged call would have left behind.
+    import torch as _t
+
+    page_size = env["page_size"]
+    # Pop page 3 from free_slots and pretend it's retained by ta.
+    all_free_before_manual = env["cm"].free_slots.tolist()
+    assert 3 * page_size in all_free_before_manual
+    # Remove that entry, keep the rest.
+    keep = [x for x in all_free_before_manual if x != 3 * page_size]
+    env["cm"].free_slots = _t.tensor(keep, dtype=_t.int32)
+    env["page_table"][ta, 0:page_size] = _t.arange(
+        3 * page_size, 3 * page_size + page_size, dtype=_t.int32
+    )
+
+    # Snapshot the "retained prefix" state — this is what MUST survive.
+    prefix_before = env["page_table"][ta, 0:page_size].clone()
+    before = _snapshot(env)
+
+    # Now build a req with cached_len=page_size (== retained prefix length)
+    # and device_len=page_size+1 → needs exactly one new page starting at
+    # logical position page_size.
+    reqs = [
+        _make_req(
+            env, table_idx=ta,
+            cached_len=page_size, device_len=page_size + 1, uid=10,
+        ),
+    ]
+
+    def _explode(batch):
+        raise NotImplementedError("gate23b_B: mimicking Ascend FIA refusal")
+
+    sched = _build_scheduler_skeleton(env, prepare_metadata=_explode)
+    batch = _new_prefill_batch(reqs)
+
+    with pytest.raises(NotImplementedError, match="gate23b_B"):
+        sched._prepare_batch(batch)
+
+    after = _snapshot(env)
+    _assert_state_restored(before, after)
+
+    # Prefix page contents preserved bit-equal.
+    prefix_after = env["page_table"][ta, 0:page_size]
+    assert _t.equal(prefix_before, prefix_after), (
+        f"prefix page mutated: {prefix_before} -> {prefix_after}"
+    )
+    # Retained physical page 3 must NOT be back on the free list.
+    assert 3 * page_size not in env["cm"].free_slots.tolist()
+
+
+# =========================================================================
+# C. Two requests with different new-page counts — all-or-nothing rollback
+# =========================================================================
+
+
+def test_C_two_reqs_different_page_counts_all_rolled_back(cm_env):
+    """Two reqs allocate 3 pages and 1 page respectively; failure returns
+    ALL 4 pages, restores BOTH page_table slices, and does so without
+    double-freeing any page."""
+    env = cm_env
+    ta = env["tm"].allocate()
+    tb = env["tm"].allocate()
+    page_size = env["page_size"]
+
+    reqs = [
+        # 3 new pages (device_len 9 spans logical pages 0..2 inclusive)
+        _make_req(env, table_idx=ta, cached_len=0, device_len=9, uid=100),
+        # 1 new page (device_len 2 spans logical page 0 only)
+        _make_req(env, table_idx=tb, cached_len=0, device_len=2, uid=101),
+    ]
+    before = _snapshot(env)
+
+    def _explode(batch):
+        raise RuntimeError("gate23b_C: injected failure")
+
+    sched = _build_scheduler_skeleton(env, prepare_metadata=_explode)
+    batch = _new_prefill_batch(reqs)
+
+    with pytest.raises(RuntimeError, match="gate23b_C"):
+        sched._prepare_batch(batch)
+
+    after = _snapshot(env)
+    _assert_state_restored(before, after)
+
+    # Duplicate-free check: sorted free_slots must have no repeated entries.
+    slots = after["free_slots_sorted"]
+    assert len(slots) == len(set(slots)), (
+        f"double free detected in free_slots: {slots}"
+    )
+    # And every entry must still be page-aligned.
+    assert all(x % page_size == 0 for x in slots)
+
+
+# =========================================================================
+# D. Success path — behaviour identical to pre-Gate-2.3b
+# =========================================================================
+
+
+def test_D_success_path_pages_retained_and_forward_input_populated(cm_env):
+    """Metadata succeeds → new pages stay allocated, page_table stays
+    written, no rollback runs, ForwardInput carries the sampler sentinel."""
+    env = cm_env
+    ta = env["tm"].allocate()
+    tb = env["tm"].allocate()
+    reqs = [
+        _make_req(env, table_idx=ta, cached_len=0, device_len=5, uid=200),  # 2 pages
+        _make_req(env, table_idx=tb, cached_len=0, device_len=3, uid=201),  # 1 page
+    ]
+    before = _snapshot(env)
+
+    def _ok(batch):
+        # Set an attn_metadata sentinel so downstream can observe success.
+        batch.attn_metadata = "meta_sentinel"
+
+    sched = _build_scheduler_skeleton(env, prepare_metadata=_ok)
+    batch = _new_prefill_batch(reqs)
+
+    fi = sched._prepare_batch(batch)
+
+    # 3 pages consumed total (2 + 1).
+    after = _snapshot(env)
+    assert after["free_pages"] == before["free_pages"] - 3, (
+        f"expected 3 pages consumed, got "
+        f"{before['free_pages']} -> {after['free_pages']}"
+    )
+    # Sampler sentinel propagated.
+    assert fi.sample_args == ("sample_args_sentinel", 2)
+    # Batch retains its scratch attrs on the success path.
+    assert hasattr(batch, "positions")
+    assert hasattr(batch, "out_loc")
+    assert hasattr(batch, "padded_reqs")
+    assert batch.attn_metadata == "meta_sentinel"
+    # page_table row for ta got written into positions [0..5) — non-trivial.
+    assert env["page_table"][ta, :5].abs().sum().item() > 0
+    assert env["page_table"][tb, :3].abs().sum().item() > 0
+
+
+# =========================================================================
+# E. Second call after a rollback still succeeds
+# =========================================================================
+
+
+def test_E_rollback_then_success_leaves_allocator_healthy(cm_env):
+    """Fail once, roll back, then re-run _prepare_batch with a success
+    metadata callback. Must succeed and produce exactly the same effect as
+    if the failed call had never happened."""
+    env = cm_env
+    ta = env["tm"].allocate()
+    tb = env["tm"].allocate()
+
+    baseline = _snapshot(env)
+
+    # ---- Round 1: injected failure ----
+    reqs_fail = [
+        _make_req(env, table_idx=ta, cached_len=0, device_len=5, uid=300),
+        _make_req(env, table_idx=tb, cached_len=0, device_len=3, uid=301),
+    ]
+
+    def _explode(batch):
+        raise RuntimeError("gate23b_E: round1 boom")
+
+    sched1 = _build_scheduler_skeleton(env, prepare_metadata=_explode)
+    batch1 = _new_prefill_batch(reqs_fail)
+    with pytest.raises(RuntimeError, match="gate23b_E"):
+        sched1._prepare_batch(batch1)
+
+    after_round1 = _snapshot(env)
+    _assert_state_restored(baseline, after_round1)
+
+    # ---- Round 2: same reqs, this time metadata succeeds ----
+    reqs_ok = [
+        _make_req(env, table_idx=ta, cached_len=0, device_len=5, uid=302),
+        _make_req(env, table_idx=tb, cached_len=0, device_len=3, uid=303),
+    ]
+
+    def _ok(batch):
+        batch.attn_metadata = "round2_ok"
+
+    sched2 = _build_scheduler_skeleton(env, prepare_metadata=_ok)
+    batch2 = _new_prefill_batch(reqs_ok)
+    fi = sched2._prepare_batch(batch2)
+
+    after_round2 = _snapshot(env)
+    # 3 pages consumed after round 2 — matches what round 1 would have done
+    # if it had succeeded.
+    assert after_round2["free_pages"] == baseline["free_pages"] - 3, (
+        f"post-round2 page count wrong: {baseline['free_pages']}"
+        f" -> {after_round2['free_pages']}"
+    )
+    assert fi.batch is batch2
+    assert batch2.attn_metadata == "round2_ok"

--- a/tests/misc/test_scheduler_shutdown_drain.py
+++ b/tests/misc/test_scheduler_shutdown_drain.py
@@ -1,0 +1,390 @@
+"""Gate 2.3d — ``Scheduler._drain_requests`` shutdown drain.
+
+Exercises the drain helper directly on a bare-bones Scheduler skeleton
+built via ``__new__``. Uses the real ``CacheManager`` (with the naive
+prefix cache), the real ``TableManager``, the real ``PrefillManager``,
+the real ``DecodeManager``, and real ``Req`` / ``PendingReq`` / ``ChunkedReq``
+objects. Only the outer ``shutdown()`` collaborators (engine, distributed
+sync) are mocked.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PYTHON_ROOT = _REPO_ROOT / "python"
+
+
+def _ensure_python_root_on_path() -> None:
+    p = str(_PYTHON_ROOT)
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+
+def _purge_minisgl_from_sys_modules() -> None:
+    for name in list(sys.modules):
+        if name == "minisgl" or name.startswith("minisgl."):
+            del sys.modules[name]
+
+
+# --------------------------------------------------------------------- fixtures
+
+
+@pytest.fixture
+def sched_env():
+    _ensure_python_root_on_path()
+    _purge_minisgl_from_sys_modules()
+
+    import torch
+
+    from minisgl.core import Req, SamplingParams
+    from minisgl.kvcache.naive_cache import NaiveCacheHandle
+    from minisgl.scheduler.cache import CacheManager
+    from minisgl.scheduler.decode import DecodeManager
+    from minisgl.scheduler.prefill import ChunkedReq, PrefillManager
+    from minisgl.scheduler.scheduler import Scheduler
+    from minisgl.scheduler.table import TableManager
+    from minisgl.scheduler.utils import PendingReq
+
+    page_size = 4
+    num_pages = 8
+    max_running = 4
+    page_table = torch.zeros((max_running, num_pages * page_size), dtype=torch.int32)
+
+    tm = TableManager(max_running, page_table)
+    cm = CacheManager(num_pages, page_size, page_table, type="naive")
+    dm = DecodeManager(page_size)
+    pm = PrefillManager(cache_manager=cm, table_manager=tm, decode_manager=dm)
+
+    sched = Scheduler.__new__(Scheduler)
+    sched.cache_manager = cm
+    sched.table_manager = tm
+    sched.decode_manager = dm
+    sched.prefill_manager = pm
+    sched.finished_reqs = set()
+
+    return {
+        "torch": torch,
+        "sched": sched,
+        "cm": cm,
+        "tm": tm,
+        "dm": dm,
+        "pm": pm,
+        "page_table": page_table,
+        "page_size": page_size,
+        "num_pages": num_pages,
+        "Req": Req,
+        "ChunkedReq": ChunkedReq,
+        "PendingReq": PendingReq,
+        "SamplingParams": SamplingParams,
+        "NaiveCacheHandle": NaiveCacheHandle,
+    }
+
+
+def _make_req(env, *, cls, cached_len: int, device_len: int, uid: int):
+    tm = env["tm"]
+    cm = env["cm"]
+    # Reserve a table row + pages the way PrefillAdder + allocate_paged would.
+    table_idx = tm.allocate()
+    # Allocate pages for this req and write them into the page_table.
+    reqs = [
+        cls(
+            input_ids=env["torch"].zeros(device_len, dtype=env["torch"].int32),
+            table_idx=table_idx,
+            cached_len=cached_len,
+            output_len=8,
+            uid=uid,
+            sampling_params=env["SamplingParams"](temperature=0.0, max_tokens=1),
+            cache_handle=env["NaiveCacheHandle"](),
+        )
+    ]
+    cm.allocate_paged(reqs)
+    return reqs[0]
+
+
+def _make_pending(env, *, uid: int, input_len: int, chunked_req=None):
+    input_ids = env["torch"].zeros(input_len, dtype=env["torch"].int32)
+    pending = env["PendingReq"](
+        uid=uid,
+        input_ids=input_ids,
+        sampling_params=env["SamplingParams"](temperature=0.0, max_tokens=4),
+    )
+    pending.chunked_req = chunked_req
+    return pending
+
+
+def _snapshot(env) -> dict:
+    return {
+        "free_pages": int(len(env["cm"].free_slots)),
+        "available_size": int(env["cm"].available_size),
+        "free_slots_sorted": sorted(int(x) for x in env["cm"].free_slots.tolist()),
+        "table_free_sorted": sorted(env["tm"]._free_slots),
+        "pending_len": len(env["pm"].pending_list),
+        "running_len": len(env["dm"].running_reqs),
+    }
+
+
+# =========================================================================
+# A. Only unresourced waiting pending reqs — drop from pending_list.
+# =========================================================================
+
+
+def test_A_waiting_only_drops_pending_list(sched_env):
+    env = sched_env
+    baseline = _snapshot(env)
+
+    env["pm"].pending_list.append(_make_pending(env, uid=1, input_len=4))
+    env["pm"].pending_list.append(_make_pending(env, uid=2, input_len=6))
+
+    assert len(env["pm"].pending_list) == 2
+    env["sched"]._drain_requests()
+
+    after = _snapshot(env)
+    assert after == baseline, (
+        f"drain changed allocator state despite no allocated resources: "
+        f"{baseline} -> {after}"
+    )
+
+
+# =========================================================================
+# B. Pending with chunked_req — release table + KV via _free_req_resources.
+# =========================================================================
+
+
+def test_B_pending_with_chunked_req_releases_resources(sched_env):
+    env = sched_env
+    baseline = _snapshot(env)
+
+    chunked = _make_req(
+        env, cls=env["ChunkedReq"], cached_len=0, device_len=5, uid=10
+    )
+    pending = _make_pending(env, uid=10, input_len=8, chunked_req=chunked)
+    env["pm"].pending_list.append(pending)
+
+    # Verify pre-drain: one page consumed (5 tokens spanning 2 pages of size 4).
+    pre = _snapshot(env)
+    assert pre["free_pages"] < baseline["free_pages"]
+    assert 0 not in env["tm"]._free_slots or len(env["tm"]._free_slots) < len(
+        baseline["table_free_sorted"]
+    )
+
+    env["sched"]._drain_requests()
+
+    after = _snapshot(env)
+    assert after["pending_len"] == 0
+    assert after["running_len"] == 0
+    assert after["free_pages"] == baseline["free_pages"], (
+        f"KV pages not fully returned: {baseline['free_pages']} != {after['free_pages']}"
+    )
+    assert after["table_free_sorted"] == baseline["table_free_sorted"], (
+        f"table_free drift after drain: {after['table_free_sorted']}"
+    )
+    env["cm"].check_integrity()
+
+
+# =========================================================================
+# C. Only running decode reqs — clean them out via decode_manager.
+# =========================================================================
+
+
+def test_C_running_only_releases_via_decode_manager(sched_env):
+    env = sched_env
+    baseline = _snapshot(env)
+
+    r1 = _make_req(env, cls=env["Req"], cached_len=0, device_len=5, uid=100)
+    r2 = _make_req(env, cls=env["Req"], cached_len=0, device_len=9, uid=101)
+    env["dm"].running_reqs.update([r1, r2])
+
+    pre = _snapshot(env)
+    assert pre["running_len"] == 2
+    assert pre["free_pages"] < baseline["free_pages"]
+
+    env["sched"]._drain_requests()
+
+    after = _snapshot(env)
+    assert after["pending_len"] == 0
+    assert after["running_len"] == 0
+    assert after["free_pages"] == baseline["free_pages"]
+    assert after["table_free_sorted"] == baseline["table_free_sorted"]
+    env["cm"].check_integrity()
+
+
+# =========================================================================
+# D. Mixed: pending + chunked + running — everything released.
+# =========================================================================
+
+
+def test_D_mixed_all_resources_reclaimed(sched_env):
+    env = sched_env
+    baseline = _snapshot(env)
+
+    # 2 pure waiting (no chunked_req, no resources)
+    env["pm"].pending_list.append(_make_pending(env, uid=200, input_len=3))
+    env["pm"].pending_list.append(_make_pending(env, uid=201, input_len=4))
+
+    # 1 pending with a ChunkedReq occupying a table slot + pages
+    ck = _make_req(env, cls=env["ChunkedReq"], cached_len=0, device_len=5, uid=202)
+    env["pm"].pending_list.append(
+        _make_pending(env, uid=202, input_len=10, chunked_req=ck)
+    )
+
+    # 2 running decode reqs
+    r1 = _make_req(env, cls=env["Req"], cached_len=0, device_len=7, uid=203)
+    r2 = _make_req(env, cls=env["Req"], cached_len=0, device_len=9, uid=204)
+    env["dm"].running_reqs.update([r1, r2])
+
+    pre = _snapshot(env)
+    assert pre["pending_len"] == 3
+    assert pre["running_len"] == 2
+    assert pre["free_pages"] < baseline["free_pages"]
+    assert pre["table_free_sorted"] != baseline["table_free_sorted"]
+
+    env["sched"]._drain_requests()
+
+    after = _snapshot(env)
+    assert after["pending_len"] == 0
+    assert after["running_len"] == 0
+    assert after["free_pages"] == baseline["free_pages"], (
+        f"page leak: {baseline['free_pages']} -> {after['free_pages']}"
+    )
+    assert after["table_free_sorted"] == baseline["table_free_sorted"], (
+        f"table_free drift: {after['table_free_sorted']}"
+    )
+    env["cm"].check_integrity()
+
+
+# =========================================================================
+# E. Same Req referenced twice — freed exactly once (no double free).
+# =========================================================================
+
+
+def test_E_shared_req_freed_once(sched_env):
+    env = sched_env
+    baseline = _snapshot(env)
+
+    # A single Req referenced by BOTH the pending list (as a ChunkedReq) AND
+    # the running set. This simulates a bookkeeping edge case where the same
+    # request object is somehow tracked in two containers.
+    shared = _make_req(env, cls=env["ChunkedReq"], cached_len=0, device_len=5, uid=300)
+    env["pm"].pending_list.append(
+        _make_pending(env, uid=300, input_len=8, chunked_req=shared)
+    )
+    env["dm"].running_reqs.add(shared)
+
+    env["sched"]._drain_requests()
+
+    after = _snapshot(env)
+    # Exactly one table slot restored (not two): if we double-freed, table_free
+    # would carry a duplicate entry.
+    assert sorted(env["tm"]._free_slots) == baseline["table_free_sorted"]
+    assert len(env["tm"]._free_slots) == len(set(env["tm"]._free_slots)), (
+        "double-free detected in table_manager._free_slots"
+    )
+    # No double-freed KV pages either.
+    slots = after["free_slots_sorted"]
+    assert len(slots) == len(set(slots)), (
+        f"double-free detected in cache_manager.free_slots: {slots}"
+    )
+    assert after["free_pages"] == baseline["free_pages"]
+    env["cm"].check_integrity()
+
+
+# =========================================================================
+# F. drain twice — second call is a no-op.
+# =========================================================================
+
+
+def test_F_drain_is_idempotent(sched_env):
+    env = sched_env
+    baseline = _snapshot(env)
+
+    r = _make_req(env, cls=env["Req"], cached_len=0, device_len=5, uid=400)
+    env["dm"].running_reqs.add(r)
+    env["pm"].pending_list.append(_make_pending(env, uid=401, input_len=4))
+
+    env["sched"]._drain_requests()
+    mid = _snapshot(env)
+    assert mid["pending_len"] == 0
+    assert mid["running_len"] == 0
+    assert mid["free_pages"] == baseline["free_pages"]
+    assert mid["table_free_sorted"] == baseline["table_free_sorted"]
+
+    # Second call — must not touch allocator state.
+    env["sched"]._drain_requests()
+    end = _snapshot(env)
+    assert end == mid, f"drain #2 mutated state: {mid} -> {end}"
+
+
+# =========================================================================
+# G. Empty scheduler — shutdown drain is a clean no-op.
+# =========================================================================
+
+
+def test_G_empty_scheduler_drain_no_op(sched_env):
+    env = sched_env
+    baseline = _snapshot(env)
+
+    env["sched"]._drain_requests()
+
+    after = _snapshot(env)
+    assert after == baseline
+    env["cm"].check_integrity()
+
+
+# =========================================================================
+# H. shutdown() invokes drain in the correct order.
+# =========================================================================
+
+
+def test_H_shutdown_calls_drain_before_engine_shutdown(sched_env):
+    env = sched_env
+    # Stash real dependencies + monkeypatch shutdown-side collaborators.
+    sched = env["sched"]
+
+    call_order: List[str] = []
+
+    from minisgl.utils import device_runtime
+
+    real_sync = device_runtime.synchronize_device
+    device_runtime.synchronize_device = lambda dt: call_order.append("sync_device")
+    # Rebind the name imported inside scheduler.py too.
+    import minisgl.scheduler.scheduler as sched_mod
+
+    sched_mod.synchronize_device = lambda dt: call_order.append("sync_device")
+
+    sched.device_type = "cpu"
+    sched.sync_all_ranks = lambda: call_order.append("sync_ranks")
+
+    original_drain = sched._drain_requests
+
+    def _tracked_drain():
+        call_order.append("drain")
+        return original_drain()
+
+    sched._drain_requests = _tracked_drain
+
+    engine = MagicMock()
+    engine.shutdown = lambda: call_order.append("engine_shutdown")
+    sched.engine = engine
+
+    # Put one running req so drain has something to do.
+    r = _make_req(env, cls=env["Req"], cached_len=0, device_len=5, uid=500)
+    env["dm"].running_reqs.add(r)
+
+    try:
+        sched.shutdown()
+    finally:
+        device_runtime.synchronize_device = real_sync
+        sched_mod.synchronize_device = real_sync
+
+    assert call_order == [
+        "sync_device",
+        "sync_ranks",
+        "drain",
+        "engine_shutdown",
+    ], f"shutdown order wrong: {call_order}"

--- a/tests/misc/test_scheduler_stop_tokens.py
+++ b/tests/misc/test_scheduler_stop_tokens.py
@@ -1,0 +1,339 @@
+"""Gate 2.1c — Scheduler-side stop_token_ids finish contract.
+
+Two-layer test strategy:
+
+1. Structural (AST) — the finish path in ``_process_last_data`` must literally
+   consult ``req.sampling_params.stop_token_ids``. This locks the semantics
+   even on hosts where the runtime probe cannot execute (no NPU).
+
+2. Behavioural — drive ``_process_last_data`` against a minimal fake
+   scheduler + fake batch, exercising the six behaviour rows the Gate 2.1c
+   spec calls out:
+      a. default empty tuple = no change from pre-2.1c behaviour;
+      b. hit on an explicit stop token finishes the request;
+      c. the stop token itself is appended to req.input_ids (retained);
+      d. ignore_eos=True still honours explicit stop tokens;
+      e. non-hit next_token keeps the request running;
+      f. max_tokens (can_decode-False) and scalar EOS paths are unchanged.
+"""
+from __future__ import annotations
+
+import ast
+from contextlib import contextmanager
+from pathlib import Path
+from typing import List
+
+import torch
+
+from minisgl.core import SamplingParams
+from minisgl.message import DetokenizeMsg
+from minisgl.scheduler.scheduler import Scheduler
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCHED_PATH = _REPO_ROOT / "python" / "minisgl" / "scheduler" / "scheduler.py"
+
+
+# ---------------------------------------------------------------- AST checks
+
+
+def _process_last_data_fn() -> ast.FunctionDef:
+    tree = ast.parse(_SCHED_PATH.read_text())
+    cls = next(
+        n for n in tree.body
+        if isinstance(n, ast.ClassDef) and n.name == "Scheduler"
+    )
+    return next(
+        n for n in cls.body
+        if isinstance(n, ast.FunctionDef) and n.name == "_process_last_data"
+    )
+
+
+def _walk(node):
+    yield node
+    for child in ast.iter_child_nodes(node):
+        yield from _walk(child)
+
+
+def test_process_last_data_references_stop_token_ids() -> None:
+    fn = _process_last_data_fn()
+    hits = [
+        n for n in _walk(fn)
+        if isinstance(n, ast.Attribute) and n.attr == "stop_token_ids"
+    ]
+    assert hits, (
+        "Scheduler._process_last_data must reference sampling_params.stop_token_ids"
+    )
+
+
+def test_stop_token_check_is_in_membership_form() -> None:
+    """Must be an ``in`` compare — a plain equality check would not honour
+    the tuple contract when multiple stop ids are configured."""
+    fn = _process_last_data_fn()
+    for cmp_node in [n for n in _walk(fn) if isinstance(n, ast.Compare)]:
+        if len(cmp_node.ops) != 1 or not isinstance(cmp_node.ops[0], ast.In):
+            continue
+        right = cmp_node.comparators[0]
+        if (
+            isinstance(right, ast.Attribute)
+            and right.attr == "stop_token_ids"
+        ):
+            return
+    raise AssertionError(
+        "Scheduler._process_last_data must check `next_token in "
+        "req.sampling_params.stop_token_ids`"
+    )
+
+
+def test_stop_token_check_does_not_gate_on_ignore_eos() -> None:
+    """The stop-token compare must not sit inside an `if not ignore_eos`
+    branch — ignore_eos governs only the EOS check, not user stop tokens.
+
+    We look at every ``In`` compare referencing stop_token_ids and walk its
+    ancestor If nodes; none of them may test ``ignore_eos``.
+    """
+    fn = _process_last_data_fn()
+
+    parent = {}
+    for n in _walk(fn):
+        for c in ast.iter_child_nodes(n):
+            parent[c] = n
+
+    def _walk_up(n):
+        while n in parent:
+            n = parent[n]
+            yield n
+
+    stop_cmps = []
+    for cmp_node in [n for n in _walk(fn) if isinstance(n, ast.Compare)]:
+        if len(cmp_node.ops) == 1 and isinstance(cmp_node.ops[0], ast.In):
+            right = cmp_node.comparators[0]
+            if isinstance(right, ast.Attribute) and right.attr == "stop_token_ids":
+                stop_cmps.append(cmp_node)
+    assert stop_cmps, "structural precondition: stop_token_ids compare must exist"
+
+    for cmp_node in stop_cmps:
+        for anc in _walk_up(cmp_node):
+            if not isinstance(anc, ast.If):
+                continue
+            names = [a.attr for a in _walk(anc.test) if isinstance(a, ast.Attribute)]
+            assert "ignore_eos" not in names, (
+                "stop_token_ids check must NOT be nested inside an ignore_eos guard"
+            )
+
+
+# ------------------------------------------------------------- behaviour harness
+
+
+class _FakeChunkedReq:  # sentinel — the guard on line 160 uses isinstance
+    """Stand-in for prefill.ChunkedReq — only the type identity is needed here."""
+
+
+class _FakeReq:
+    def __init__(
+        self,
+        *,
+        input_ids: List[int],
+        remain_after_append: int,
+        sampling_params: SamplingParams,
+        uid: int = 42,
+    ) -> None:
+        self.input_ids = torch.tensor(input_ids, dtype=torch.int32)
+        self._remain_after_append = remain_after_append
+        self.sampling_params = sampling_params
+        self.uid = uid
+        self.append_calls: List[int] = []
+        self.free_calls = 0
+
+    def append_host(self, next_token: torch.Tensor) -> None:
+        self.append_calls.append(int(next_token.item()))
+        self.input_ids = torch.cat([self.input_ids, next_token])
+
+    @property
+    def can_decode(self) -> bool:
+        return self._remain_after_append > 0
+
+
+class _FakeBatch:
+    def __init__(self, reqs, is_prefill: bool = False) -> None:
+        self.reqs = reqs
+        self.is_prefill = is_prefill
+
+
+class _FakeCopyEvent:
+    def synchronize(self) -> None:
+        return None
+
+
+class _FakeCacheMgr:
+    def __init__(self) -> None:
+        self.cache_calls: List[tuple] = []
+
+    @contextmanager
+    def lazy_free_region(self):
+        yield
+
+    def cache_req(self, req, *, finished: bool) -> None:
+        self.cache_calls.append((req, finished))
+
+
+class _FakeDecodeMgr:
+    def __init__(self) -> None:
+        self.removed: List = []
+
+    def remove_req(self, req) -> None:
+        self.removed.append(req)
+
+
+class _FakeTableMgr:
+    def __init__(self) -> None:
+        self.freed: List = []
+
+    def free(self, slot) -> None:
+        self.freed.append(slot)
+
+
+def _build_scheduler(reqs, is_prefill=False, eos_token_id: int = 99999):
+    """Assemble the minimal Scheduler surface `_process_last_data` touches."""
+    sched = Scheduler.__new__(Scheduler)  # bypass __init__ — no engine needed
+    sched.eos_token_id = eos_token_id
+    sched.cache_manager = _FakeCacheMgr()
+    sched.decode_manager = _FakeDecodeMgr()
+    sched.table_manager = _FakeTableMgr()
+    sched.finished_reqs = set()
+    sent: List[List[DetokenizeMsg]] = []
+    sched.send_result = lambda reply: sent.append(list(reply))
+
+    def _free_req_resources(req):
+        sched.table_manager.free(getattr(req, "table_idx", None))
+        sched.cache_manager.cache_req(req, finished=True)
+
+    sched._free_req_resources = _free_req_resources
+
+    # last_data[0] only needs a .batch attribute; last_data[1] must unpack as
+    # (_, next_tokens_cpu, copy_done). See Scheduler._process_last_data line 154.
+    class _FI:
+        pass
+
+    fi = _FI()
+    fi.batch = _FakeBatch(reqs, is_prefill=is_prefill)
+
+    next_tokens_cpu = torch.tensor(
+        [_pick_next_token(r) for r in reqs], dtype=torch.int32
+    )
+    output = (None, next_tokens_cpu, _FakeCopyEvent())
+    return sched, (fi, output), sent
+
+
+_NEXT_TOKEN_SLOT: dict = {}
+
+
+def _pick_next_token(req):
+    """Read the pre-programmed next_token for this req."""
+    return _NEXT_TOKEN_SLOT[id(req)]
+
+
+def _program_next_token(req, tok: int) -> None:
+    _NEXT_TOKEN_SLOT[id(req)] = tok
+
+
+# -------------------------------------------------------------------- rows
+
+
+def test_default_empty_tuple_matches_pre_2_1c_behavior() -> None:
+    """Default `stop_token_ids=()` must not cause any premature finish."""
+    sp = SamplingParams(max_tokens=8)
+    req = _FakeReq(input_ids=[3, 7], remain_after_append=5, sampling_params=sp)
+    _program_next_token(req, 42)
+    sched, last_data, sent = _build_scheduler([req])
+    Scheduler._process_last_data(sched, last_data)
+    assert len(sent) == 1 and len(sent[0]) == 1
+    msg = sent[0][0]
+    assert msg.next_token == 42
+    assert msg.finished is False
+    assert req.append_calls == [42]
+    # Not finished ⇒ no table free, no cache_req (batch is decode-flavored).
+    assert sched.table_manager.freed == []
+    assert sched.cache_manager.cache_calls == []
+
+
+def test_stop_token_hit_finishes_and_retains_token() -> None:
+    sp = SamplingParams(max_tokens=8, stop_token_ids=(11, 200))
+    # remain_after_append=3 -> can_decode=True -> only stop_token_ids can end this.
+    req = _FakeReq(input_ids=[3, 7], remain_after_append=3, sampling_params=sp)
+    _program_next_token(req, 11)
+    sched, last_data, sent = _build_scheduler([req])
+    Scheduler._process_last_data(sched, last_data)
+    msg = sent[0][0]
+    assert msg.next_token == 11
+    assert msg.finished is True
+    # The stop token was appended BEFORE the finish decision.
+    assert req.append_calls == [11]
+    assert req.input_ids.tolist()[-1] == 11
+    # Finished ⇒ scheduler frees the request.
+    assert sched.table_manager.freed == [None]  # table_idx wasn't set on fake
+    assert sched.cache_manager.cache_calls[0][1] is True  # finished=True
+
+
+def test_ignore_eos_true_still_honours_stop_token() -> None:
+    sp = SamplingParams(
+        max_tokens=8, ignore_eos=True, stop_token_ids=(11,)
+    )
+    req = _FakeReq(input_ids=[3, 7], remain_after_append=3, sampling_params=sp)
+    _program_next_token(req, 11)
+    sched, last_data, sent = _build_scheduler([req], eos_token_id=99999)
+    Scheduler._process_last_data(sched, last_data)
+    msg = sent[0][0]
+    assert msg.next_token == 11
+    assert msg.finished is True, (
+        "ignore_eos must silence only the tokenizer EOS check; explicit "
+        "stop_token_ids must still take effect"
+    )
+
+
+def test_ignore_eos_true_without_stop_token_never_finishes_on_eos_token() -> None:
+    """Regression guard: ignore_eos=True must still suppress the scalar EOS."""
+    sp = SamplingParams(max_tokens=8, ignore_eos=True, stop_token_ids=())
+    req = _FakeReq(input_ids=[3, 7], remain_after_append=3, sampling_params=sp)
+    _program_next_token(req, 99999)  # same value as fake eos_token_id below
+    sched, last_data, sent = _build_scheduler([req], eos_token_id=99999)
+    Scheduler._process_last_data(sched, last_data)
+    msg = sent[0][0]
+    assert msg.next_token == 99999
+    assert msg.finished is False
+
+
+def test_non_matching_next_token_keeps_running() -> None:
+    sp = SamplingParams(max_tokens=8, stop_token_ids=(11,))
+    req = _FakeReq(input_ids=[3, 7], remain_after_append=3, sampling_params=sp)
+    _program_next_token(req, 12)  # not in stop set
+    sched, last_data, sent = _build_scheduler([req])
+    Scheduler._process_last_data(sched, last_data)
+    msg = sent[0][0]
+    assert msg.finished is False
+    assert msg.next_token == 12
+    assert sched.table_manager.freed == []
+
+
+def test_max_tokens_still_finishes_regardless_of_stop_tokens() -> None:
+    """remain_after_append==0 -> can_decode=False -> finished True even when
+    stop_token_ids is empty."""
+    sp = SamplingParams(max_tokens=1, stop_token_ids=())
+    req = _FakeReq(input_ids=[3, 7], remain_after_append=0, sampling_params=sp)
+    _program_next_token(req, 42)
+    sched, last_data, sent = _build_scheduler([req])
+    Scheduler._process_last_data(sched, last_data)
+    msg = sent[0][0]
+    assert msg.finished is True
+    assert msg.next_token == 42
+
+
+def test_scalar_eos_still_finishes_when_ignore_eos_false() -> None:
+    """The pre-2.1c EOS path must remain intact."""
+    sp = SamplingParams(max_tokens=8, ignore_eos=False, stop_token_ids=())
+    req = _FakeReq(input_ids=[3, 7], remain_after_append=3, sampling_params=sp)
+    _program_next_token(req, 12345)
+    sched, last_data, sent = _build_scheduler([req], eos_token_id=12345)
+    Scheduler._process_last_data(sched, last_data)
+    msg = sent[0][0]
+    assert msg.finished is True
+    assert msg.next_token == 12345

--- a/tests/misc/test_scheduler_sync_all_ranks.py
+++ b/tests/misc/test_scheduler_sync_all_ranks.py
@@ -1,0 +1,182 @@
+"""Gate 1.11h — SchedulerIOMixin.sync_all_ranks must be a no-op when there is
+no CPU process group.
+
+The guard is orthogonal to device type: single-rank / offline hosts never build
+a ``torch.distributed.ProcessGroup`` regardless of accelerator, and calling
+``.barrier()`` on ``None`` is what previously blocked ``Scheduler.shutdown()``
+on a TP=1 NPU deployment. These tests pin three properties:
+
+1. ``sync_all_ranks`` with ``tp_cpu_group=None`` does not touch a barrier.
+2. ``sync_all_ranks`` with a real-looking group calls ``barrier`` and the
+   returned work object's ``wait`` exactly once each — the original TP>1
+   behaviour is preserved.
+3. ``Scheduler.shutdown`` on a TP=1 NPU (group=None) still routes device
+   synchronize through ``minisgl.utils.device_runtime.synchronize_device`` and
+   still tears down the engine — the sync_all_ranks no-op does not short-circuit
+   the rest of shutdown.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, List
+from unittest.mock import MagicMock
+
+import pytest
+
+# Ensure ``python/`` is discoverable so ``import minisgl.*`` resolves the real
+# source tree even when this file is run standalone. Other tests in this dir
+# rely on side-effects from ``test_ascend_fia_backend.py`` for the same insert.
+_PY_ROOT = Path(__file__).resolve().parents[2] / "python"
+if str(_PY_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PY_ROOT))
+
+
+def _purge_minisgl_from_sys_modules() -> None:
+    """Evict any ``minisgl*`` entries so behavioural tests get a clean re-import.
+
+    ``tests/misc/test_device_runtime.py`` installs stub ``minisgl`` /
+    ``minisgl.utils`` package objects at import time; leaving them in place
+    shadows the real package for later ``from minisgl.scheduler.io import ...``
+    resolution.
+    """
+    for name in list(sys.modules):
+        if name == "minisgl" or name.startswith("minisgl."):
+            del sys.modules[name]
+
+
+# ---------------------------------------------------------------------------
+# 1. sync_all_ranks with tp_cpu_group=None must not touch a barrier.
+# ---------------------------------------------------------------------------
+
+
+def test_sync_all_ranks_no_op_when_group_is_none() -> None:
+    _purge_minisgl_from_sys_modules()
+
+    from minisgl.scheduler.io import SchedulerIOMixin
+
+    # Build a bare mixin without running __init__ — we only test the guard.
+    holder = SchedulerIOMixin.__new__(SchedulerIOMixin)
+    holder.tp_cpu_group = None  # type: ignore[assignment]
+
+    # No exception, no attribute access on None — proves the guard fired.
+    holder.sync_all_ranks()
+
+
+# ---------------------------------------------------------------------------
+# 2. sync_all_ranks preserves original barrier().wait() call when group exists.
+# ---------------------------------------------------------------------------
+
+
+def test_sync_all_ranks_calls_barrier_then_wait_when_group_present() -> None:
+    _purge_minisgl_from_sys_modules()
+
+    from minisgl.scheduler.io import SchedulerIOMixin
+
+    call_log: List[str] = []
+
+    class _FakeWork:
+        def wait(self) -> None:
+            call_log.append("wait")
+
+    class _FakeGroup:
+        def barrier(self) -> _FakeWork:
+            call_log.append("barrier")
+            return _FakeWork()
+
+    holder = SchedulerIOMixin.__new__(SchedulerIOMixin)
+    holder.tp_cpu_group = _FakeGroup()  # type: ignore[assignment]
+
+    holder.sync_all_ranks()
+
+    # barrier then wait, each exactly once, in that order.
+    assert call_log == ["barrier", "wait"], call_log
+
+
+# ---------------------------------------------------------------------------
+# 3. Scheduler.shutdown on a TP=1 NPU (group=None) still synchronizes the
+#    device and shuts the engine down. The sync_all_ranks no-op is transparent
+#    to the surrounding shutdown sequence.
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_shutdown_with_none_group_still_runs_synchronize_and_engine_shutdown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("torch")
+    _purge_minisgl_from_sys_modules()
+
+    import minisgl.scheduler.scheduler as sched_mod
+    import minisgl.utils.device_runtime as dr
+
+    sync_calls: List[str] = []
+
+    def _fake_synchronize_device(dt: str) -> None:
+        sync_calls.append(dt)
+
+    monkeypatch.setattr(dr, "synchronize_device", _fake_synchronize_device)
+    monkeypatch.setattr(sched_mod, "synchronize_device", _fake_synchronize_device)
+
+    scheduler = sched_mod.Scheduler.__new__(sched_mod.Scheduler)
+    scheduler.device_type = "npu"
+    scheduler.engine = MagicMock()
+    # Real production state on a TP=1 NPU: Engine._init_communication returned
+    # None because tp_info.size == 1, so the mixin stored None into tp_cpu_group.
+    scheduler.tp_cpu_group = None  # type: ignore[attr-defined]
+
+    scheduler.shutdown()
+
+    # Device synchronize routed through device_runtime with the engine's dtype.
+    assert sync_calls == ["npu"], sync_calls
+    # Engine still torn down after the no-op barrier.
+    scheduler.engine.shutdown.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 4. Symmetric check — when a real group is attached, Scheduler.shutdown
+#    invokes barrier().wait() exactly once between synchronize_device and
+#    engine.shutdown. Guards against future regressions of the TP>1 path.
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_shutdown_with_real_group_still_barriers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("torch")
+    _purge_minisgl_from_sys_modules()
+
+    import minisgl.scheduler.scheduler as sched_mod
+    import minisgl.utils.device_runtime as dr
+
+    order: List[str] = []
+
+    def _fake_synchronize_device(dt: str) -> None:
+        order.append(f"sync:{dt}")
+
+    monkeypatch.setattr(dr, "synchronize_device", _fake_synchronize_device)
+    monkeypatch.setattr(sched_mod, "synchronize_device", _fake_synchronize_device)
+
+    class _FakeWork:
+        def wait(self) -> None:
+            order.append("wait")
+
+    class _FakeGroup:
+        def barrier(self) -> _FakeWork:
+            order.append("barrier")
+            return _FakeWork()
+
+    engine = MagicMock()
+
+    def _record_engine_shutdown() -> None:
+        order.append("engine_shutdown")
+
+    engine.shutdown.side_effect = _record_engine_shutdown
+
+    scheduler = sched_mod.Scheduler.__new__(sched_mod.Scheduler)
+    scheduler.device_type = "npu"
+    scheduler.engine = engine
+    scheduler.tp_cpu_group = _FakeGroup()  # type: ignore[attr-defined]
+
+    scheduler.shutdown()
+
+    assert order == ["sync:npu", "barrier", "wait", "engine_shutdown"], order

--- a/tests/utils/test_nvtx.py
+++ b/tests/utils/test_nvtx.py
@@ -1,0 +1,232 @@
+"""Gate 1.9j: hermetic tests for the CUDA/non-CUDA dispatch of nvtx_annotate.
+
+The decorator must:
+  * be a real no-op when torch.cuda.is_available() returns False
+    (no attribute access on torch.cuda.nvtx, no RuntimeError)
+  * preserve wraps metadata (__name__, __doc__)
+  * transparently forward args/kwargs, return value, and exceptions
+  * use torch.cuda.nvtx.range as a context manager when CUDA is available,
+    and its __exit__ must run even when the wrapped function raises
+  * not touch NVTX at import time nor at decorator construction time
+  * not depend on torch_npu
+"""
+from __future__ import annotations
+
+import ast
+import importlib
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+MODULE_PATH = "minisgl.utils.torch_utils"
+SOURCE_PATH = Path(__file__).resolve().parents[2] / "python" / "minisgl" / "utils" / "torch_utils.py"
+
+
+@pytest.fixture()
+def nvtx_annotate():
+    mod = importlib.import_module(MODULE_PATH)
+    return mod.nvtx_annotate
+
+
+# -------------------------------------------------------------------- helpers
+class _FakeNvtxRange:
+    """Context manager that records the exact ordering of __enter__/__exit__."""
+
+    def __init__(self, log: list[tuple], name: str):
+        self._log = log
+        self._name = name
+
+    def __enter__(self):
+        self._log.append(("enter", self._name))
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self._log.append(("exit", self._name, exc_type))
+        return False   # do NOT swallow exceptions
+
+
+class _FakeNvtx:
+    def __init__(self, log: list[tuple]):
+        self._log = log
+        self.range_call_count = 0
+
+    def range(self, name):
+        self.range_call_count += 1
+        return _FakeNvtxRange(self._log, name)
+
+
+class _Host:
+    """A container to hang decorated methods off of; exercises the ``self`` path."""
+
+
+# ================================================================== 1. no-CUDA
+def test_no_cuda_returns_value_and_forwards_args(nvtx_annotate):
+    @nvtx_annotate("Op")
+    def fn(self, a, b, *, kw):
+        return (a, b, kw)
+
+    host = _Host()
+    with mock.patch("torch.cuda.is_available", return_value=False):
+        result = fn(host, 1, 2, kw=99)
+    assert result == (1, 2, 99)
+
+
+def test_no_cuda_does_not_touch_torch_cuda_nvtx(nvtx_annotate):
+    """Under no-CUDA the decorator must never access torch.cuda.nvtx at all."""
+    @nvtx_annotate("Op")
+    def fn(self):
+        return "ok"
+
+    host = _Host()
+
+    # Sentinel that raises on ANY attribute access — proves the no-CUDA branch
+    # doesn't reach into the nvtx submodule.
+    class _Boom:
+        def __getattr__(self, item):
+            raise AssertionError(f"torch.cuda.nvtx.{item} was accessed under no-CUDA")
+
+    with mock.patch("torch.cuda.is_available", return_value=False), \
+         mock.patch("torch.cuda.nvtx", new=_Boom()):
+        assert fn(host) == "ok"
+
+
+def test_no_cuda_propagates_wrapped_exception(nvtx_annotate):
+    @nvtx_annotate("Op")
+    def fn(self):
+        raise ValueError("boom-no-cuda")
+
+    host = _Host()
+    with mock.patch("torch.cuda.is_available", return_value=False):
+        with pytest.raises(ValueError, match="boom-no-cuda"):
+            fn(host)
+
+
+# ================================================================== 2. metadata
+def test_functools_wraps_preserves_name_and_doc(nvtx_annotate):
+    @nvtx_annotate("Op")
+    def fn(self):
+        """my docstring"""
+        return None
+
+    assert fn.__name__ == "fn"
+    assert fn.__doc__ == "my docstring"
+
+
+# ================================================================== 3. fake CUDA
+def test_cuda_available_enters_and_exits_nvtx_range_once(nvtx_annotate):
+    log: list[tuple] = []
+    fake = _FakeNvtx(log)
+
+    @nvtx_annotate("Layer_{}", layer_id_field="_layer_id")
+    def fn(self):
+        log.append(("body", getattr(self, "_layer_id", None)))
+        return "done"
+
+    host = _Host()
+    host._layer_id = 7
+
+    with mock.patch("torch.cuda.is_available", return_value=True), \
+         mock.patch("torch.cuda.nvtx", new=fake):
+        out = fn(host)
+
+    assert out == "done"
+    assert fake.range_call_count == 1
+    # ordering: enter → body → exit
+    assert log == [("enter", "Layer_7"), ("body", 7), ("exit", "Layer_7", None)]
+
+
+def test_cuda_available_exits_range_when_function_raises(nvtx_annotate):
+    log: list[tuple] = []
+    fake = _FakeNvtx(log)
+
+    @nvtx_annotate("Op")
+    def fn(self):
+        log.append(("body-before-raise",))
+        raise RuntimeError("boom-cuda")
+
+    host = _Host()
+
+    with mock.patch("torch.cuda.is_available", return_value=True), \
+         mock.patch("torch.cuda.nvtx", new=fake):
+        with pytest.raises(RuntimeError, match="boom-cuda"):
+            fn(host)
+
+    # __exit__ must still fire; and it must observe the RuntimeError type.
+    assert ("enter", "Op") in log
+    assert log[-1][0] == "exit"
+    assert log[-1][1] == "Op"
+    assert log[-1][2] is RuntimeError
+    assert fake.range_call_count == 1
+
+
+def test_cuda_available_forwards_args_and_return(nvtx_annotate):
+    log: list[tuple] = []
+    fake = _FakeNvtx(log)
+
+    @nvtx_annotate("Op")
+    def fn(self, a, b, *, kw):
+        return (a * 10, b * 10, kw)
+
+    host = _Host()
+    with mock.patch("torch.cuda.is_available", return_value=True), \
+         mock.patch("torch.cuda.nvtx", new=fake):
+        assert fn(host, 1, 2, kw=3) == (10, 20, 3)
+
+
+# ================================================================== 4. import-time
+def test_import_does_not_touch_nvtx_or_query_is_available():
+    """Fresh import of the module must not call NVTX or torch.cuda.is_available."""
+    sys.modules.pop(MODULE_PATH, None)
+
+    is_available_calls = 0
+    nvtx_accesses: list[str] = []
+
+    real_is_available = None
+    try:
+        import torch  # noqa: F401 — ensure torch is importable
+        real_is_available = importlib.import_module("torch").cuda.is_available
+    except Exception:
+        pytest.skip("torch not importable in this environment")
+
+    def _tracked_is_available():
+        nonlocal is_available_calls
+        is_available_calls += 1
+        return False
+
+    class _NvtxTracker:
+        def __getattr__(self, item):
+            nvtx_accesses.append(item)
+            raise AssertionError(f"NVTX attr {item} accessed at import time")
+
+    with mock.patch("torch.cuda.is_available", new=_tracked_is_available), \
+         mock.patch("torch.cuda.nvtx", new=_NvtxTracker()):
+        importlib.import_module(MODULE_PATH)
+        # Construct a decorator (module-level effect equivalent) — must also
+        # be inert until the wrapped function is *called*.
+        mod = sys.modules[MODULE_PATH]
+        deco = mod.nvtx_annotate("Op")
+        @deco
+        def _f(self):
+            return None
+    assert is_available_calls == 0, "torch.cuda.is_available called at import/decorator time"
+    assert nvtx_accesses == [], f"NVTX touched at import/decorator time: {nvtx_accesses}"
+
+
+# ================================================================== 5. no torch_npu
+def test_source_does_not_import_torch_npu():
+    src = SOURCE_PATH.read_text()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert not alias.name.startswith("torch_npu"), \
+                    f"unexpected import: {alias.name}"
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            assert not mod.startswith("torch_npu"), \
+                f"unexpected from-import: {mod}"
+    # Belt-and-braces textual check
+    assert "torch_npu" not in src


### PR DESCRIPTION
## Summary
                                                                                                                                                                     
Cumulative Ascend NPU port PR — builds on #138. This PR takes the port from "single-request greedy" to "request lifecycle safe": multi-step generation, ragged + equal-length continuous batching, mixed-KV-length decode, transactional page allocation, sampler-commit atomicity, shutdown drain, overlap-safe abort, and end-to-end abort ack.                                                                                             
  
Public fork: https://github.com/Ray-RP/mini-sglang-ascend                                                                                                          
                                                                                                                                                                     
## What's in the PR (three signed gates, one PR)                                                                                                                   
                  
### Gate 2.1 — Single-request multistep runtime                                                                                                                    
Frozen at tag `gate2-multistep-scheduler`, verdict [`gate2_1_multistep_verdict.md`](https://github.com/Ray-RP/mini-sglang-ascend/blob/ascend-port/docs/ascend_port/gate2_1_multistep_verdict.md). 
                                                                                                                                                              
- Scheduler honours per-request `stop_token_ids`.
- `apache-tvm-ffi` moved to base deps (radix cache uses it on every device — Ascend install was previously broken by an invisible extras split, root-caused in Gate 2.1e).                                                                                              
                                                                                                                                                             
### Gate 2.2 — Multi-request batching                                                                                                                              
Frozen at tag `gate2-multirequest-batching`, verdict [`gate2_2_multirequest_verdict.md`](https://github.com/Ray-RP/mini-sglang-ascend/blob/ascend-port/docs/ascend_port/gate2_2_multirequest_verdict.md).                                                                                                               
                                                                                                                                                   
- `ascend_fia` supports equal-length B≥1 batches (Gate 2.2c).                                                                                                      
- Ragged prefill + pure-decode mixed-cached-length batches (Gate 2.2f).                                                                                            
                                                                                                                                                                     
### Gate 2.3 — Request lifecycle & cancel protocol                                                                                                                 
Frozen at commit `6742e30`, tag `gate2-request-lifecycle`, verdict [`gate2_3_request_lifecycle_verdict.md`](https://github.com/Ray-RP/mini-sglang-ascend/blob/ascend-port/docs/ascend_port/gate2_3_request_lifecycle_verdict.md).
       
- 2.3b: transactional page allocation rollback in `_prepare_batch` —  `prepare_metadata` failure returns every KV page the failing batch newly allocated, allocator invariants unchanged, retained-prefix rows untouched.                                                                                            
- 2.3c: atomic request-state commit past the sampler in `forward_batch`— sampler-stage failure leaves the request uncommitted; no partial- token state escapes.                                                                                            
- 2.3d: shutdown-time drain of pending + running requests.                                                                                                         
- 2.3e: overlap-loop abort fence between the compute and post-processing stages.                                                                                           
- 2.3f: end-to-end abort acknowledgement via `AbortAckMsg` / `AbortAckReply`.                                                                                                      

## Evidence                                                                                                                                                        
                  
Six hermetic test files locked to Gate 2.3 (see verdict §11):                                                                                                      
                  
- `tests/misc/test_scheduler_prepare_batch_txn.py`                                                                                                                 
- `tests/misc/test_engine_forward_sampler_atomic.py`
- `tests/misc/test_scheduler_shutdown_drain.py`
- `tests/misc/test_scheduler_overlap_abort_fence.py`                                                                                                               
- `tests/misc/test_scheduler_abort_ack.py`
- `tests/misc/test_pyproject_config.py`                                                                                                                            
                  
Plus 910B1 fault-injection probes A–E in the Gate 2.3g section of the verdict (rollback survives, sampler atomicity holds, shutdown drains pending+running, overlap abort fences correctly, AbortAck round-trips).                                                                                             
         
## Explicitly out of scope for this PR                                                                                                                             
                  
- TP > 1 on NPU (still init-only).                                                                                                                                 
- Only Qwen3-0.6B has been driven end-to-end.
- Full HTTP + ZMQ multi-process API server path is not frozen — every guarantee above was proven with the in-process offline driver plus the committed hermetic tests.                                                                                            
- No long-duration soak; no performance-leadership claim.                                                                                                          
                                                                                                                                                                     
## Test plan    
                                                                                                                                                                     
Run all six hermetic files on the 910B1 host:

  ```bash
  pytest -q -o addopts="" tests/misc/test_scheduler_prepare_batch_txn.py
  pytest -q -o addopts="" tests/misc/test_engine_forward_sampler_atomic.py                                                                                           
  pytest -q -o addopts="" tests/misc/test_scheduler_shutdown_drain.py                                                                                                
  pytest -q -o addopts="" tests/misc/test_scheduler_overlap_abort_fence.py                                                                                           
  pytest -q -o addopts="" tests/misc/test_scheduler_abort_ack.py                                                                                                     
  pytest -q -o addopts="" tests/misc/test_pyproject_config.py
 ```
                                                                                                                                                                
Verified totals: 47 tests, 47 pass (Gate 2.3 merge closure).                                                                                                       
                                                                                                                                                                     
## Notes for upstream reviewers                                                                                                                                       
                  
The lifecycle safety changes (2.3b–2.3f) are CUDA-agnostic — they harden the scheduler's transactional boundaries independent of device. If upstream is only interested in a subset, the rollback + sampler- atomicity commits (d520a71, f56ce2a) are the smallest self- contained pair and both ship with dedicated hermetic tests.                                                                                              
