### PR TITLE
Fix: Warm up radix AOT kernels during engine init

### DIFF
--- a/python/minisgl/engine/engine.py
+++ b/python/minisgl/engine/engine.py
@@ -82,6 +82,12 @@ class Engine:
         # ======================= Sampler initialization ========================
         self.sampler = Sampler(self.device, config.model_config.vocab_size)
 
+        # Prefetch radix AOT kernels so the first prefix match does not compile mid-request.
+        from minisgl.kernel import warmup_radix_kernels
+
+        # NOTE: this is a hack to warm up the radix AOT kernels so the first prefix match does not compile mid-request
+        warmup_radix_kernels()
+
         post_free_memory = self._sync_get_memory()[0]
         logger.info_rank0(f"Free memory after initialization: {mem_GB(post_free_memory)}")
 

--- a/python/minisgl/kernel/__init__.py
+++ b/python/minisgl/kernel/__init__.py
@@ -1,13 +1,14 @@
 from .index import indexing
 from .moe_impl import fused_moe_kernel_triton, moe_sum_reduce_triton
 from .pynccl import PyNCCLCommunicator, init_pynccl
-from .radix import fast_compare_key
+from .radix import fast_compare_key, warmup_radix_kernels
 from .store import store_cache
 from .tensor import test_tensor
 
 __all__ = [
     "indexing",
     "fast_compare_key",
+    "warmup_radix_kernels",
     "store_cache",
     "test_tensor",
     "init_pynccl",

--- a/python/minisgl/kernel/radix.py
+++ b/python/minisgl/kernel/radix.py
@@ -15,6 +15,11 @@ def _load_radix_module() -> Module:
     return load_aot("radix", cpp_files=["radix.cpp"])
 
 
+def warmup_radix_kernels() -> None:
+    """Eagerly compile/load radix AOT kernels to avoid first-match latency."""
+    _load_radix_module()
+
+
 def fast_compare_key(x: torch.Tensor, y: torch.Tensor) -> int:
     # compare 2 1-D int cpu tensors for equality
     return _load_radix_module().fast_compare_key(x, y)


### PR DESCRIPTION
# Warm up radix AOT kernels during engine init

## Motivation

First successful radix prefix match previously triggered `load_aot("radix")` lazily inside `fast_compare_key` / `get_match_len`. That one-time C++ AOT compile could land in the serving critical path — observed under Nsight as `Sched.process_last` → `cache_req` → `insert_prefix` / tree walk stalling for ~3.7s on a short prefix (`len=768`), even though the walk itself should be millisecond-scale.

This PR moves that compile to **Engine initialization**, so the cost is paid at startup/warmup instead of the first finish/cache path. The default algorithm and lazy `_load_radix_module` cache are unchanged; we only eagerly invoke the existing loader.

## Modifications

- `python/minisgl/kernel/radix.py` — add `warmup_radix_kernels()` that calls `_load_radix_module()` (same `load_aot("radix", cpp_files=["radix.cpp"])` path).
- `python/minisgl/kernel/__init__.py` — export `warmup_radix_kernels`.
- `python/minisgl/engine/engine.py` — call `warmup_radix_kernels()` after Sampler init, before CUDA graph capture.

No Scheduler / CacheManager / serving API changes. Debug NVTX ranges used during investigation were **not** included.

## Accuracy Tests

N/A for functional output — this only changes **when** the radix compare kernel is compiled, not verification or sampling logic. Prefix cache match/insert behavior is unchanged after the module is loaded.

## Speed Tests and Profiling

- **Environment:** RTX 4090, Ubuntu, Docker (`minisgl` image) with host Nsight Systems (`nsys`); workload is offline `benchmark/offline/bench.py` (Qwen3-0.6B), Python sources bind-mounted into the container for the profiled runs.
- 
<img width="1390" height="782" alt="Before Nsys GUI shotcut" src="https://github.com/user-attachments/assets/d6013f7e-3517-4bb8-9793-a6a116cba001" />

- **Before:** first radix tree walk that actually compares keys could show ~3–4s wall time under nsys (compile attributed into the NVTX range around `insert_prefix` / tree walk during `process_last`).

<img width="1390" height="782" alt="After Nsys GUI shotcut" src="https://github.com/user-attachments/assets/f5c45e27-d550-4920-80b2-9a7ce16cedeb" />

-  **After:** same `load_aot` cost moves to Engine init (`Warming up radix AOT kernels...`); subsequent `process_last` / tree walks stay at normal ms-scale for short prefixes.
- Steady-state tok/s should be unaffected once the module is warm; only cold-start / first-match latency changes.

## Known limitations / follow-ups

- Warmup always runs in `Engine.__init__`, including `cache_type=naive` (Engine does not see `cache_type`). A tighter hook would be `RadixPrefixCache.__init__` / `create_radix_cache` only.
- Does not prebuild a persistent on-disk artifact beyond whatever `tvm_ffi`/`load_aot` already caches; first process after a clean cache may still compile at init.

## Checklist

- [x] Code formatted (pre-commit).
- [ ] Unit tests added (optional smoke: call `warmup_radix_kernels()` twice, assert second is cheap / cached).
- [ ] Documentation updated (optional one-liner in structures / README JIT note).
- [x] Accuracy + speed results provided (profiling-based; before/after first-match stall).
- [x] Naming/code style follows existing `minisgl.kernel` / Engine init patterns.
