### PR TITLE
Fix radix cache duplicate prefix remapping

### DIFF
--- a/python/minisgl/scheduler/cache.py
+++ b/python/minisgl/scheduler/cache.py
@@ -70,8 +70,14 @@ class CacheManager:
         cached_len, new_handle = self.prefix_cache.insert_prefix(insert_ids, page_indices)
         # unlock until all operations on handle is done
         self.unlock(old_handle)
-        # this part is already in the prefix cache, free it
-        self._free(page_indices[old_handle.cached_len : cached_len])
+        duplicate_indices = page_indices[old_handle.cached_len : cached_len]
+        if not finished and cached_len > old_handle.cached_len:
+            duplicate_indices = duplicate_indices.clone()
+            matched_indices = new_handle.get_matched_indices()
+            page_indices[old_handle.cached_len : cached_len].copy_(
+                matched_indices[old_handle.cached_len : cached_len]
+            )
+        self._free(duplicate_indices)
         if finished:  # this tail part should be freed
             self._free(page_indices[new_handle.cached_len :])
         else:  # keep the tail part, update the handle


### PR DESCRIPTION
## Summary

This PR fixes radix prefix cache handling for unfinished requests.

When `CacheManager.cache_req()` inserts a request prefix into the radix cache, part of the current request's computed prefix may already exist in the cache. The previous logic freed those duplicate request-local pages directly, but the request's `page_table` could still point to the freed pages. Later decode steps could then read KV pages that had already been returned to the free pool and potentially reused.

This PR remaps the unfinished request's `page_table` entries to the canonical radix-cache page indices before freeing the duplicate request-local pages.

## Validation

Validated with Qwen3-32B AIME26 repeat testing using radix cache.