### PR TITLE
Add OLMo3 hybrid attention and TP support

### DIFF
--- a/docs/olmo3-phase1.md
+++ b/docs/olmo3-phase1.md
@@ -1,0 +1,90 @@
+# OLMo3 phase 1
+
+This phase adds a single-GPU (`TP=1`) OLMo 3 execution path on top of
+Mini-SGLang commit `9a91cfafe754aa85daee49998176275667eb58f2`.
+
+## Scope
+
+- Register `Olmo3ForCausalLM` and load the official model configuration.
+- Implement the OLMo 3 Post-Norm decoder order.
+- Apply projection-wide Q/K RMSNorm without changing Qwen's per-head behavior.
+- Use ordinary RoPE for sliding layers and YaRN, including its attention factor,
+  for full-attention layers.
+- Select a 4096-token causal sliding window or full attention per layer in both
+  FlashAttention and FlashInfer.
+- Preserve the complete KV cache. Physical sliding-window KV eviction is not part
+  of this phase.
+
+Tensor parallel OLMo 3 is deliberately rejected for now. Its projection-wide
+Q/K RMSNorm requires cross-rank statistics and must not silently use local-only
+statistics.
+
+## Remote environment
+
+The validated checkout is `/root/autodl-tmp/mini-sglang` on the AutoDL server.
+The environment uses Python 3.12, PyTorch 2.8.0+cu128, Transformers 4.57.3, and
+FlashInfer 0.6.16.post2 on an RTX 4090 (SM 8.9).
+
+Use the persistent disk for caches. The official Hugging Face endpoint was not
+reachable from this server, so configuration downloads used the mirror:
+
+```bash
+source /etc/network_turbo
+source /root/autodl-tmp/mini-sglang/.venv/bin/activate
+export HF_HOME=/root/autodl-tmp/huggingface
+export HF_ENDPOINT=https://hf-mirror.com
+export PIP_CACHE_DIR=/root/autodl-tmp/pip-cache
+export FLASHINFER_WORKSPACE_BASE=/root/autodl-tmp/flashinfer
+```
+
+On this machine Mini-SGLang's automatic backend selection correctly chooses
+FlashInfer. `sgl_kernel==0.3.17.post1` imports with PyTorch 2.8, but its
+FlashAttention submodule currently fails in the installed CUTLASS DSL. The
+FlashAttention code path is implemented and unit-tested, but phase 1 GPU
+validation therefore uses FlashInfer.
+
+## Verification
+
+Run only the focused tests; the project-wide pytest defaults enable coverage and
+are unnecessary for this phase:
+
+```bash
+pytest -q -o addopts='' \
+  tests/models/test_olmo3_config.py \
+  tests/models/test_olmo3_post_norm.py \
+  tests/layers/test_olmo3_attention.py \
+  tests/layers/test_olmo3_rotary.py \
+  tests/attention/test_olmo3_window.py
+```
+
+Validated results:
+
+- 12 focused tests passed in 3.19 seconds.
+- YaRN cache values matched Transformers 4.57.3 at positions 0, 1, 8191,
+  and 8192 (maximum observed error: 0).
+- The official 32-layer configuration matched the expected
+  `[sliding, sliding, sliding, full] * 8` layout.
+- Official checkpoint keys reduce from 355 to 259 after the existing QKV and
+  gate/up merges, exactly matching the model skeleton's 259 state-dict keys.
+- A direct FlashInfer boundary check confirmed `window_left=4095`: at query
+  position 4096, key 0 is excluded while the full-attention path includes it.
+- A dummy-weight, single-request GPU smoke test completed prefill and one-token
+  generation with CUDA graphs disabled.
+- A second dummy-weight smoke completed two-token generation through CUDA graph
+  capture and decode replay.
+
+The dummy-weight smokes do not establish numerical agreement with the official
+checkpoint. The roughly 14.6 GB model download and Transformers logits comparison
+are intentionally deferred to avoid spending bandwidth and GPU time before the
+implementation shape is stable.
+
+## Known limitations
+
+- `TP=2` is not implemented for OLMo 3.
+- Official BF16 weights and Hugging Face logits have not yet been compared.
+- The FlashAttention GPU path is blocked by the current `sgl_kernel`/CUTLASS
+  environment; FlashInfer is the validated RTX 4090 path.
+- Full KV is retained for sliding layers, so phase 1 provides attention semantics
+  but not sliding-cache memory savings.
+- Upstream currently expands `cuda_graph_max_bs=1` to capture batch sizes
+  `[1, 2, 4]`; use `cuda_graph_bs=[1]` when an exact one-size capture is needed.

--- a/docs/olmo3-phase2.md
+++ b/docs/olmo3-phase2.md
@@ -1,0 +1,85 @@
+# OLMo3 phase 2: official-weight alignment
+
+Phase 2 validates the phase-1 `TP=1` implementation against the official BF16
+checkpoint. It is a correctness check, not a performance benchmark.
+
+## Fixed inputs
+
+- Model: `allenai/Olmo-3-7B-Instruct`
+- Snapshot revision: `6e5971d9eba42665f5bd5a0fcf047f299ce1dccc`
+- Local snapshot: `/root/autodl-tmp/models/Olmo-3-7B-Instruct`
+- Prompt: `Answer with one word: what is the capital of France?`
+- Chat-template input length: 48 tokens
+- Precision: BF16
+- GPU: one RTX 4090
+
+The three safetensors files have 355 tensors and 7,298,011,136 parameters. Their
+SHA-256 values match the Hugging Face LFS metadata, every tensor is BF16, and the
+index has no missing or extra keys.
+
+## Procedure
+
+HF Transformers and Mini-SGLang run in separate processes so that the two 7B
+models never occupy the GPU together. Both use the same local snapshot and run
+offline. CUDA graphs and overlap scheduling are disabled for this one comparison.
+
+```bash
+export CUDA_VISIBLE_DEVICES=0
+export HF_HUB_OFFLINE=1
+export TRANSFORMERS_OFFLINE=1
+export MINISGL_DISABLE_OVERLAP_SCHEDULING=1
+
+python tools/olmo3/hf_reference.py \
+  /root/autodl-tmp/models/Olmo-3-7B-Instruct \
+  /root/autodl-tmp/olmo3-validation/hf_reference.pt
+
+python tools/olmo3/mini_reference.py \
+  /root/autodl-tmp/models/Olmo-3-7B-Instruct \
+  /root/autodl-tmp/olmo3-validation/hf_reference.pt \
+  /root/autodl-tmp/olmo3-validation/mini_reference.pt
+
+python tools/olmo3/compare_references.py \
+  /root/autodl-tmp/olmo3-validation/hf_reference.pt \
+  /root/autodl-tmp/olmo3-validation/mini_reference.pt \
+  --json-output /root/autodl-tmp/olmo3-validation/metrics.json
+```
+
+Only the first prefill logits and four greedy tokens are retained. The result
+files are small and no latency or throughput measurements are collected.
+
+## Result
+
+```json
+{
+  "argmax_match": true,
+  "greedy_tokens_match": true,
+  "hf_token_ids": [60704, 100257, 100264, 78191],
+  "mini_token_ids": [60704, 100257, 100264, 78191],
+  "cosine_similarity": 0.9999091029167175,
+  "mean_absolute_error": 0.024406513199210167,
+  "max_absolute_error": 0.125,
+  "top20_overlap": 20,
+  "hf_top1_margin": 5.625
+}
+```
+
+All acceptance thresholds passed: identical argmax and four-token sequence,
+cosine similarity at least 0.999, mean absolute error at most 0.05, maximum
+absolute error at most 0.5, and top-20 overlap at least 18.
+
+## Additional fix
+
+The official generation configuration has two EOS tokens: `<|endoftext|>`
+(`100257`) and `<|im_end|>` (`100265`). Mini-SGLang now loads the complete EOS
+set and uses it consistently in the scheduler, offline LLM output, and online
+detokenizer instead of recognizing only the tokenizer's primary EOS token.
+
+## Remaining scope
+
+- OLMo3 `TP=2` remains intentionally unsupported until projection-wide Q/K
+  RMSNorm has correct cross-rank statistics.
+- Sliding layers retain full KV storage; physical window eviction is not part of
+  this phase.
+- The FlashInfer path is the validated RTX 4090 backend. FlashAttention remains
+  blocked by the current `sgl_kernel`/CUTLASS environment.
+- No benchmark matrix was run.

