### PR TITLE
Fix attention backend auto-detection for consumer Blackwell (sm120)

### DIFF
--- a/python/minisgl/engine/engine.py
+++ b/python/minisgl/engine/engine.py
@@ -11,7 +11,14 @@ from minisgl.kvcache import create_kvcache_pool
 from minisgl.layers import set_rope_device
 from minisgl.models import create_model, load_weight
 from minisgl.moe import create_moe_backend
-from minisgl.utils import div_even, init_logger, is_sm90_supported, is_sm100_supported, torch_dtype
+from minisgl.utils import (
+    div_even,
+    init_logger,
+    is_sm90_supported,
+    is_sm100_supported,
+    is_sm120_supported,
+    torch_dtype,
+)
 
 from .config import EngineConfig
 from .graph import GraphRunner, get_free_memory, mem_GB
@@ -220,7 +227,14 @@ def _adjust_config(config: EngineConfig):
         object.__setattr__(config, attr, value)
 
     if config.attention_backend == "auto":
-        backend = "trtllm" if is_sm100_supported() else ("fa,fi" if is_sm90_supported() else "fi")
+        if is_sm120_supported():
+            backend = "fi"
+        elif is_sm100_supported():
+            backend = "trtllm"
+        elif is_sm90_supported():
+            backend = "fa,fi"
+        else:
+            backend = "fi"
         override("attention_backend", backend)
         logger.info_rank0(f"Auto-selected attention backend: {config.attention_backend}")
 

--- a/python/minisgl/utils/__init__.py
+++ b/python/minisgl/utils/__init__.py
@@ -1,4 +1,4 @@
-from .arch import is_arch_supported, is_sm90_supported, is_sm100_supported
+from .arch import is_arch_supported, is_sm90_supported, is_sm100_supported, is_sm120_supported
 from .hf import cached_load_hf_config, download_hf_weight, load_tokenizer
 from .logger import init_logger
 from .misc import UNSET, Unset, align_ceil, align_down, call_if_main, div_ceil, div_even
@@ -21,6 +21,7 @@ __all__ = [
     "is_arch_supported",
     "is_sm90_supported",
     "is_sm100_supported",
+    "is_sm120_supported",
     "call_if_main",
     "div_even",
     "div_ceil",

--- a/python/minisgl/utils/arch.py
+++ b/python/minisgl/utils/arch.py
@@ -27,3 +27,9 @@ def is_sm90_supported() -> bool:
 
 def is_sm100_supported() -> bool:
     return is_arch_supported(10, 0)
+
+
+def is_sm120_supported() -> bool:
+    # Consumer Blackwell (sm120) numerically passes the sm100 check but doesn't support
+    # trtllm-gen/FA4 kernels, which target datacenter Blackwell (sm100/B200) only.
+    return is_arch_supported(12, 0)


### PR DESCRIPTION
Found this issue on my 5080. 
## Motivition 
is_sm100_supported() in python/minisgl/utils/arch.py uses a plain compute_capability >= (10, 0) check to decide GPU support tiers. Consumer Blackwell GPUs (RTX 50-series, sm120) satisfy that check numerically, so they get misdetected as datacenter Blackwell (sm100/B200) and the engine auto-selects the trtllm attention backend. But trtllm's underlying kernels (flashinfer's TensorRT-LLM-Gen FMHA) are only built for Hopper/datacenter-Blackwell — they don't support sm120 at all, so the server crashes immediately on startup with RuntimeError: ... Unsupported architecture in fmhaRunner.cuh. This makes mini-sglang unusable out of the box on any RTX 50-series card with the default --attention-backend auto.

## Goal

Make auto backend selection correctly detect consumer Blackwell as its own tier and route it to the portable fi (FlashInfer) backend instead of trtllm, so RTX 50-series users get a working server out of the box without needing to manually pass --attention-backend fi.