--- a/docs/olmo3-phase3.md
+++ b/docs/olmo3-phase3.md
@@ -1,0 +1,88 @@
+# OLMo3 phase 3: tensor parallel correctness
+
+Phase 3 adds correct OLMo3 tensor parallel execution for the official 7B model
+and validates `TP=2` against the phase-2 HF and Mini-SGLang `TP=1` references.
+It does not include performance benchmarking.
+
+## Implementation
+
+OLMo3 applies Q/K RMSNorm across each complete projection before reshaping into
+heads. With tensor parallelism, every rank owns only a contiguous projection
+shard. `DistributedRMSNorm` therefore computes a local FP32 square sum, performs
+a cross-rank SUM all-reduce, divides by the full projection width, and applies
+the corresponding local weight shard. Q/K activations are never all-gathered.
+
+The official OLMo3 7B projections are 4096 elements wide. At `TP=2`, each rank
+holds 2048 Q-Norm and K-Norm weights. The loader shards only OLMo3 keys matching
+`self_attn.q_norm.weight` or `self_attn.k_norm.weight`; Qwen3's replicated
+per-head norms remain unchanged.
+
+Existing Mini-SGLang TP behavior is reused for QKV, O projection, MLP,
+embedding, and LM head. Models whose KV head count is smaller than TP size are
+explicitly rejected until replicated-KV normalization is implemented.
+
+PyNCCL does not currently support the FP32 distributed statistics required by
+this normalization. OLMo3 with `TP>1` therefore automatically selects standard
+`torch.distributed` NCCL, which is the validated communication path.
+
+## Validation environment
+
+- Two RTX 4090 GPUs connected through PCIe PXB, without NVLink or P2P access.
+- `NCCL_P2P_DISABLE=1` and `NCCL_IB_DISABLE=1` force the supported fallback.
+- FlashInfer attention backend.
+- BF16 official snapshot revision
+  `6e5971d9eba42665f5bd5a0fcf047f299ce1dccc`.
+- One 48-token input and four greedy output tokens.
+- CUDA graphs and overlap scheduling disabled for the comparison.
+
+The reproducible entry point is `tools/olmo3/tp_reference.py`. It launches two
+offline scheduler processes, binds one process to each GPU, and saves rank 0's
+first prefill logits and four sampled tokens.
+
+## Result
+
+All HF, `TP=1`, and `TP=2` greedy token IDs are identical:
+
+```text
+[60704, 100257, 100264, 78191]
+```
+
+HF versus `TP=2`:
+
+```json
+{
+  "cosine_similarity": 0.9999080300331116,
+  "mean_absolute_error": 0.023565489798784256,
+  "max_absolute_error": 0.21875,
+  "top20_overlap": 20,
+  "argmax_match": true,
+  "greedy_tokens_match": true
+}
+```
+
+Mini-SGLang `TP=1` versus `TP=2`:
+
+```json
+{
+  "cosine_similarity": 0.9998343586921692,
+  "mean_absolute_error": 0.03872865438461304,
+  "max_absolute_error": 0.1875,
+  "top20_overlap": 20,
+  "argmax_match": true,
+  "greedy_tokens_match": true
+}
+```
+
+Both comparisons pass the fixed correctness thresholds. Result files are stored
+under `/root/autodl-tmp/olmo3-validation/` as `tp2_reference.pt`,
+`tp2-vs-hf.json`, and `tp2-vs-tp1.json`.
+
+## Remaining limitations
+
+- Standard NCCL is the validated TP2 communication path; PyNCCL is automatically
+  disabled for OLMo3 TP until it supports FP32 statistics.
+- OLMo3 configurations requiring replicated KV heads remain unsupported.
+- Sliding layers retain full KV storage.
+- FlashAttention remains blocked by the current `sgl_kernel`/CUTLASS setup;
+  FlashInfer is the validated RTX 4090 backend.
+- No throughput, latency, concurrency, or long-context benchmark was run.

--- a/docs/olmo3-phase4.md
+++ b/docs/olmo3-phase4.md
@@ -1,0 +1,62 @@
+# OLMo3 phase 4: scheduler and API smoke
+
+Phase 4 closes the smallest useful system-level validation surface before
+publication. It intentionally combines related features into two short smoke
+tests instead of creating a benchmark matrix.
+
+## Scheduler integration
+
+`tools/olmo3/system_smoke.py` loads the official model once with FlashInfer,
+Radix Cache, a two-request limit, and a 64-token prefill budget. It submits two
+identical 48-token requests together and then submits the same prefix once more.
+
+Validated properties:
+
+- Both initial requests produce the same first greedy token as the saved HF
+  reference.
+- The maximum prefill batch size is two, exercising batching.
+- Three prefill forwards are required, exercising chunked prefill under the
+  fixed token budget.
+- The repeated request matches 47 cached prefix tokens.
+- CacheManager integrity passes after all requests finish.
+
+```text
+OLMO3_SYSTEM_SMOKE=passed
+prefill_calls=3
+max_prefill_batch=2
+radix_cached_tokens=47
+```
+
+## OpenAI-compatible API
+
+`tools/olmo3/run_api_smoke.sh` starts a temporary `TP=2` server and always
+terminates its complete process group. `tools/olmo3/api_smoke.py` validates:
+
+- `GET /v1/models` returns the local OLMo3 model.
+- Non-streaming `POST /v1/chat/completions` returns HTTP 200, `Paris`, and
+  `finish_reason="stop"`.
+- The streaming endpoint returns the assistant role, the same combined content,
+  one final stop chunk, and one `[DONE]` marker.
+- Neither configured EOS token is exposed in response text.
+
+```text
+OLMO3_API_SMOKE=passed content='Paris'
+```
+
+The API test uses the same standard-NCCL fallback as the validated TP2 path.
+After shutdown both GPUs return to 1 MiB used memory and no Mini-SGLang or
+Uvicorn worker remains.
+
+## Publication fixes
+
+The final review also made three compatibility corrections:
+
+- Distributed Q/K RMSNorm now multiplies the local weight in FP32 and performs
+  only one final cast, matching Transformers OLMo3.
+- OLMo3 `TP>1` automatically disables PyNCCL because its all-reduce path does
+  not support the required FP32 statistics.
+- Multi-EOS loading falls back to `GenerationConfig.from_model_config` when a
+  separate `generation_config.json` is unavailable, while retaining the legacy
+  single `eos_token_id` attribute.
+
+No throughput, latency, concurrency-scale, or long-context benchmark was run.

--- a/python/minisgl/attention/fa.py
+++ b/python/minisgl/attention/fa.py
@@ -62,7 +62,21 @@ class FlashAttentionBackend(BaseAttnBackend):
             max_seqlen_q=metadata.max_seqlen_q,
             softmax_scale=self.scale,
             version=self.version,
+            window_size=self._window_size(layer_id),
         )
+
+    def _window_size(self, layer_id: int) -> Tuple[int, int]:
+        if self.config.model_type != "olmo3":
+            return (-1, -1)
+        assert self.config.layer_types is not None
+        layer_type = self.config.layer_types[layer_id]
+        if layer_type == "full_attention":
+            return (-1, -1)
+        assert layer_type == "sliding_attention"
+        assert self.config.sliding_window is not None
+        # FlashAttention window endpoints are inclusive, so a 4096-token
+        # causal window uses 4095 tokens to the left plus the current token.
+        return (self.config.sliding_window - 1, 0)
 
     def prepare_metadata(self, batch: Batch) -> None:
         reqs = batch.padded_reqs

--- a/python/minisgl/attention/fi.py
+++ b/python/minisgl/attention/fi.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
 from typing import TYPE_CHECKING, Dict, List, Literal
 
@@ -58,8 +58,8 @@ class FIMetadata(BaseAttnMetadata):
     pos_encoding_mode:  str
     seq_lens_cpu:       torch.Tensor  # on cpu
     dtype:              torch.dtype
-    wrapper:            BatchPrefillWithPagedKVCacheWrapper | BatchDecodeWithPagedKVCacheWrapper
-    initialized:        bool = False
+    wrappers:           Dict[str, BatchPrefillWithPagedKVCacheWrapper | BatchDecodeWithPagedKVCacheWrapper]
+    initialized:        set[str] = field(default_factory=set)
     # fmt: on
 
     def __post_init__(self) -> None:
@@ -90,21 +90,28 @@ class FlashInferBackend(BaseAttnBackend):
         self.float_workspace_buffer = torch.empty(
             128 * 1024 * 1024, dtype=torch.uint8, device=self.device
         )
-        self.prefill_wrapper = BatchPrefillWithPagedKVCacheWrapper(
-            self.float_workspace_buffer,
-            kv_layout="NHD",
-            backend="fa2",  # flashinfer fa3 is slow, use fa2 instead
+        self.attention_types = (
+            ("sliding_attention", "full_attention")
+            if config.model_type == "olmo3"
+            else ("full_attention",)
         )
-        self.decode_wrappers = BatchDecodeWithPagedKVCacheWrapper(
-            self.float_workspace_buffer,
-            use_tensor_cores=self.use_tensor_cores,
-            kv_layout="NHD",
-            backend="fa2",  # flashinfer fa3 is slow, use fa2 instead
-        )
-
-        # NOTE: some hack to reuse the int_workspace_buffer
-        self.int_workspace_buffer = self.prefill_wrapper._int_workspace_buffer
-        self.decode_wrappers._int_workspace_buffer = self.int_workspace_buffer
+        self.prefill_wrappers = {
+            attention_type: BatchPrefillWithPagedKVCacheWrapper(
+                self.float_workspace_buffer,
+                kv_layout="NHD",
+                backend="fa2",  # flashinfer fa3 is slow, use fa2 instead
+            )
+            for attention_type in self.attention_types
+        }
+        self.decode_wrappers = {
+            attention_type: BatchDecodeWithPagedKVCacheWrapper(
+                self.float_workspace_buffer,
+                use_tensor_cores=self.use_tensor_cores,
+                kv_layout="NHD",
+                backend="fa2",  # flashinfer fa3 is slow, use fa2 instead
+            )
+            for attention_type in self.attention_types
+        }
 
         # initialize some data members
         tp_size = get_tp_info().size
@@ -115,23 +122,38 @@ class FlashInferBackend(BaseAttnBackend):
         # for cuda graph
         self.capture_bs: List[int] = []
         self.max_graph_bs = 0
-        self.graph_wrappers: Dict[int, CUDAGraphBatchDecodeWithPagedKVCacheWrapper] = {}
+        self.graph_wrappers: Dict[
+            tuple[int, str], CUDAGraphBatchDecodeWithPagedKVCacheWrapper
+        ] = {}
         self.capture: FICaptureData | None = None
         self.last_event = torch.cuda.Event()
         self.last_event.record()
 
-    def _initialize_metadata_once(self, metadata: FIMetadata) -> None:
-        if metadata.initialized:
+    def _window_left(self, attention_type: str) -> int:
+        if attention_type == "full_attention":
+            return -1
+        assert attention_type == "sliding_attention"
+        assert self.config.sliding_window is not None
+        return self.config.sliding_window - 1
+
+    def _attention_type(self, layer_id: int) -> str:
+        if self.config.model_type != "olmo3":
+            return "full_attention"
+        assert self.config.layer_types is not None
+        return self.config.layer_types[layer_id]
+
+    def _initialize_metadata_once(self, metadata: FIMetadata, attention_type: str) -> None:
+        if attention_type in metadata.initialized:
             return
 
         from flashinfer import BatchDecodeWithPagedKVCacheWrapper
 
-        metadata.initialized = True
+        wrapper = metadata.wrappers[attention_type]
         # FlashInfer planning reuses a pinned host staging buffer and launches an
         # async H2D copy. Wait here before the next plan mutates that host buffer.
         self.last_event.synchronize()
-        if isinstance(metadata.wrapper, BatchDecodeWithPagedKVCacheWrapper):
-            metadata.wrapper.plan(
+        if isinstance(wrapper, BatchDecodeWithPagedKVCacheWrapper):
+            wrapper.plan(
                 indptr=metadata.cu_seqlens_k_cpu,
                 indices=metadata.indices,
                 last_page_len=metadata.last_page_len_cpu,
@@ -145,9 +167,10 @@ class FlashInferBackend(BaseAttnBackend):
                 q_data_type=metadata.dtype,
                 kv_data_type=metadata.dtype,
                 non_blocking=True,
+                window_left=self._window_left(attention_type),
             )
         else:
-            metadata.wrapper.plan(
+            wrapper.plan(
                 qo_indptr=metadata.cu_seqlens_q_cpu,
                 paged_kv_indptr=metadata.cu_seqlens_k_cpu,
                 paged_kv_indices=metadata.indices,
@@ -162,8 +185,10 @@ class FlashInferBackend(BaseAttnBackend):
                 kv_data_type=metadata.dtype,
                 non_blocking=True,
                 causal=True,
+                window_left=self._window_left(attention_type),
             )
         self.last_event.record()
+        metadata.initialized.add(attention_type)
 
     def _get_ones_cpu(self, bs: int) -> torch.Tensor:
         if bs <= len(self.cached_ones_cpu):
@@ -181,11 +206,12 @@ class FlashInferBackend(BaseAttnBackend):
 
         metadata = batch.attn_metadata
         assert isinstance(metadata, FIMetadata)
-        self._initialize_metadata_once(metadata)
+        attention_type = self._attention_type(layer_id)
+        self._initialize_metadata_once(metadata, attention_type)
         self.kvcache.store_kv(k, v, batch.out_loc, layer_id)
         kv_cache = (self.kvcache.k_cache(layer_id), self.kvcache.v_cache(layer_id))
         kv_cache = (_flatten_cache(kv_cache[0]), _flatten_cache(kv_cache[1]))
-        return metadata.wrapper.run(q=q, paged_kv_cache=kv_cache)
+        return metadata.wrappers[attention_type].run(q=q, paged_kv_cache=kv_cache)
 
     def prepare_metadata(self, batch: Batch) -> None:
         reqs = batch.padded_reqs
@@ -221,7 +247,7 @@ class FlashInferBackend(BaseAttnBackend):
             pos_encoding_mode="NONE",
             seq_lens_cpu=seq_len_cpu,
             dtype=self.kvcache.dtype,
-            wrapper=self.decode_wrappers if batch.is_decode else self.prefill_wrapper,
+            wrappers=self.decode_wrappers if batch.is_decode else self.prefill_wrappers,
         )
 
     def init_capture_graph(self, max_seq_len: int, bs_list: List[int]) -> None:
@@ -245,27 +271,37 @@ class FlashInferBackend(BaseAttnBackend):
         from flashinfer import CUDAGraphBatchDecodeWithPagedKVCacheWrapper
 
         bs = batch.size
-        assert bs in self.capture_bs and bs not in self.graph_wrappers and self.capture
+        assert bs in self.capture_bs and self.capture
+        assert all((bs, attention_type) not in self.graph_wrappers for attention_type in self.attention_types)
         capture = self.capture
-        self.graph_wrappers[bs] = CUDAGraphBatchDecodeWithPagedKVCacheWrapper(
-            self.float_workspace_buffer,
-            kv_layout="NHD",
-            use_tensor_cores=self.use_tensor_cores,
-            indptr_buffer=capture.cu_seqlens_k[: bs + 1],
-            indices_buffer=capture.indices,
-            last_page_len_buffer=capture.one_tensor[:bs],
-        )
-        self.graph_wrappers[bs]._backend = "fa2"
-        self.graph_wrappers[bs]._int_workspace_buffer = self.int_workspace_buffer
+        for attention_type in self.attention_types:
+            wrapper = CUDAGraphBatchDecodeWithPagedKVCacheWrapper(
+                self.float_workspace_buffer,
+                kv_layout="NHD",
+                use_tensor_cores=self.use_tensor_cores,
+                indptr_buffer=capture.cu_seqlens_k[: bs + 1],
+                indices_buffer=capture.indices,
+                last_page_len_buffer=capture.one_tensor[:bs],
+            )
+            wrapper._backend = "fa2"
+            self.graph_wrappers[(bs, attention_type)] = wrapper
         self.prepare_metadata(batch)
         metadata = batch.attn_metadata
         assert isinstance(metadata, FIMetadata)
-        metadata.wrapper = self.graph_wrappers[bs]
-        self._initialize_metadata_once(metadata)
+        metadata.wrappers = {
+            attention_type: self.graph_wrappers[(bs, attention_type)]
+            for attention_type in self.attention_types
+        }
+        for attention_type in self.attention_types:
+            self._initialize_metadata_once(metadata, attention_type)
 
     def prepare_for_replay(self, batch: Batch) -> None:
         metadata, bs = batch.attn_metadata, batch.padded_size
         assert isinstance(metadata, FIMetadata) and not metadata.initialized
         assert self.capture is not None and bs in self.capture_bs
-        metadata.wrapper = self.graph_wrappers[bs]
-        self._initialize_metadata_once(metadata)
+        metadata.wrappers = {
+            attention_type: self.graph_wrappers[(bs, attention_type)]
+            for attention_type in self.attention_types
+        }
+        for attention_type in self.attention_types:
+            self._initialize_metadata_once(metadata, attention_type)

--- a/python/minisgl/engine/engine.py
+++ b/python/minisgl/engine/engine.py
@@ -224,6 +224,17 @@ def _adjust_config(config: EngineConfig):
         override("attention_backend", backend)
         logger.info_rank0(f"Auto-selected attention backend: {config.attention_backend}")
 
+    if (
+        config.model_config.model_type == "olmo3"
+        and config.tp_info.size > 1
+        and config.use_pynccl
+    ):
+        override("use_pynccl", False)
+        logger.warning_rank0(
+            "PyNCCL does not support OLMo3's FP32 distributed Q/K RMSNorm; "
+            "using torch.distributed NCCL instead"
+        )
+
     if "trtllm" in config.attention_backend and config.page_size not in [16, 32, 64]:
         override("page_size", 64)
         logger.warning_rank0("Page size is overridden to 64 for TRTLLM backend")

--- a/python/minisgl/layers/__init__.py
+++ b/python/minisgl/layers/__init__.py
@@ -10,7 +10,7 @@ from .linear import (
     LinearRowParallel,
 )
 from .moe import MoELayer
-from .norm import RMSNorm, RMSNormFused
+from .norm import DistributedRMSNorm, RMSNorm, RMSNormFused
 from .rotary import get_rope, set_rope_device
 
 __all__ = [
@@ -28,6 +28,7 @@ __all__ = [
     "LinearQKVMerged",
     "RMSNorm",
     "RMSNormFused",
+    "DistributedRMSNorm",
     "get_rope",
     "set_rope_device",
     "LinearReplicated",

--- a/python/minisgl/layers/attention.py
+++ b/python/minisgl/layers/attention.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import torch
 from minisgl.core import get_global_ctx
@@ -11,7 +11,7 @@ from .base import StateLessOP
 from .rotary import get_rope
 
 if TYPE_CHECKING:
-    from minisgl.layers import RMSNorm
+    from minisgl.layers import DistributedRMSNorm, RMSNorm
     from minisgl.models import RotaryConfig
 
 
@@ -23,8 +23,9 @@ class AttentionLayer(StateLessOP):
         num_kv_heads: int,
         head_dim: int,
         rotary_config: RotaryConfig,
-        q_norm: RMSNorm | None = None,
-        k_norm: RMSNorm | None = None,
+        q_norm: RMSNorm | DistributedRMSNorm | None = None,
+        k_norm: RMSNorm | DistributedRMSNorm | None = None,
+        qk_norm_mode: Literal["per_head", "projection"] = "per_head",
     ):
         assert num_qo_heads % num_kv_heads == 0
         self.layer_id = layer_id
@@ -43,14 +44,25 @@ class AttentionLayer(StateLessOP):
         )
         self.q_norm = q_norm
         self.k_norm = k_norm
+        self.qk_norm_mode = qk_norm_mode
 
     def forward(self, qkv: torch.Tensor) -> torch.Tensor:
         ctx = get_global_ctx()
         q, k, v = qkv.split([self.qo_attn_dim, self.kv_attn_dim, self.kv_attn_dim], dim=-1)
         if self.q_norm is not None:
-            self.q_norm.forward_inplace(q.view(-1, self.num_qo_heads, self.head_dim))
+            q_norm_input = (
+                q.view(-1, self.num_qo_heads, self.head_dim)
+                if self.qk_norm_mode == "per_head"
+                else q
+            )
+            self.q_norm.forward_inplace(q_norm_input)
         if self.k_norm is not None:
-            self.k_norm.forward_inplace(k.view(-1, self.num_kv_heads, self.head_dim))
+            k_norm_input = (
+                k.view(-1, self.num_kv_heads, self.head_dim)
+                if self.qk_norm_mode == "per_head"
+                else k
+            )
+            self.k_norm.forward_inplace(k_norm_input)
         q, k = self.rotary.forward(ctx.batch.positions, q, k)
         q = q.view(-1, self.num_qo_heads, self.head_dim)
         o = ctx.attn_backend.forward(q, k, v, self.layer_id, ctx.batch)

--- a/python/minisgl/layers/norm.py
+++ b/python/minisgl/layers/norm.py
@@ -1,6 +1,8 @@
 from typing import Tuple
 
 import torch
+from minisgl.distributed import DistributedCommunicator, get_tp_info
+from minisgl.utils import div_even
 
 from .base import BaseOP
 
@@ -18,6 +20,30 @@ class RMSNorm(BaseOP):
 
     def forward_inplace(self, x: torch.Tensor) -> None:
         self.rmsnorm(x, self.weight, self.eps, out=x)
+
+
+class DistributedRMSNorm(BaseOP):
+    """RMSNorm over a projection sharded across tensor-parallel ranks."""
+
+    def __init__(self, full_size: int, eps: float) -> None:
+        tp_info = get_tp_info()
+        assert tp_info.size > 1
+        self.eps = eps
+        self.full_size = full_size
+        self.weight = torch.empty(div_even(full_size, tp_info.size))
+        self._comm = DistributedCommunicator()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        output = x.clone()
+        self.forward_inplace(output)
+        return output
+
+    def forward_inplace(self, x: torch.Tensor) -> None:
+        assert x.shape[-1] == self.weight.shape[0]
+        square_sum = x.float().square().sum(dim=-1, keepdim=True)
+        square_sum = self._comm.all_reduce(square_sum)
+        inv_rms = torch.rsqrt(square_sum / self.full_size + self.eps)
+        x.copy_((x.float() * inv_rms * self.weight.float()).to(x.dtype))
 
 
 class RMSNormFused(BaseOP):

--- a/python/minisgl/layers/rotary.py
+++ b/python/minisgl/layers/rotary.py
@@ -17,6 +17,7 @@ class RotaryEmbedding(StateLessOP):
         max_position_embeddings: int,
         base: float,
         post_process: None | Callable[[torch.Tensor], torch.Tensor] = None,
+        attention_scaling: float = 1.0,
     ) -> None:
         super().__init__()
         self.head_size = head_size
@@ -26,8 +27,8 @@ class RotaryEmbedding(StateLessOP):
             inv_freq = post_process(inv_freq)
         t = torch.arange(max_position_embeddings, dtype=torch.float)
         freqs = torch.einsum("i,j -> ij", t, inv_freq)
-        cos = freqs.cos()
-        sin = freqs.sin()
+        cos = freqs.cos() * attention_scaling
+        sin = freqs.sin() * attention_scaling
         # buffer, so don't load/save
         self._cos_sin_cache = torch.cat((cos, sin), dim=-1)
         assert self.head_size in [64, 128, 256, 512]
@@ -95,6 +96,9 @@ def _get_rope(
             beta_fast: float = rope_scaling.get("beta_fast", 32.0)
             beta_slow: float = rope_scaling.get("beta_slow", 1.0)
             orig_max_pos: int = rope_scaling["original_max_position_embeddings"]
+            attention_scaling = rope_scaling.get("attention_factor")
+            if attention_scaling is None:
+                attention_scaling = 1.0 if factor <= 1 else 0.1 * math.log(factor) + 1.0
 
             def _find_correction_dim(num_rotations: float) -> float:
                 return rotary_dim * math.log(orig_max_pos / (num_rotations * 2 * math.pi)) / (2 * math.log(base))
@@ -109,7 +113,14 @@ def _get_rope(
                 )
                 return (inv_freq / factor) * ramp + inv_freq * (1 - ramp)
 
-            return RotaryEmbedding(head_dim, rotary_dim, max_position, base, post_process)
+            return RotaryEmbedding(
+                head_dim,
+                rotary_dim,
+                max_position,
+                base,
+                post_process,
+                attention_scaling=attention_scaling,
+            )
 
     raise ValueError(f"Unsupported {rope_scaling = }")
 

--- a/python/minisgl/llm/llm.py
+++ b/python/minisgl/llm/llm.py
@@ -71,7 +71,7 @@ class LLM(Scheduler):
     def offline_send_result(self, reply: List[DetokenizeMsg]) -> None:
         for msg in reply:
             status = self.status_map[msg.uid]
-            if not (msg.finished and msg.next_token == self.eos_token_id):
+            if not (msg.finished and msg.next_token in self.eos_token_ids):
                 status.output_ids.append(msg.next_token)
 
     def generate(

--- a/python/minisgl/models/config.py
+++ b/python/minisgl/models/config.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Any, Dict
+
 from transformers import PretrainedConfig
 
 
@@ -32,6 +34,8 @@ class ModelConfig:
     norm_topk_prob: bool
     model_type: str
     architectures: list[str]
+    layer_types: tuple[str, ...] | None = None
+    sliding_window: int | None = None
 
     @property
     def is_moe(self) -> bool:
@@ -55,6 +59,21 @@ class ModelConfig:
         moe_intermediate_size = getattr(config, "moe_intermediate_size", 0)
         norm_topk_prob = getattr(config, "norm_topk_prob", False)
         architectures = getattr(config, "architectures", ["LlamaForCausalLM"])
+        layer_types = None
+        sliding_window = None
+        if model_type == "olmo3":
+            raw_layer_types = getattr(config, "layer_types", None)
+            if raw_layer_types is None or len(raw_layer_types) != config.num_hidden_layers:
+                raise ValueError(
+                    "OLMo3 layer_types must contain exactly one entry per hidden layer"
+                )
+            allowed_layer_types = {"full_attention", "sliding_attention"}
+            if invalid := set(raw_layer_types) - allowed_layer_types:
+                raise ValueError(f"Unsupported OLMo3 layer types: {sorted(invalid)}")
+            layer_types = tuple(raw_layer_types)
+            sliding_window = getattr(config, "sliding_window", None)
+            if sliding_window is None or sliding_window <= 0:
+                raise ValueError("OLMo3 sliding_window must be a positive integer")
 
         # Llama/Qwen: rope_theta is a direct attr; Mistral: it's inside rope_scaling dict
         rope_scaling = getattr(config, "rope_scaling", None)
@@ -84,4 +103,6 @@ class ModelConfig:
             norm_topk_prob=norm_topk_prob,
             model_type=model_type,
             architectures=architectures,
+            layer_types=layer_types,
+            sliding_window=sliding_window,
         )

--- a/python/minisgl/models/olmo3.py
+++ b/python/minisgl/models/olmo3.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from minisgl.core import get_global_ctx
+from minisgl.distributed import get_tp_info
+from minisgl.layers import (
+    AttentionLayer,
+    BaseOP,
+    DistributedRMSNorm,
+    LinearOProj,
+    LinearQKVMerged,
+    OPList,
+    ParallelLMHead,
+    RMSNorm,
+    VocabParallelEmbedding,
+)
+from minisgl.utils import nvtx_annotate
+
+from .base import BaseLLMModel
+from .config import RotaryConfig
+from .utils import GatedMLP
+
+if TYPE_CHECKING:
+    from .config import ModelConfig
+
+
+class Olmo3Attention(BaseOP):
+    def __init__(self, config: ModelConfig, layer_id: int):
+        tp_size = get_tp_info().size
+        if config.num_kv_heads < tp_size:
+            raise NotImplementedError(
+                "OLMo3 TP with replicated KV heads requires replica-aware K RMSNorm"
+            )
+        assert config.layer_types is not None
+        layer_type = config.layer_types[layer_id]
+        rotary_config = config.rotary_config
+        if layer_type == "sliding_attention":
+            rotary_config = RotaryConfig(
+                head_dim=rotary_config.head_dim,
+                rotary_dim=rotary_config.rotary_dim,
+                max_position=rotary_config.max_position,
+                base=rotary_config.base,
+                scaling=None,
+            )
+        else:
+            assert layer_type == "full_attention"
+
+        self.qkv_proj = LinearQKVMerged(
+            hidden_size=config.hidden_size,
+            head_dim=config.head_dim,
+            num_qo_heads=config.num_qo_heads,
+            num_kv_heads=config.num_kv_heads,
+            has_bias=False,
+        )
+        q_projection_size = config.num_qo_heads * config.head_dim
+        k_projection_size = config.num_kv_heads * config.head_dim
+        norm_cls = DistributedRMSNorm if tp_size > 1 else RMSNorm
+        self.q_norm = norm_cls(q_projection_size, config.rms_norm_eps)
+        self.k_norm = norm_cls(k_projection_size, config.rms_norm_eps)
+        self.attn = AttentionLayer(
+            layer_id=layer_id,
+            num_qo_heads=config.num_qo_heads,
+            num_kv_heads=config.num_kv_heads,
+            head_dim=config.head_dim,
+            rotary_config=rotary_config,
+            q_norm=self.q_norm,
+            k_norm=self.k_norm,
+            qk_norm_mode="projection",
+        )
+        self.o_proj = LinearOProj(
+            input_size=config.num_qo_heads * config.head_dim,
+            output_size=config.hidden_size,
+            has_bias=False,
+        )
+
+    @nvtx_annotate("MHA")
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        qkv = self.qkv_proj.forward(x)
+        del x
+        output = self.attn.forward(qkv)
+        return self.o_proj.forward(output)
+
+
+class Olmo3DecoderLayer(BaseOP):
+    def __init__(self, config: ModelConfig, layer_id: int):
+        self.self_attn = Olmo3Attention(config, layer_id)
+        self.mlp = GatedMLP(config)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+        self.post_feedforward_layernorm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+        self._layer_id = layer_id
+
+    @nvtx_annotate("Layer_{}", layer_id_field="_layer_id")
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        residual = x
+        x = self.self_attn.forward(x)
+        x = self.post_attention_layernorm.forward(x)
+        x = residual + x
+
+        residual = x
+        x = self.mlp.forward(x)
+        x = self.post_feedforward_layernorm.forward(x)
+        return residual + x
+
+
+class Olmo3Model(BaseOP):
+    def __init__(self, config: ModelConfig):
+        self.embed_tokens = VocabParallelEmbedding(
+            num_embeddings=config.vocab_size,
+            embedding_dim=config.hidden_size,
+        )
+        self.layers = OPList(
+            [Olmo3DecoderLayer(config, layer_id) for layer_id in range(config.num_layers)]
+        )
+        self.norm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        x = self.embed_tokens.forward(input_ids)
+        for layer in self.layers.op_list:
+            x = layer.forward(x)
+        return self.norm.forward(x)
+
+
+class Olmo3ForCausalLM(BaseLLMModel):
+    def __init__(self, config: ModelConfig):
+        self.model = Olmo3Model(config)
+        self.lm_head = ParallelLMHead(
+            num_embeddings=config.vocab_size,
+            embedding_dim=config.hidden_size,
+            tie_word_embeddings=config.tie_word_embeddings,
+            tied_embedding=self.model.embed_tokens if config.tie_word_embeddings else None,
+        )
+        super().__init__()
+
+    def forward(self) -> torch.Tensor:
+        output = self.model.forward(get_global_ctx().batch.input_ids)
+        return self.lm_head.forward(output)
+
+
+__all__ = ["Olmo3ForCausalLM"]

--- a/python/minisgl/models/register.py
+++ b/python/minisgl/models/register.py
@@ -9,6 +9,7 @@ _MODEL_REGISTRY = {
     "Qwen3MoeForCausalLM": (".qwen3_moe", "Qwen3MoeForCausalLM"),
     "MistralForCausalLM": (".mistral", "MistralForCausalLM"),
     "Mistral3ForConditionalGeneration": (".mistral", "MistralForCausalLM"),
+    "Olmo3ForCausalLM": (".olmo3", "Olmo3ForCausalLM"),
 }
 
 

--- a/python/minisgl/models/weight.py
+++ b/python/minisgl/models/weight.py
@@ -31,9 +31,21 @@ _SLOT_NAMES = {
 _EXPERT_PATTERN = re.compile(r"^(?P<prefix>.+\.experts)\.(?P<idx>\d+)\.(?P<name>.+)$")
 
 
-def _shard_tensor(key: str, value: torch.Tensor, r: int, n: int, num_kv_heads: int):
+def _shard_tensor(
+    key: str,
+    value: torch.Tensor,
+    r: int,
+    n: int,
+    num_kv_heads: int,
+    model_type: str | None = None,
+):
     """Extract rank r's shard from a single tensor. Returns a contiguous copy."""
-    if any(key.count(sub) for sub in _SPLIT_DIM_0):
+    olmo_qk_norm = model_type == "olmo3" and key.endswith(
+        (".self_attn.q_norm.weight", ".self_attn.k_norm.weight")
+    )
+    if olmo_qk_norm:
+        return value.chunk(n, dim=0)[r].clone()
+    elif any(key.count(sub) for sub in _SPLIT_DIM_0):
         is_kv_proj = any(key.count(sub) for sub in (".k_proj", ".v_proj"))
         if is_kv_proj and num_kv_heads is not None and num_kv_heads < n:
             head_dim = value.shape[0] // num_kv_heads
@@ -94,7 +106,14 @@ def load_weight(model_path: str, device: torch.device) -> Iterator[Tuple[str, to
                     continue
                 raw = f.get_tensor(name)
                 name = name.removeprefix("language_model.")
-                tensor = _shard_tensor(name, raw, tp_info.rank, tp_info.size, config.num_kv_heads)
+                tensor = _shard_tensor(
+                    name,
+                    raw,
+                    tp_info.rank,
+                    tp_info.size,
+                    config.num_kv_heads,
+                    config.model_type,
+                )
                 del raw
 
                 if (info := _get_merge_info(name)) is None:

--- a/python/minisgl/scheduler/scheduler.py
+++ b/python/minisgl/scheduler/scheduler.py
@@ -13,7 +13,7 @@ from minisgl.message import (
     ExitMsg,
     UserMsg,
 )
-from minisgl.utils import init_logger, load_tokenizer
+from minisgl.utils import init_logger, load_eos_token_ids, load_tokenizer
 
 from .cache import CacheManager
 from .config import SchedulerConfig
@@ -68,6 +68,7 @@ class Scheduler(SchedulerIOMixin):
         self.finished_reqs: Set[Req] = set()
         self.tokenizer = load_tokenizer(config.model_path)
         self.eos_token_id = self.tokenizer.eos_token_id
+        self.eos_token_ids = load_eos_token_ids(config.model_path, self.tokenizer)
         self.token_pool = self.table_manager.token_pool
         self.prefill_budget = config.max_extend_tokens
         # self.config = config
@@ -152,7 +153,7 @@ class Scheduler(SchedulerIOMixin):
                 next_token = int(next_token.item())
                 finished = not req.can_decode
                 if not req.sampling_params.ignore_eos:
-                    finished |= next_token == self.eos_token_id
+                    finished |= next_token in self.eos_token_ids
                 reply.append(DetokenizeMsg(uid=req.uid, next_token=next_token, finished=finished))
 
                 # NOTE: overlap scheduling may make the request freed twice, skip second free

--- a/python/minisgl/tokenizer/detokenize.py
+++ b/python/minisgl/tokenizer/detokenize.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, Iterable, List
 
 from minisgl.message import DetokenizeMsg
 from transformers import PreTrainedTokenizerBase
@@ -61,11 +61,15 @@ class DecodeStatus:
 
 
 class DetokenizeManager:
-    def __init__(self, tokenizer: PreTrainedTokenizerBase) -> None:
+    def __init__(
+        self, tokenizer: PreTrainedTokenizerBase, eos_token_ids: Iterable[int] | None = None
+    ) -> None:
         # uid -> DecodeStatus
         self.decode_map: Dict[int, DecodeStatus] = {}
         self.tokenizer = tokenizer
-        self.eos_token_id = self.tokenizer.eos_token_id
+        self.eos_token_ids = frozenset(
+            eos_token_ids if eos_token_ids is not None else [self.tokenizer.eos_token_id]
+        )
 
     def detokenize(self, msgs: List[DetokenizeMsg]) -> List[str]:
         read_ids: List[List[int]] = []
@@ -80,7 +84,7 @@ class DetokenizeManager:
                     sent_offset=0,
                 )
             s = self.decode_map[msg.uid]
-            if not (msg.finished and msg.next_token == self.eos_token_id):
+            if not (msg.finished and msg.next_token in self.eos_token_ids):
                 s.decoded_ids.append(msg.next_token)
             read_ids.append(s.decoded_ids[s.surr_offset :])
             surr_ids.append(s.decoded_ids[s.surr_offset : s.read_offset])

--- a/python/minisgl/tokenizer/server.py
+++ b/python/minisgl/tokenizer/server.py
@@ -18,7 +18,13 @@ from minisgl.message import (
     UserMsg,
     UserReply,
 )
-from minisgl.utils import ZmqPullQueue, ZmqPushQueue, init_logger, load_tokenizer
+from minisgl.utils import (
+    ZmqPullQueue,
+    ZmqPushQueue,
+    init_logger,
+    load_eos_token_ids,
+    load_tokenizer,
+)
 
 
 def _unwrap_msg(msg: BaseTokenizerMsg) -> List[BaseTokenizerMsg]:
@@ -45,13 +51,14 @@ def tokenize_worker(
     recv_listener = ZmqPullQueue(addr, create=create, decoder=BatchTokenizerMsg.decoder)
     assert local_bs > 0
     tokenizer = load_tokenizer(tokenizer_path)
+    eos_token_ids = load_eos_token_ids(tokenizer_path, tokenizer)
     logger = init_logger(__name__, f"tokenizer_{tokenizer_id}")
 
     from .detokenize import DetokenizeManager
     from .tokenize import TokenizeManager
 
     tokenize_manager = TokenizeManager(tokenizer)
-    detokenize_manager = DetokenizeManager(tokenizer)
+    detokenize_manager = DetokenizeManager(tokenizer, eos_token_ids)
 
     if ack_queue is not None:
         ack_queue.put(f"Tokenize server {tokenizer_id} is ready")

--- a/python/minisgl/utils/__init__.py
+++ b/python/minisgl/utils/__init__.py
@@ -1,5 +1,5 @@
 from .arch import is_arch_supported, is_sm90_supported, is_sm100_supported
-from .hf import cached_load_hf_config, download_hf_weight, load_tokenizer
+from .hf import cached_load_hf_config, download_hf_weight, load_eos_token_ids, load_tokenizer
 from .logger import init_logger
 from .misc import UNSET, Unset, align_ceil, align_down, call_if_main, div_ceil, div_even
 from .mp import (
@@ -16,6 +16,7 @@ from .torch_utils import nvtx_annotate, torch_dtype
 __all__ = [
     "cached_load_hf_config",
     "download_hf_weight",
+    "load_eos_token_ids",
     "load_tokenizer",
     "init_logger",
     "is_arch_supported",

--- a/python/minisgl/utils/hf.py
+++ b/python/minisgl/utils/hf.py
@@ -5,7 +5,14 @@ from typing import Any
 
 from huggingface_hub import hf_hub_download, snapshot_download
 from tqdm.asyncio import tqdm
-from transformers import AutoConfig, AutoTokenizer, PretrainedConfig, PreTrainedTokenizerBase
+from transformers import (
+    AutoConfig,
+    AutoTokenizer,
+    GenerationConfig,
+    PretrainedConfig,
+    PreTrainedTokenizerBase,
+)
+
 
 class DisabledTqdm(tqdm):
     def __init__(self, *args, **kwargs):
@@ -25,6 +32,33 @@ def load_tokenizer(model_path: str) -> PreTrainedTokenizerBase:
         except Exception:
             pass
     return tokenizer
+
+
+def _normalize_token_ids(token_ids: int | list[int] | None) -> set[int]:
+    if token_ids is None:
+        return set()
+    if isinstance(token_ids, int):
+        return {token_ids}
+    return {int(token_id) for token_id in token_ids}
+
+
+def load_eos_token_ids(
+    model_path: str, tokenizer: PreTrainedTokenizerBase
+) -> frozenset[int]:
+    """Load every configured EOS token while retaining the tokenizer fallback."""
+    eos_token_ids = _normalize_token_ids(tokenizer.eos_token_id)
+    try:
+        generation_config = GenerationConfig.from_pretrained(model_path)
+    except (OSError, ValueError):
+        try:
+            generation_config = GenerationConfig.from_model_config(
+                cached_load_hf_config(model_path)
+            )
+        except (OSError, ValueError):
+            generation_config = None
+    if generation_config is not None:
+        eos_token_ids.update(_normalize_token_ids(generation_config.eos_token_id))
+    return frozenset(eos_token_ids)
 
 
 @functools.cache

--- a/tests/attention/test_olmo3_window.py
+++ b/tests/attention/test_olmo3_window.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+
+from minisgl.attention.fa import FlashAttentionBackend
+from minisgl.attention.fi import FlashInferBackend
+
+
+def _backend(layer_types, sliding_window=4096):
+    backend = object.__new__(FlashAttentionBackend)
+    backend.config = SimpleNamespace(
+        model_type="olmo3",
+        layer_types=layer_types,
+        sliding_window=sliding_window,
+    )
+    return backend
+
+
+def test_olmo3_attention_window_is_layer_aware():
+    backend = _backend(("sliding_attention", "full_attention"))
+
+    assert backend._window_size(0) == (4095, 0)
+    assert backend._window_size(1) == (-1, -1)
+
+
+def test_non_olmo_models_remain_full_attention():
+    backend = object.__new__(FlashAttentionBackend)
+    backend.config = SimpleNamespace(model_type="qwen3")
+
+    assert backend._window_size(0) == (-1, -1)
+
+
+def test_flashinfer_uses_the_same_olmo3_window_semantics():
+    backend = object.__new__(FlashInferBackend)
+    backend.config = SimpleNamespace(
+        model_type="olmo3",
+        layer_types=("sliding_attention", "full_attention"),
+        sliding_window=4096,
+    )
+
+    assert backend._attention_type(0) == "sliding_attention"
+    assert backend._attention_type(1) == "full_attention"
+    assert backend._window_left("sliding_attention") == 4095
+    assert backend._window_left("full_attention") == -1

--- a/tests/layers/test_olmo3_attention.py
+++ b/tests/layers/test_olmo3_attention.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+
+import minisgl.layers.attention as attention_module
+import pytest
+import torch
+from minisgl.layers.attention import AttentionLayer
+
+
+class _RecordingNorm:
+    def __init__(self):
+        self.shape = None
+
+    def forward_inplace(self, x):
+        self.shape = tuple(x.shape)
+
+
+class _IdentityRotary:
+    def forward(self, positions, query, key):
+        return query, key
+
+
+class _AttentionBackend:
+    def forward(self, q, k, v, layer_id, batch):
+        return torch.zeros_like(q)
+
+
+@pytest.mark.parametrize(
+    ("mode", "q_shape", "k_shape"),
+    [
+        ("per_head", (3, 2, 4), (3, 1, 4)),
+        ("projection", (3, 8), (3, 4)),
+    ],
+)
+def test_qk_norm_mode_controls_normalization_axis(monkeypatch, mode, q_shape, k_shape):
+    q_norm = _RecordingNorm()
+    k_norm = _RecordingNorm()
+    layer = object.__new__(AttentionLayer)
+    layer.layer_id = 0
+    layer.head_dim = 4
+    layer.num_qo_heads = 2
+    layer.num_kv_heads = 1
+    layer.qo_attn_dim = 8
+    layer.kv_attn_dim = 4
+    layer.rotary = _IdentityRotary()
+    layer.q_norm = q_norm
+    layer.k_norm = k_norm
+    layer.qk_norm_mode = mode
+
+    context = SimpleNamespace(
+        batch=SimpleNamespace(positions=torch.arange(3)),
+        attn_backend=_AttentionBackend(),
+    )
+    monkeypatch.setattr(attention_module, "get_global_ctx", lambda: context)
+
+    layer.forward(torch.randn(3, 16))
+
+    assert q_norm.shape == q_shape
+    assert k_norm.shape == k_shape

--- a/tests/layers/test_olmo3_rotary.py
+++ b/tests/layers/test_olmo3_rotary.py
@@ -1,0 +1,51 @@
+import sys
+from types import SimpleNamespace
+
+import torch
+from minisgl.layers.rotary import _get_rope
+
+
+def _stub_flashinfer(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "flashinfer",
+        SimpleNamespace(apply_rope_with_cos_sin_cache_inplace=lambda **kwargs: None),
+    )
+
+
+def test_yarn_attention_factor_scales_cos_sin_cache(monkeypatch):
+    _stub_flashinfer(monkeypatch)
+    attention_factor = 1.2079441541679836
+    rope = _get_rope(
+        head_dim=64,
+        rotary_dim=64,
+        max_position=16,
+        base=500000.0,
+        rope_scaling={
+            "rope_type": "yarn",
+            "factor": 8.0,
+            "beta_fast": 32.0,
+            "beta_slow": 1.0,
+            "original_max_position_embeddings": 8192,
+            "attention_factor": attention_factor,
+        },
+    )
+
+    cos, sin = rope._cos_sin_cache[0].chunk(2)
+    assert torch.allclose(cos, torch.full_like(cos, attention_factor))
+    assert torch.count_nonzero(sin) == 0
+
+
+def test_default_rope_keeps_unit_attention_scaling(monkeypatch):
+    _stub_flashinfer(monkeypatch)
+    rope = _get_rope(
+        head_dim=64,
+        rotary_dim=64,
+        max_position=16,
+        base=500000.0,
+        rope_scaling=None,
+    )
+
+    cos, sin = rope._cos_sin_cache[0].chunk(2)
+    assert torch.equal(cos, torch.ones_like(cos))
+    assert torch.count_nonzero(sin) == 0

--- a/tests/models/test_multi_eos.py
+++ b/tests/models/test_multi_eos.py
@@ -1,0 +1,83 @@
+from types import SimpleNamespace
+
+import minisgl.utils.hf as hf_utils
+from minisgl.llm.llm import LLM, RequestStatus
+from minisgl.message import DetokenizeMsg
+from minisgl.tokenizer.detokenize import DetokenizeManager
+
+
+class _Tokenizer:
+    eos_token_id = 100257
+
+    def batch_decode(self, batches):
+        return [" ".join(map(str, batch)) for batch in batches]
+
+
+def test_generation_config_adds_all_eos_tokens(monkeypatch):
+    monkeypatch.setattr(
+        hf_utils.GenerationConfig,
+        "from_pretrained",
+        lambda _: SimpleNamespace(eos_token_id=[100265, 100257]),
+    )
+
+    assert hf_utils.load_eos_token_ids("model", _Tokenizer()) == frozenset(
+        {100257, 100265}
+    )
+
+
+def test_generation_config_falls_back_to_tokenizer(monkeypatch):
+    def _missing_generation_config(_):
+        raise OSError("missing")
+
+    monkeypatch.setattr(
+        hf_utils.GenerationConfig, "from_pretrained", _missing_generation_config
+    )
+    monkeypatch.setattr(hf_utils, "cached_load_hf_config", lambda _: object())
+    monkeypatch.setattr(
+        hf_utils.GenerationConfig,
+        "from_model_config",
+        lambda _: (_ for _ in ()).throw(ValueError("missing")),
+    )
+
+    assert hf_utils.load_eos_token_ids("model", _Tokenizer()) == frozenset({100257})
+
+
+def test_generation_config_falls_back_to_model_config(monkeypatch):
+    monkeypatch.setattr(
+        hf_utils.GenerationConfig,
+        "from_pretrained",
+        lambda _: (_ for _ in ()).throw(OSError("missing")),
+    )
+    monkeypatch.setattr(hf_utils, "cached_load_hf_config", lambda _: object())
+    monkeypatch.setattr(
+        hf_utils.GenerationConfig,
+        "from_model_config",
+        lambda _: SimpleNamespace(eos_token_id=[100265]),
+    )
+
+    assert hf_utils.load_eos_token_ids("model", _Tokenizer()) == frozenset(
+        {100257, 100265}
+    )
+
+
+def test_detokenizer_filters_any_finished_eos_token():
+    manager = DetokenizeManager(_Tokenizer(), {100257, 100265})
+
+    output = manager.detokenize(
+        [DetokenizeMsg(uid=1, next_token=100265, finished=True)]
+    )
+
+    assert output == [""]
+    assert manager.decode_map == {}
+
+
+def test_offline_llm_filters_secondary_finished_eos_token():
+    llm = object.__new__(LLM)
+    llm.eos_token_ids = frozenset({100257, 100265})
+    llm.status_map = {1: RequestStatus(uid=1, input_ids=[1], output_ids=[])}
+
+    llm.offline_send_result(
+        [DetokenizeMsg(uid=1, next_token=100265, finished=True)]
+    )
+
+    assert llm.status_map[1].output_ids == []

--- a/tests/models/test_olmo3_config.py
+++ b/tests/models/test_olmo3_config.py
@@ -1,0 +1,70 @@
+from types import SimpleNamespace
+
+import pytest
+from minisgl.models.config import ModelConfig
+
+
+def _hf_config(**overrides):
+    values = {
+        "architectures": ["Olmo3ForCausalLM"],
+        "hidden_act": "silu",
+        "hidden_size": 4096,
+        "intermediate_size": 11008,
+        "layer_types": [
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+        ],
+        "max_position_embeddings": 65536,
+        "model_type": "olmo3",
+        "num_attention_heads": 32,
+        "num_hidden_layers": 4,
+        "num_key_value_heads": 32,
+        "rms_norm_eps": 1e-6,
+        "rope_scaling": {
+            "attention_factor": 1.2079441541679836,
+            "beta_fast": 32.0,
+            "beta_slow": 1.0,
+            "factor": 8.0,
+            "original_max_position_embeddings": 8192,
+            "rope_type": "yarn",
+        },
+        "rope_theta": 500000.0,
+        "sliding_window": 4096,
+        "tie_word_embeddings": False,
+        "vocab_size": 100278,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_olmo3_layer_configuration_is_preserved():
+    config = ModelConfig.from_hf(_hf_config())
+
+    assert config.layer_types == (
+        "sliding_attention",
+        "sliding_attention",
+        "sliding_attention",
+        "full_attention",
+    )
+    assert config.sliding_window == 4096
+    assert config.rotary_config.scaling["attention_factor"] == pytest.approx(
+        1.2079441541679836
+    )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"layer_types": ["full_attention"]}, "one entry per hidden layer"),
+        (
+            {"layer_types": ["sliding_attention", "invalid", "full_attention", "full_attention"]},
+            "Unsupported OLMo3 layer types",
+        ),
+        ({"sliding_window": 0}, "positive integer"),
+    ],
+)
+def test_olmo3_invalid_layer_configuration_is_rejected(overrides, message):
+    with pytest.raises(ValueError, match=message):
+        ModelConfig.from_hf(_hf_config(**overrides))

--- a/tests/models/test_olmo3_post_norm.py
+++ b/tests/models/test_olmo3_post_norm.py
@@ -1,0 +1,24 @@
+import torch
+from minisgl.models.olmo3 import Olmo3DecoderLayer
+
+
+class _Op:
+    def __init__(self, fn):
+        self.fn = fn
+
+    def forward(self, x):
+        return self.fn(x)
+
+
+def test_olmo3_decoder_applies_norm_before_residual_add():
+    layer = object.__new__(Olmo3DecoderLayer)
+    layer.self_attn = _Op(lambda x: x + 1)
+    layer.post_attention_layernorm = _Op(lambda x: x * 10)
+    layer.mlp = _Op(lambda x: x + 2)
+    layer.post_feedforward_layernorm = _Op(lambda x: x * 100)
+
+    output = Olmo3DecoderLayer.forward.__wrapped__(layer, torch.tensor([2.0]))
+
+    # Attention: (2 + 1) * 10 + 2 = 32
+    # MLP:       (32 + 2) * 100 + 32 = 3432
+    assert torch.equal(output, torch.tensor([3432.0]))

--- a/tests/models/test_olmo3_tp.py
+++ b/tests/models/test_olmo3_tp.py
@@ -1,0 +1,70 @@
+import torch
+from minisgl.layers.norm import DistributedRMSNorm
+from minisgl.models.weight import _shard_tensor
+
+
+class _AddRemoteSquareSum:
+    def __init__(self, remote_square_sum):
+        self.remote_square_sum = remote_square_sum
+
+    def all_reduce(self, value):
+        return value + self.remote_square_sum
+
+
+def test_distributed_rmsnorm_matches_full_projection_reference():
+    norm = object.__new__(DistributedRMSNorm)
+    norm.eps = 1e-6
+    norm.full_size = 4
+    norm.weight = torch.tensor([1.5, 0.5])
+    norm._comm = _AddRemoteSquareSum(torch.tensor([[25.0]]))
+    local = torch.tensor([[1.0, 2.0]])
+
+    norm.forward_inplace(local)
+
+    full = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+    inv_rms = torch.rsqrt(full.square().mean(dim=-1, keepdim=True) + norm.eps)
+    expected = full[:, :2] * inv_rms * norm.weight
+    assert torch.allclose(local, expected, rtol=1e-6, atol=1e-6)
+
+
+def test_distributed_rmsnorm_rounds_only_after_weight_multiply():
+    torch.manual_seed(42)
+    full = torch.randn(32, 8).to(torch.bfloat16)
+    local = full[:, :4].clone()
+    remote_square_sum = full[:, 4:].float().square().sum(dim=-1, keepdim=True)
+    norm = object.__new__(DistributedRMSNorm)
+    norm.eps = 1e-6
+    norm.full_size = 8
+    norm.weight = torch.randn(4).to(torch.bfloat16)
+    norm._comm = _AddRemoteSquareSum(remote_square_sum)
+
+    norm.forward_inplace(local)
+
+    inv_rms = torch.rsqrt(full.float().square().mean(dim=-1, keepdim=True) + norm.eps)
+    expected = (full[:, :4].float() * inv_rms * norm.weight.float()).to(torch.bfloat16)
+    legacy = (full[:, :4].float() * inv_rms).to(torch.bfloat16) * norm.weight
+    assert torch.equal(local, expected)
+    assert not torch.equal(legacy, expected)
+
+
+def test_olmo3_qk_norm_weights_are_sharded_without_affecting_qwen():
+    weight = torch.arange(8)
+    key = "model.layers.0.self_attn.q_norm.weight"
+
+    rank0 = _shard_tensor(key, weight, 0, 2, 2, "olmo3")
+    rank1 = _shard_tensor(key, weight, 1, 2, 2, "olmo3")
+    qwen = _shard_tensor(key, weight, 1, 2, 2, "qwen3")
+
+    assert torch.equal(rank0, torch.tensor([0, 1, 2, 3]))
+    assert torch.equal(rank1, torch.tensor([4, 5, 6, 7]))
+    assert torch.equal(torch.cat((rank0, rank1)), weight)
+    assert qwen is weight
+
+
+def test_olmo3_post_norm_weights_remain_replicated():
+    weight = torch.arange(8)
+    key = "model.layers.0.post_attention_layernorm.weight"
+
+    sharded = _shard_tensor(key, weight, 1, 2, 2, "olmo3")
+
+    assert sharded is weight

--- a/tools/olmo3/api_smoke.py
+++ b/tools/olmo3/api_smoke.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+import requests
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run one minimal OLMo3 API smoke")
+    parser.add_argument("--base-url", default="http://127.0.0.1:1919")
+    parser.add_argument("--model", required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    model_response = requests.get(f"{args.base_url}/v1/models", timeout=30)
+    model_response.raise_for_status()
+    models = model_response.json()["data"]
+    assert models and models[0]["id"] == args.model
+
+    payload = {
+        "model": args.model,
+        "messages": [
+            {
+                "role": "user",
+                "content": "Answer with one word: what is the capital of France?",
+            }
+        ],
+        "temperature": 0,
+        "max_tokens": 8,
+    }
+    response = requests.post(
+        f"{args.base_url}/v1/chat/completions", json=payload, timeout=60
+    )
+    response.raise_for_status()
+    body = response.json()
+    choice = body["choices"][0]
+    content = choice["message"]["content"]
+    assert choice["finish_reason"] == "stop"
+    assert "Paris" in content
+    assert "<|im_end|>" not in content and "<|endoftext|>" not in content
+
+    stream_response = requests.post(
+        f"{args.base_url}/v1/chat/completions",
+        json={**payload, "stream": True},
+        timeout=60,
+        stream=True,
+    )
+    stream_response.raise_for_status()
+    chunks = []
+    done_count = 0
+    for line in stream_response.iter_lines(decode_unicode=True):
+        if not line:
+            continue
+        assert line.startswith("data: ")
+        data = line.removeprefix("data: ")
+        if data == "[DONE]":
+            done_count += 1
+        else:
+            chunks.append(json.loads(data))
+
+    assert done_count == 1
+    assert chunks[0]["choices"][0]["delta"]["role"] == "assistant"
+    streamed_content = "".join(
+        chunk["choices"][0]["delta"].get("content", "") for chunk in chunks
+    )
+    assert streamed_content == content
+    assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+    print(f"OLMO3_API_SMOKE=passed content={content!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/olmo3/compare_references.py
+++ b/tools/olmo3/compare_references.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compare one OLMo3 HF/Mini reference")
+    parser.add_argument("hf_reference", type=Path)
+    parser.add_argument("mini_reference", type=Path)
+    parser.add_argument("--json-output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    hf = torch.load(args.hf_reference, map_location="cpu", weights_only=True)
+    mini = torch.load(args.mini_reference, map_location="cpu", weights_only=True)
+    assert torch.equal(hf["input_ids"].long(), mini["input_ids"].long())
+    hf_logits = hf["first_logits"].float()
+    mini_logits = mini["first_logits"].float()
+    assert hf_logits.shape == mini_logits.shape
+    assert torch.isfinite(hf_logits).all() and torch.isfinite(mini_logits).all()
+
+    error = (hf_logits - mini_logits).abs()
+    hf_top20 = set(hf_logits.topk(20).indices.tolist())
+    mini_top20 = set(mini_logits.topk(20).indices.tolist())
+    hf_top2 = hf_logits.topk(2).values
+    metrics = {
+        "argmax_match": hf_logits.argmax().item() == mini_logits.argmax().item(),
+        "greedy_tokens_match": hf["token_ids"] == mini["token_ids"],
+        "hf_token_ids": hf["token_ids"],
+        "mini_token_ids": mini["token_ids"],
+        "cosine_similarity": F.cosine_similarity(hf_logits, mini_logits, dim=0).item(),
+        "mean_absolute_error": error.mean().item(),
+        "max_absolute_error": error.max().item(),
+        "top20_overlap": len(hf_top20 & mini_top20),
+        "hf_top1_margin": (hf_top2[0] - hf_top2[1]).item(),
+    }
+    print(json.dumps(metrics, indent=2))
+    if args.json_output is not None:
+        args.json_output.parent.mkdir(parents=True, exist_ok=True)
+        args.json_output.write_text(json.dumps(metrics, indent=2) + "\n")
+
+    assert metrics["argmax_match"]
+    assert metrics["greedy_tokens_match"]
+    assert metrics["cosine_similarity"] >= 0.999
+    assert metrics["mean_absolute_error"] <= 0.05
+    assert metrics["max_absolute_error"] <= 0.5
+    assert metrics["top20_overlap"] >= 18
+    print("OLMO3_ALIGNMENT=passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/olmo3/hf_reference.py
+++ b/tools/olmo3/hf_reference.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create one minimal OLMo3 HF reference")
+    parser.add_argument("model_path", type=Path)
+    parser.add_argument("output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    prompt = "Answer with one word: what is the capital of France?"
+    messages = [{"role": "user", "content": prompt}]
+    tokenizer = AutoTokenizer.from_pretrained(args.model_path, local_files_only=True)
+    input_ids = tokenizer.apply_chat_template(
+        messages,
+        add_generation_prompt=True,
+        return_tensors="pt",
+    ).to("cuda:0")
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model_path,
+        dtype=torch.bfloat16,
+        device_map={"": "cuda:0"},
+        low_cpu_mem_usage=True,
+        attn_implementation="eager",
+        local_files_only=True,
+    ).eval()
+
+    generated: list[int] = []
+    first_logits: torch.Tensor | None = None
+    current_ids = input_ids
+    past_key_values = None
+    with torch.inference_mode():
+        for _ in range(4):
+            output = model(
+                input_ids=current_ids,
+                past_key_values=past_key_values,
+                use_cache=True,
+                logits_to_keep=1,
+            )
+            logits = output.logits[0, -1].float()
+            if first_logits is None:
+                first_logits = logits.cpu()
+            next_token = logits.argmax().view(1, 1)
+            generated.append(int(next_token.item()))
+            current_ids = next_token
+            past_key_values = output.past_key_values
+
+    assert first_logits is not None
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(
+        {
+            "prompt": prompt,
+            "input_ids": input_ids[0].cpu(),
+            "first_logits": first_logits,
+            "token_ids": generated,
+        },
+        args.output,
+    )
+    print(
+        f"HF_REFERENCE=ok input_tokens={input_ids.shape[-1]} "
+        f"token_ids={generated} output={args.output}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/olmo3/mini_reference.py
+++ b/tools/olmo3/mini_reference.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+from minisgl.core import SamplingParams
+from minisgl.llm import LLM
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create one minimal OLMo3 Mini reference")
+    parser.add_argument("model_path", type=Path)
+    parser.add_argument("hf_reference", type=Path)
+    parser.add_argument("output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    reference = torch.load(args.hf_reference, map_location="cpu", weights_only=True)
+    llm = LLM(
+        str(args.model_path),
+        attention_backend="fi",
+        max_running_req=1,
+        max_seq_len_override=64,
+        max_extend_tokens=64,
+        num_page_override=64,
+        page_size=1,
+        cache_type="naive",
+        cuda_graph_bs=[],
+    )
+    captured: list[torch.Tensor] = []
+    sampled_tokens: list[int] = []
+    original_sample = llm.engine.sampler.sample
+
+    def capture_sample(logits, sampling_args):
+        if not captured:
+            captured.append(logits[0].detach().float().cpu().clone())
+        next_tokens = original_sample(logits, sampling_args)
+        sampled_tokens.extend(next_tokens.detach().cpu().tolist())
+        return next_tokens
+
+    llm.engine.sampler.sample = capture_sample
+    try:
+        result = llm.generate(
+            [reference["input_ids"].tolist()],
+            SamplingParams(temperature=0, max_tokens=4, ignore_eos=True),
+        )[0]
+    finally:
+        llm.shutdown()
+
+    assert len(captured) == 1
+    assert len(sampled_tokens) == 4
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(
+        {
+            "input_ids": reference["input_ids"],
+            "first_logits": captured[0],
+            "token_ids": sampled_tokens,
+        },
+        args.output,
+    )
+    print(
+        f"MINI_REFERENCE=ok token_ids={sampled_tokens} "
+        f"decoded_token_ids={result['token_ids']} output={args.output}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/olmo3/run_api_smoke.sh
+++ b/tools/olmo3/run_api_smoke.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+model_path=${1:?"usage: run_api_smoke.sh MODEL_PATH [PORT]"}
+server_port=${2:-1919}
+server_log=${OLMO3_API_LOG:-/root/autodl-tmp/olmo3-validation/api_server.log}
+api_pid=""
+
+cleanup() {
+  if [[ -n "${api_pid}" ]] && kill -0 "${api_pid}" 2>/dev/null; then
+    kill -INT -- "-${api_pid}" 2>/dev/null || true
+    for _ in $(seq 1 20); do
+      kill -0 "${api_pid}" 2>/dev/null || break
+      sleep 1
+    done
+    kill -TERM -- "-${api_pid}" 2>/dev/null || true
+    wait "${api_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+setsid python -m minisgl \
+  --model "${model_path}" \
+  --tp-size 2 \
+  --dtype bfloat16 \
+  --attn fi \
+  --cuda-graph-max-bs 0 \
+  --max-running-requests 2 \
+  --max-seq-len-override 64 \
+  --max-prefill-length 64 \
+  --num-pages 256 \
+  --cache-type radix \
+  --host 127.0.0.1 \
+  --port "${server_port}" >"${server_log}" 2>&1 &
+api_pid=$!
+
+api_ready=0
+for _ in $(seq 1 90); do
+  if curl --fail --silent "http://127.0.0.1:${server_port}/v1/models" >/dev/null; then
+    api_ready=1
+    break
+  fi
+  sleep 1
+done
+
+if [[ "${api_ready}" -ne 1 ]]; then
+  tail -100 "${server_log}"
+  exit 1
+fi
+
+python tools/olmo3/api_smoke.py \
+  --base-url "http://127.0.0.1:${server_port}" \
+  --model "${model_path}"
+
+cleanup
+trap - EXIT

--- a/tools/olmo3/system_smoke.py
+++ b/tools/olmo3/system_smoke.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+from minisgl.core import SamplingParams
+from minisgl.llm import LLM
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run one minimal OLMo3 scheduler smoke")
+    parser.add_argument("model_path", type=Path)
+    parser.add_argument("hf_reference", type=Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    reference = torch.load(args.hf_reference, map_location="cpu", weights_only=True)
+    input_ids = reference["input_ids"].tolist()
+    expected_token = reference["token_ids"][0]
+    llm = LLM(
+        str(args.model_path),
+        attention_backend="fi",
+        max_running_req=2,
+        max_seq_len_override=64,
+        max_extend_tokens=64,
+        num_page_override=256,
+        page_size=1,
+        cache_type="radix",
+        cuda_graph_bs=[],
+    )
+
+    prefill_calls = 0
+    max_prefill_batch = 0
+    matched_lengths: list[int] = []
+    original_forward = llm.engine.forward_batch
+    original_match = llm.cache_manager.match_req
+
+    def capture_forward(batch, sampling_args):
+        nonlocal prefill_calls, max_prefill_batch
+        if batch.is_prefill:
+            prefill_calls += 1
+            max_prefill_batch = max(max_prefill_batch, batch.size)
+        return original_forward(batch, sampling_args)
+
+    def capture_match(req):
+        result = original_match(req)
+        matched_lengths.append(result.cuda_handle.cached_len)
+        return result
+
+    llm.engine.forward_batch = capture_forward
+    llm.cache_manager.match_req = capture_match
+    sampling = SamplingParams(temperature=0, max_tokens=1, ignore_eos=True)
+    try:
+        batched = llm.generate([input_ids, input_ids], sampling)
+        first_pass_matches = list(matched_lengths)
+        matched_lengths.clear()
+        cached = llm.generate([input_ids], sampling)
+        second_pass_matches = list(matched_lengths)
+        llm.cache_manager.check_integrity()
+    finally:
+        llm.shutdown()
+
+    assert [item["token_ids"] for item in batched] == [
+        [expected_token],
+        [expected_token],
+    ]
+    assert cached[0]["token_ids"] == [expected_token]
+    assert max_prefill_batch == 2
+    assert prefill_calls >= 2
+    assert first_pass_matches == [0, 0]
+    assert second_pass_matches and second_pass_matches[0] >= len(input_ids) - 1
+    print(
+        "OLMO3_SYSTEM_SMOKE=passed "
+        f"prefill_calls={prefill_calls} max_prefill_batch={max_prefill_batch} "
+        f"radix_cached_tokens={second_pass_matches[0]}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/olmo3/tp_reference.py
+++ b/tools/olmo3/tp_reference.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+import torch.multiprocessing as mp
+from minisgl.core import SamplingParams
+from minisgl.distributed import DistributedInfo
+from minisgl.llm.llm import LLM
+from minisgl.scheduler import Scheduler, SchedulerConfig
+
+
+class TPReferenceLLM(LLM):
+    def __init__(self, model_path: str, rank: int, world_size: int):
+        config = SchedulerConfig(
+            model_path=model_path,
+            tp_info=DistributedInfo(rank, world_size),
+            dtype=torch.bfloat16,
+            offline_mode=True,
+            attention_backend="fi",
+            max_running_req=1,
+            max_seq_len_override=64,
+            max_extend_tokens=64,
+            num_page_override=64,
+            page_size=1,
+            cache_type="naive",
+            cuda_graph_bs=[],
+        )
+        Scheduler.__init__(self, config)
+        self.pending_requests = []
+        self.status_map = {}
+        self.counter = 0
+
+
+def _worker(
+    rank: int,
+    world_size: int,
+    model_path: str,
+    hf_reference: str,
+    output: str,
+) -> None:
+    reference = torch.load(hf_reference, map_location="cpu", weights_only=True)
+    llm = TPReferenceLLM(model_path, rank, world_size)
+    captured: list[torch.Tensor] = []
+    sampled_tokens: list[int] = []
+    original_sample = llm.engine.sampler.sample
+
+    def capture_sample(logits, sampling_args):
+        if not captured:
+            captured.append(logits[0].detach().float().cpu().clone())
+        next_tokens = original_sample(logits, sampling_args)
+        sampled_tokens.extend(next_tokens.detach().cpu().tolist())
+        return next_tokens
+
+    llm.engine.sampler.sample = capture_sample
+    try:
+        llm.generate(
+            [reference["input_ids"].tolist()],
+            SamplingParams(temperature=0, max_tokens=4, ignore_eos=True),
+        )
+    finally:
+        llm.shutdown()
+
+    assert len(captured) == 1
+    assert len(sampled_tokens) == 4
+    if rank == 0:
+        output_path = Path(output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(
+            {
+                "input_ids": reference["input_ids"],
+                "first_logits": captured[0],
+                "token_ids": sampled_tokens,
+            },
+            output_path,
+        )
+        print(f"TP_REFERENCE=ok token_ids={sampled_tokens} output={output_path}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create one minimal OLMo3 TP reference")
+    parser.add_argument("model_path", type=Path)
+    parser.add_argument("hf_reference", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--world-size", type=int, default=2)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    mp.spawn(
+        _worker,
+        args=(
+            args.world_size,
+            str(args.model_path),
+            str(args.hf_reference),
+            str(args.output),
+        ),
+        nprocs=args.world_size,
+        join=True,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add `Olmo3ForCausalLM` with Post-Norm decoder semantics
- support layer-aware sliding/full attention in FlashAttention and FlashInfer
- add local RoPE and YaRN attention scaling for the official hybrid layer layout
- implement projection-wide Q/K RMSNorm for TP1 and distributed TP2 execution
- add OLMo3-specific Q/K norm weight sharding without changing Qwen3 behavior
- support all EOS IDs from generation/model configuration
- add focused correctness tests and reproducible HF/TP1/TP2/system/API smoke tools

## Why

OLMo3 differs from the existing Llama/Qwen model paths in its Post-Norm order,
projection-wide Q/K normalization, per-layer attention window, and per-layer
RoPE selection. Reusing the existing paths directly would produce incorrect
normalization and attention semantics, especially under tensor parallelism.

## Validation

- `21 passed` focused CPU tests
- Ruff, Python compile, shell syntax, and `git diff --check`
- official `allenai/Olmo-3-7B-Instruct` BF16 snapshot integrity verified
- HF vs TP1: identical four greedy tokens; cosine `0.9999091`
- HF vs TP2: identical four greedy tokens; cosine `0.9999080`
- TP1 batching + chunked prefill + Radix Cache smoke passed
- TP2 OpenAI-compatible non-streaming and streaming API smoke passed

No throughput or latency benchmark was run. FlashInfer is the validated RTX 4090
backend. OLMo3 TP2 automatically uses standard NCCL because PyNCCL does not
currently support the required FP32 distributed norm statistics.
